### PR TITLE
Add loss_function_weight to CeresBundleAdjustmentOptions

### DIFF
--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -115,7 +115,13 @@ CeresBundleAdjustmentOptions::CeresBundleAdjustmentOptions() {
 
 std::unique_ptr<ceres::LossFunction>
 CeresBundleAdjustmentOptions::CreateLossFunction() const {
-  return colmap::CreateLossFunction(loss_function_type, loss_function_scale);
+  auto loss = colmap::CreateLossFunction(loss_function_type, loss_function_scale);
+  if (loss_function_weight != 1.0) {
+    THROW_CHECK_GT(loss_function_weight, 0);
+    return std::make_unique<ceres::ScaledLoss>(
+        loss.release(), loss_function_weight, ceres::TAKE_OWNERSHIP);
+  }
+  return loss;
 }
 
 ceres::Solver::Options CeresBundleAdjustmentOptions::CreateSolverOptions(

--- a/src/colmap/estimators/bundle_adjustment_ceres.h
+++ b/src/colmap/estimators/bundle_adjustment_ceres.h
@@ -46,6 +46,11 @@ struct CeresBundleAdjustmentOptions {
   // Scaling factor determines residual at which robustification takes place.
   double loss_function_scale = 1.0;
 
+  // Weight applied to the loss function via ScaledLoss.
+  // The final cost is: weight * rho(s), where rho is the loss function.
+  // Use 1/sigma^2 to normalize reprojection residuals by keypoint uncertainty.
+  double loss_function_weight = 1.0;
+
   // Whether to use Ceres' CUDA linear algebra library, if available.
   bool use_gpu = false;
   std::string gpu_index = "-1";


### PR DESCRIPTION
## Summary
- Add `loss_function_weight` field to `CeresBundleAdjustmentOptions` (default 1.0, no-op)
- When weight != 1.0, wraps the loss function with `ceres::ScaledLoss(rho, weight, TAKE_OWNERSHIP)`
- Enables `rho(r²/σ²)` by setting `weight = 1/σ²` for keypoint uncertainty normalization

## Changes
- `bundle_adjustment_ceres.h`: new `double loss_function_weight = 1.0` field
- `bundle_adjustment_ceres.cc`: `CreateLossFunction()` wraps with `ScaledLoss` when weight != 1.0