### PR TITLE
glomap-refactor-3: LC + depth + MDRP research deltas on top of move_upstream

### DIFF
--- a/python/pycolmap/__init__.py
+++ b/python/pycolmap/__init__.py
@@ -68,5 +68,5 @@ __all__ = import_module_symbols(
 )
 __all__.extend(["__version__", "__ceres_version__"])
 
-__version__ = _core.__version__ + "-zador"
+__version__ = _core.__version__ + "+zador"
 __ceres_version__ = _core.__ceres_version__

--- a/src/colmap/estimators/bundle_adjustment_ceres.cc
+++ b/src/colmap/estimators/bundle_adjustment_ceres.cc
@@ -32,10 +32,10 @@
 #include "colmap/estimators/alignment.h"
 #include "colmap/estimators/cost_functions/depth_prior.h"
 #include "colmap/estimators/cost_functions/manifold.h"
-#include "colmap/estimators/cost_functions/weighted_reprojection_error.h"
 #include "colmap/estimators/cost_functions/pose_prior.h"
 #include "colmap/estimators/cost_functions/reprojection_error.h"
 #include "colmap/estimators/cost_functions/utils.h"
+#include "colmap/estimators/cost_functions/weighted_reprojection_error.h"
 #include "colmap/util/cuda.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/threading.h"
@@ -673,8 +673,8 @@ class DefaultBundleAdjuster : public CeresBundleAdjuster {
     Rigid3d& rig_from_world = image.FramePtr()->RigFromWorld();
 
     // Add residuals to bundle adjustment problem.
-    const bool use_covariances = options_.use_keypoint_covariances &&
-                                 image.HasPixelCovariances();
+    const bool use_covariances =
+        options_.use_keypoint_covariances && image.HasPixelCovariances();
     size_t num_observations = 0;
     point2D_t point2D_idx = 0;
     for (const Point2D& point2D : image.Points2D()) {
@@ -697,32 +697,27 @@ class DefaultBundleAdjuster : public CeresBundleAdjuster {
       num_observations += 1;
       point3D_num_observations_[point2D.point3D_id] += 1;
 
-      const bool use_weighted = use_covariances &&
-                                point2D_idx < image.PixelCholeskyXY().size();
+      const bool use_weighted =
+          use_covariances && point2D_idx < image.PixelCholeskyXY().size();
 
       if (use_weighted) {
         const Eigen::Vector3d& chol = image.PixelCholeskyXY()[point2D_idx];
         if (constant_cam_from_world) {
           problem_->AddResidualBlock(
               CreateCameraCostFunction<
-                  WeightedReprojErrorConstantPoseCostFunctor>(
-                  camera.model_id,
-                  point2D.xy,
-                  rig_from_world,
-                  chol[0],
-                  chol[1],
-                  chol[2]),
+                  WeightedReprojErrorConstantPoseCostFunctor>(camera.model_id,
+                                                              point2D.xy,
+                                                              rig_from_world,
+                                                              chol[0],
+                                                              chol[1],
+                                                              chol[2]),
               loss_function_.get(),
               point3D.xyz.data(),
               camera.params.data());
         } else {
           problem_->AddResidualBlock(
               CreateCameraCostFunction<WeightedReprojErrorCostFunctor>(
-                  camera.model_id,
-                  point2D.xy,
-                  chol[0],
-                  chol[1],
-                  chol[2]),
+                  camera.model_id, point2D.xy, chol[0], chol[1], chol[2]),
               loss_function_.get(),
               point3D.xyz.data(),
               rig_from_world.params.data(),
@@ -738,8 +733,8 @@ class DefaultBundleAdjuster : public CeresBundleAdjuster {
               camera.params.data());
         } else {
           problem_->AddResidualBlock(
-              CreateCameraCostFunction<ReprojErrorCostFunctor>(
-                  camera.model_id, point2D.xy),
+              CreateCameraCostFunction<ReprojErrorCostFunctor>(camera.model_id,
+                                                               point2D.xy),
               loss_function_.get(),
               point3D.xyz.data(),
               rig_from_world.params.data(),
@@ -1182,6 +1177,9 @@ void DepthPriorBundleAdjuster(
 
   Image& image = reconstruction.Image(image_id);
   double* pose_params = image.FramePtr()->RigFromWorld().params.data();
+  if (!problem->HasParameterBlock(shift_scale_ptr)) {
+    problem->AddParameterBlock(shift_scale_ptr, 2);
+  }
 
   for (size_t i = 0; i < point3D_ids.size(); ++i) {
     Point3D& point3D = reconstruction.Point3D(point3D_ids[i]);
@@ -1203,9 +1201,21 @@ void DepthPriorBundleAdjuster(
           final_loss, loss_magnitudes[i], ceres::TAKE_OWNERSHIP);
     }
 
-    problem->AddResidualBlock(
-        cost_function, final_loss, pose_params, point3D.xyz.data(),
-        shift_scale_ptr);
+    problem->AddResidualBlock(cost_function,
+                              final_loss,
+                              pose_params,
+                              point3D.xyz.data(),
+                              shift_scale_ptr);
+  }
+
+  if (fix_shift && fix_scale) {
+    problem->SetParameterBlockConstant(shift_scale_ptr);
+  } else if (fix_shift || fix_scale) {
+    std::vector<int> constant_parameters;
+    if (fix_shift) constant_parameters.push_back(0);
+    if (fix_scale) constant_parameters.push_back(1);
+    problem->SetManifold(shift_scale_ptr,
+                         new ceres::SubsetManifold(2, constant_parameters));
   }
 }
 

--- a/src/colmap/estimators/bundle_adjustment_test.cc
+++ b/src/colmap/estimators/bundle_adjustment_test.cc
@@ -434,8 +434,8 @@ TEST(CovarianceBA, RunsWithoutCrash) {
 
   // Set identity Cholesky on all images (equivalent to unweighted)
   for (const auto& [img_id, img] : reconstruction.Images()) {
-    std::vector<Eigen::Vector3d> chol(
-        img.NumPoints2D(), Eigen::Vector3d(1.0, 0.0, 1.0));
+    std::vector<Eigen::Vector3d> chol(img.NumPoints2D(),
+                                      Eigen::Vector3d(1.0, 0.0, 1.0));
     reconstruction.Image(img_id).SetPixelCholeskyXY(chol);
   }
 
@@ -467,8 +467,8 @@ TEST(CovarianceBA, IgnoredWhenDisabled) {
 
   // Set non-identity Cholesky that would change results
   for (const auto& [img_id, img] : reconstruction.Images()) {
-    std::vector<Eigen::Vector3d> chol(
-        img.NumPoints2D(), Eigen::Vector3d(2.0, 0.5, 3.0));
+    std::vector<Eigen::Vector3d> chol(img.NumPoints2D(),
+                                      Eigen::Vector3d(2.0, 0.5, 3.0));
     reconstruction.Image(img_id).SetPixelCholeskyXY(chol);
   }
 
@@ -552,6 +552,77 @@ TEST(DepthPriorBA, ConvergesOnSyntheticData) {
   // shift should be near 0, scale should be near 0 (depths are GT)
   EXPECT_NEAR(shift_scale[0], 0.0, 0.5);
   EXPECT_NEAR(shift_scale[1], 0.0, 0.5);
+}
+
+TEST(DepthPriorBA, FixShiftScaleFlagsConstrainParameterBlock) {
+  SetPRNGSeed(0);
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions opts;
+  opts.num_rigs = 1;
+  opts.num_cameras_per_rig = 1;
+  opts.num_frames_per_rig = 3;
+  opts.num_points3D = 20;
+  SynthesizeDataset(opts, &reconstruction);
+
+  const image_t image_id = *reconstruction.RegImageIds().begin();
+  const Image& image = reconstruction.Image(image_id);
+
+  std::vector<point3D_t> point3D_ids;
+  std::vector<double> depths;
+  for (point2D_t idx = 0; idx < image.NumPoints2D(); ++idx) {
+    if (!image.Point2D(idx).HasPoint3D()) continue;
+    const point3D_t point3D_id = image.Point2D(idx).point3D_id;
+    const Point3D& point3D = reconstruction.Point3D(point3D_id);
+    const Eigen::Vector3d point_cam = image.CamFromWorld() * point3D.xyz;
+    if (point_cam.z() <= 0) continue;
+    point3D_ids.push_back(point3D_id);
+    depths.push_back(point_cam.z());
+    break;
+  }
+  ASSERT_FALSE(point3D_ids.empty());
+
+  const std::vector<double> loss_magnitudes(point3D_ids.size(), 1.0);
+  const std::vector<double> loss_params(point3D_ids.size(), 1.0);
+  const std::vector<CeresBundleAdjustmentOptions::LossFunctionType> loss_types(
+      point3D_ids.size(),
+      CeresBundleAdjustmentOptions::LossFunctionType::TRIVIAL);
+
+  {
+    ceres::Problem problem;
+    double shift_scale[2] = {0.0, 0.0};
+    DepthPriorBundleAdjuster(&problem,
+                             image_id,
+                             point3D_ids,
+                             depths,
+                             loss_magnitudes,
+                             loss_params,
+                             loss_types,
+                             shift_scale,
+                             reconstruction,
+                             false,
+                             true,
+                             false);
+    EXPECT_EQ(problem.ParameterBlockSize(shift_scale), 2);
+    EXPECT_EQ(problem.ParameterBlockTangentSize(shift_scale), 1);
+  }
+
+  {
+    ceres::Problem problem;
+    double shift_scale[2] = {0.0, 0.0};
+    DepthPriorBundleAdjuster(&problem,
+                             image_id,
+                             point3D_ids,
+                             depths,
+                             loss_magnitudes,
+                             loss_params,
+                             loss_types,
+                             shift_scale,
+                             reconstruction,
+                             false,
+                             true,
+                             true);
+    EXPECT_TRUE(problem.IsParameterBlockConstant(shift_scale));
+  }
 }
 
 }  // namespace

--- a/src/colmap/estimators/cost_functions/CMakeLists.txt
+++ b/src/colmap/estimators/cost_functions/CMakeLists.txt
@@ -37,6 +37,7 @@ COLMAP_ADD_LIBRARY(
         calibration.h
         depth_prior.h
         manifold.h
+        metric_depth.h
         motion_averaging.h
         pose_prior.h
         reprojection_error.h
@@ -88,5 +89,10 @@ COLMAP_ADD_TEST(
 COLMAP_ADD_TEST(
     NAME depth_prior_test
     SRCS depth_prior_test.cc
+    LINK_LIBS colmap_estimators_cost_functions
+)
+COLMAP_ADD_TEST(
+    NAME metric_depth_test
+    SRCS metric_depth_test.cc
     LINK_LIBS colmap_estimators_cost_functions
 )

--- a/src/colmap/estimators/cost_functions/depth_prior.h
+++ b/src/colmap/estimators/cost_functions/depth_prior.h
@@ -31,6 +31,7 @@
 
 #include "colmap/estimators/cost_functions/utils.h"
 #include "colmap/geometry/rigid3.h"
+#include "colmap/util/logging.h"
 
 #include <ceres/ceres.h>
 
@@ -90,7 +91,10 @@ struct ScaledDepthErrorConstantPoseCostFunctor
 // Params: cam_from_world[7], point3D[3], shift_scale[2]
 struct LogScaledDepthErrorCostFunctor
     : public AutoDiffCostFunctor<LogScaledDepthErrorCostFunctor, 1, 7, 3, 2> {
-  explicit LogScaledDepthErrorCostFunctor(double depth) : depth_(depth) {}
+  explicit LogScaledDepthErrorCostFunctor(double depth) : depth_(depth) {
+    THROW_CHECK_GT(depth, 0.0)
+        << "LogScaledDepthErrorCostFunctor: depth must be > 0 (log undefined).";
+  }
 
   template <typename T>
   bool operator()(const T* const cam_from_world,

--- a/src/colmap/estimators/cost_functions/metric_depth.h
+++ b/src/colmap/estimators/cost_functions/metric_depth.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "colmap/util/logging.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <ceres/ceres.h>
+
+namespace colmap {
+
+enum class MetricDepthResidualType { kLinear, kLog, kLogLinear };
+
+struct MetricDepthOptions {
+  bool use_log_scale = false;
+  MetricDepthResidualType residual_type = MetricDepthResidualType::kLinear;
+  bool zero_residual_behind = false;
+  double log_linear_threshold = 0.1;
+
+  bool IsValid() const {
+    return residual_type != MetricDepthResidualType::kLogLinear ||
+           log_linear_threshold > 0.0;
+  }
+};
+
+// 1-D residual: camera-frame z-depth vs scaled depth prior (s_i * m_ik).
+// AutoDiff<1, 3, 3, 1> over (frame_center, point3D, dmap_scale).
+struct MetricDepthError {
+  MetricDepthError(const Eigen::Quaterniond& rotation,
+                   double depth_prior,
+                   double sigma_depth,
+                   const MetricDepthOptions& options = MetricDepthOptions())
+      : rotation_(rotation),
+        depth_prior_(depth_prior),
+        sigma_depth_(sigma_depth),
+        options_(options) {
+    if (sigma_depth <= 1e-9) {
+      throw std::invalid_argument(
+          "MetricDepthError: Standard deviation must be positive.");
+    }
+    if (!options.IsValid()) {
+      throw std::invalid_argument(
+          "MetricDepthError: log-linear threshold must be positive.");
+    }
+  }
+
+  template <typename T>
+  bool operator()(const T* const c_i,
+                  const T* const X_k,
+                  const T* const dmap_scale,
+                  T* residuals) const {
+    Eigen::Map<const Eigen::Matrix<T, 3, 1>> camera_center(c_i);
+    Eigen::Map<const Eigen::Matrix<T, 3, 1>> point_3d(X_k);
+    const Eigen::Matrix<T, 3, 1> point_vec_world = point_3d - camera_center;
+    const Eigen::Matrix<T, 3, 1> point_vec_cam =
+        rotation_.cast<T>() * point_vec_world;
+    const T z_est = point_vec_cam[2];
+
+    const T scale =
+        options_.use_log_scale ? ceres::exp(dmap_scale[0]) : dmap_scale[0];
+    const T scaled_prior = scale * T(depth_prior_);
+    const T scaled_sigma = scale * T(sigma_depth_);
+
+    if (options_.zero_residual_behind && z_est <= T(0.0)) {
+      residuals[0] = T(0.0);
+      return true;
+    }
+
+    T r_depth;
+    T weight;
+
+    if (options_.residual_type != MetricDepthResidualType::kLinear) {
+      const T depth_prior_safe = std::max(T(depth_prior_), T(1e-6));
+      const T sigma_log = T(sigma_depth_) / depth_prior_safe;
+      const T weight_log = T(1.0) / std::max(T(1e-6), sigma_log);
+
+      if (options_.residual_type == MetricDepthResidualType::kLogLinear) {
+        const T thresh = T(options_.log_linear_threshold);
+        const T scaled_prior_safe = std::max(scaled_prior, T(1e-6));
+        if (z_est > thresh) {
+          const T z_est_safe = std::max(z_est, T(1e-6));
+          r_depth = ceres::log(z_est_safe / scaled_prior_safe);
+        } else {
+          // Linear continuation below threshold (C¹ at boundary):
+          // d/dz log(z/p) = 1/z, so slope at threshold is 1/threshold.
+          const T r_at_threshold = ceres::log(thresh / scaled_prior_safe);
+          r_depth = r_at_threshold + (z_est - thresh) / thresh;
+        }
+        weight = weight_log;
+      } else if (z_est > T(0.0)) {
+        const T z_est_safe = std::max(z_est, T(1e-6));
+        const T scaled_prior_safe = std::max(scaled_prior, T(1e-6));
+        r_depth = ceres::log(z_est_safe / scaled_prior_safe);
+        weight = weight_log;
+      } else {
+        // Point behind camera: linear residual (log undefined).
+        r_depth = z_est - scaled_prior;
+        weight = T(1.0) / std::max(T(1e-6), scaled_sigma);
+      }
+    } else {
+      r_depth = z_est - scaled_prior;
+      weight = T(1.0) / std::max(T(1e-6), scaled_sigma);
+    }
+
+    residuals[0] = weight * r_depth;
+    return true;
+  }
+
+  static ceres::CostFunction* Create(
+      const Eigen::Quaterniond& rotation,
+      double depth_prior,
+      double sigma_depth,
+      const MetricDepthOptions& options = MetricDepthOptions()) {
+    if (sigma_depth <= 1e-9) {
+      LOG(ERROR) << "Cannot create MetricDepthError: Standard deviation must "
+                    "be positive.";
+      return nullptr;
+    }
+    if (!options.IsValid()) {
+      LOG(ERROR)
+          << "Cannot create MetricDepthError: log-linear threshold must be "
+             "positive.";
+      return nullptr;
+    }
+    return new ceres::AutoDiffCostFunction<MetricDepthError, 1, 3, 3, 1>(
+        new MetricDepthError(rotation, depth_prior, sigma_depth, options));
+  }
+
+ private:
+  const Eigen::Quaterniond rotation_;
+  const double depth_prior_;
+  const double sigma_depth_;
+  const MetricDepthOptions options_;
+};
+
+// ScalePriorError + LogScalePriorError replaced by native
+// CovarianceWeightedCostFunctor<NormalPriorCostFunctor<1>> (see
+// global_positioning.cc): prior=1.0 (linear) or 0.0 (log), cov=stddev^2.
+
+}  // namespace colmap

--- a/src/colmap/estimators/cost_functions/metric_depth_test.cc
+++ b/src/colmap/estimators/cost_functions/metric_depth_test.cc
@@ -1,0 +1,232 @@
+#include "colmap/estimators/cost_functions/metric_depth.h"
+
+#include <cmath>
+#include <limits>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <ceres/ceres.h>
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+// Helper: build a non-trivial rotation so we exercise the rotation-bake-in.
+Eigen::Quaterniond MakeRotation() {
+  return Eigen::Quaterniond(
+             Eigen::AngleAxisd(0.3, Eigen::Vector3d(1, 2, 3).normalized()))
+      .normalized();
+}
+
+// Helper: pick X / c such that ``z_est = (R * (X - c))[2]`` equals a target.
+Eigen::Vector3d MakePointWithDepth(const Eigen::Quaterniond& rotation,
+                                   const Eigen::Vector3d& camera_center,
+                                   double target_z) {
+  // Choose ``point_vec_cam = (0, 0, target_z)``; then ``X - c = R^T * vec``.
+  const Eigen::Vector3d vec_cam(0.0, 0.0, target_z);
+  const Eigen::Vector3d vec_world = rotation.inverse() * vec_cam;
+  return camera_center + vec_world;
+}
+
+MetricDepthOptions MakeMetricDepthOptions(
+    MetricDepthResidualType residual_type = MetricDepthResidualType::kLinear,
+    bool use_log_scale = false,
+    bool zero_residual_behind = false,
+    double log_linear_threshold = 0.1) {
+  MetricDepthOptions options;
+  options.use_log_scale = use_log_scale;
+  options.residual_type = residual_type;
+  options.zero_residual_behind = zero_residual_behind;
+  options.log_linear_threshold = log_linear_threshold;
+  return options;
+}
+
+TEST(MetricDepthError, ZeroResidualWhenPriorMatchesPredicted) {
+  const Eigen::Quaterniond rotation = MakeRotation();
+  const double sigma_depth = 0.5;
+  const double depth_prior = 7.0;
+  const double dmap_scale = 1.0;
+  const Eigen::Vector3d camera_center(1.0, -2.0, 3.0);
+  const Eigen::Vector3d point3D =
+      MakePointWithDepth(rotation, camera_center, dmap_scale * depth_prior);
+
+  std::unique_ptr<ceres::CostFunction> cost_function(
+      MetricDepthError::Create(rotation, depth_prior, sigma_depth));
+  ASSERT_NE(cost_function, nullptr);
+
+  double residual = std::numeric_limits<double>::quiet_NaN();
+  const double* parameters[3] = {
+      camera_center.data(), point3D.data(), &dmap_scale};
+  EXPECT_TRUE(cost_function->Evaluate(parameters, &residual, nullptr));
+  EXPECT_NEAR(residual, 0.0, 1e-9);
+}
+
+TEST(MetricDepthError, LinearResidualMatchesFormula) {
+  const Eigen::Quaterniond rotation = MakeRotation();
+  const double sigma_depth = 0.4;
+  const double depth_prior = 5.0;
+  const double dmap_scale = 1.2;
+  const double z_est = 8.0;
+  const Eigen::Vector3d camera_center(0.5, 0.5, -0.5);
+  const Eigen::Vector3d point3D =
+      MakePointWithDepth(rotation, camera_center, z_est);
+
+  std::unique_ptr<ceres::CostFunction> cost_function(
+      MetricDepthError::Create(rotation, depth_prior, sigma_depth));
+
+  // residual = (z - s*m) / (s*sigma)
+  const double expected =
+      (z_est - dmap_scale * depth_prior) / (dmap_scale * sigma_depth);
+
+  double residual = std::numeric_limits<double>::quiet_NaN();
+  const double* parameters[3] = {
+      camera_center.data(), point3D.data(), &dmap_scale};
+  EXPECT_TRUE(cost_function->Evaluate(parameters, &residual, nullptr));
+  EXPECT_NEAR(residual, expected, 1e-9);
+}
+
+TEST(MetricDepthError, LogResidualMatchesFormula) {
+  const Eigen::Quaterniond rotation = MakeRotation();
+  const double sigma_depth = 0.4;
+  const double depth_prior = 5.0;
+  const double dmap_scale = 1.2;
+  const double z_est = 8.0;
+  const Eigen::Vector3d camera_center(0.5, 0.5, -0.5);
+  const Eigen::Vector3d point3D =
+      MakePointWithDepth(rotation, camera_center, z_est);
+
+  std::unique_ptr<ceres::CostFunction> cost_function(MetricDepthError::Create(
+      rotation,
+      depth_prior,
+      sigma_depth,
+      MakeMetricDepthOptions(MetricDepthResidualType::kLog)));
+
+  // sigma_log = sigma_depth / depth_prior; residual = log(z / (s*m)) /
+  // sigma_log
+  const double sigma_log = sigma_depth / depth_prior;
+  const double expected =
+      std::log(z_est / (dmap_scale * depth_prior)) / sigma_log;
+
+  double residual = std::numeric_limits<double>::quiet_NaN();
+  const double* parameters[3] = {
+      camera_center.data(), point3D.data(), &dmap_scale};
+  EXPECT_TRUE(cost_function->Evaluate(parameters, &residual, nullptr));
+  EXPECT_NEAR(residual, expected, 1e-9);
+}
+
+TEST(MetricDepthError, ZeroResidualBehindCameraGate) {
+  const Eigen::Quaterniond rotation = MakeRotation();
+  const double sigma_depth = 0.5;
+  const double depth_prior = 4.0;
+  const double dmap_scale = 1.0;
+  const Eigen::Vector3d camera_center(0.0, 0.0, 0.0);
+  // Negative target z → point behind camera.
+  const Eigen::Vector3d point3D =
+      MakePointWithDepth(rotation, camera_center, -2.0);
+
+  std::unique_ptr<ceres::CostFunction> cost_function(MetricDepthError::Create(
+      rotation,
+      depth_prior,
+      sigma_depth,
+      MakeMetricDepthOptions(MetricDepthResidualType::kLinear,
+                             /*use_log_scale=*/false,
+                             /*zero_residual_behind=*/true)));
+
+  double residual = std::numeric_limits<double>::quiet_NaN();
+  const double* parameters[3] = {
+      camera_center.data(), point3D.data(), &dmap_scale};
+  EXPECT_TRUE(cost_function->Evaluate(parameters, &residual, nullptr));
+  EXPECT_NEAR(residual, 0.0, 1e-12);
+
+  // Sanity: without the gate, the residual is non-zero for the same input.
+  std::unique_ptr<ceres::CostFunction> cost_function_no_gate(
+      MetricDepthError::Create(
+          rotation, depth_prior, sigma_depth, MakeMetricDepthOptions()));
+  double residual_no_gate = std::numeric_limits<double>::quiet_NaN();
+  EXPECT_TRUE(
+      cost_function_no_gate->Evaluate(parameters, &residual_no_gate, nullptr));
+  EXPECT_GT(std::abs(residual_no_gate), 1e-3);
+}
+
+TEST(MetricDepthError, LogScaleParameterization) {
+  const Eigen::Quaterniond rotation = MakeRotation();
+  const double sigma_depth = 0.3;
+  const double depth_prior = 6.0;
+  const double linear_scale = 0.8;
+  const double log_scale = std::log(linear_scale);
+  const Eigen::Vector3d camera_center(1.0, 0.0, 0.0);
+  // Make z = linear_scale * depth_prior so linear-residual variant returns 0.
+  const Eigen::Vector3d point3D =
+      MakePointWithDepth(rotation, camera_center, linear_scale * depth_prior);
+
+  std::unique_ptr<ceres::CostFunction> cost_function_log(
+      MetricDepthError::Create(
+          rotation,
+          depth_prior,
+          sigma_depth,
+          MakeMetricDepthOptions(MetricDepthResidualType::kLinear,
+                                 /*use_log_scale=*/true)));
+
+  double residual = std::numeric_limits<double>::quiet_NaN();
+  const double* parameters[3] = {
+      camera_center.data(), point3D.data(), &log_scale};
+  EXPECT_TRUE(cost_function_log->Evaluate(parameters, &residual, nullptr));
+  EXPECT_NEAR(residual, 0.0, 1e-9);
+}
+
+TEST(MetricDepthError, AllOptionsSmokeFinite) {
+  const Eigen::Quaterniond rotation = MakeRotation();
+  const double sigma_depth = 0.5;
+  const double depth_prior = 5.0;
+  const double dmap_scale = 1.0;
+  const Eigen::Vector3d camera_center(0.0, 0.0, 0.0);
+  const Eigen::Vector3d point3D =
+      MakePointWithDepth(rotation, camera_center, 4.0);
+
+  const MetricDepthOptions options[] = {
+      MakeMetricDepthOptions(MetricDepthResidualType::kLinear,
+                             /*use_log_scale=*/true),
+      MakeMetricDepthOptions(MetricDepthResidualType::kLog),
+      MakeMetricDepthOptions(MetricDepthResidualType::kLinear,
+                             /*use_log_scale=*/false,
+                             /*zero_residual_behind=*/true),
+      MakeMetricDepthOptions(MetricDepthResidualType::kLogLinear),
+      MakeMetricDepthOptions(MetricDepthResidualType::kLogLinear,
+                             /*use_log_scale=*/true,
+                             /*zero_residual_behind=*/true),
+  };
+
+  for (const MetricDepthOptions& option : options) {
+    std::unique_ptr<ceres::CostFunction> cost_function(
+        MetricDepthError::Create(rotation, depth_prior, sigma_depth, option));
+    ASSERT_NE(cost_function, nullptr);
+    // For the log-scale variants, dmap_scale must be log(scale); use 0 → s=1.
+    const double scale_param = option.use_log_scale ? 0.0 : dmap_scale;
+    const double* params[3] = {
+        camera_center.data(), point3D.data(), &scale_param};
+    double residual = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_TRUE(cost_function->Evaluate(params, &residual, nullptr));
+    EXPECT_TRUE(std::isfinite(residual));
+  }
+}
+
+TEST(MetricDepthError, RejectsNonPositiveSigma) {
+  const Eigen::Quaterniond rotation = MakeRotation();
+  ceres::CostFunction* cost_function =
+      MetricDepthError::Create(rotation, /*depth_prior=*/1.0, /*sigma=*/0.0);
+  EXPECT_EQ(cost_function, nullptr);
+}
+
+TEST(MetricDepthError, RejectsNonPositiveLogLinearThreshold) {
+  const Eigen::Quaterniond rotation = MakeRotation();
+  MetricDepthOptions options;
+  options.residual_type = MetricDepthResidualType::kLogLinear;
+  options.log_linear_threshold = 0.0;
+
+  ceres::CostFunction* cost_function = MetricDepthError::Create(
+      rotation, /*depth_prior=*/1.0, /*sigma_depth=*/0.5, options);
+  EXPECT_EQ(cost_function, nullptr);
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -1,10 +1,14 @@
 #include "colmap/estimators/global_positioning.h"
 
+#include "colmap/estimators/cost_functions/metric_depth.h"
 #include "colmap/estimators/cost_functions/motion_averaging.h"
+#include "colmap/estimators/cost_functions/utils.h"
 #include "colmap/math/random.h"
 #include "colmap/util/cuda.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/threading.h"
+
+#include <cstdlib>
 
 namespace colmap {
 namespace {
@@ -13,6 +17,70 @@ Eigen::Vector3d RandVector3d(double low, double high) {
   return Eigen::Vector3d(RandomUniformReal(low, high),
                          RandomUniformReal(low, high),
                          RandomUniformReal(low, high));
+}
+
+MetricDepthOptions CreateMetricDepthOptions(
+    const GlobalPositionerOptions& options) {
+  MetricDepthOptions metric_depth_options;
+  metric_depth_options.use_log_scale =
+      options.use_log_scale_for_depth_map_scales;
+  metric_depth_options.zero_residual_behind = options.zero_residual_behind;
+  metric_depth_options.log_linear_threshold = options.log_linear_threshold;
+
+  if (options.smooth_log_linear_transition) {
+    metric_depth_options.residual_type = MetricDepthResidualType::kLogLinear;
+  } else if (options.use_log_residual_for_depth) {
+    metric_depth_options.residual_type = MetricDepthResidualType::kLog;
+  } else {
+    metric_depth_options.residual_type = MetricDepthResidualType::kLinear;
+  }
+  return metric_depth_options;
+}
+
+// Per-observation depth outlier check. Returns true when the log-space
+// residual |log(z_est / scaled_prior)| exceeds sigma * sigma_log.
+inline bool DepthOutlierFlag(const Image& image,
+                             point2D_t feature_id,
+                             const Eigen::Vector3d& point3D_xyz,
+                             bool use_log_scale,
+                             const std::map<image_t, double>& dmap_scales,
+                             image_t image_id,
+                             double sigma) {
+  if (feature_id >= image.depth_prior_validity.size() ||
+      !image.depth_prior_validity[feature_id]) {
+    return false;
+  }
+  if (feature_id >= image.depth_priors.size() ||
+      feature_id >= image.depth_prior_stddevs.size()) {
+    return false;
+  }
+  const double depth_prior_raw = image.depth_priors[feature_id];
+  const double stddev_rel = image.depth_prior_stddevs[feature_id];
+  if (depth_prior_raw <= 1e-6 || stddev_rel <= 1e-9) return false;
+
+  // Apply per-image dmap_scale if available (else use raw prior).
+  double depth_prior = depth_prior_raw;
+  auto scale_it = dmap_scales.find(image_id);
+  if (scale_it != dmap_scales.end()) {
+    const double dmap_scale =
+        use_log_scale ? std::exp(scale_it->second) : scale_it->second;
+    depth_prior = dmap_scale * depth_prior_raw;
+  }
+
+  // z_est = (cam_from_world * X_world)[2]
+  const Eigen::Vector3d point_cam = image.CamFromWorld() * point3D_xyz;
+  const double z_est = point_cam[2];
+  if (z_est <= 1e-6) return false;
+
+  const double log_z_est = std::log(std::max(z_est, 1e-6));
+  const double log_depth_prior = std::log(std::max(depth_prior, 1e-6));
+  const double log_diff = std::abs(log_z_est - log_depth_prior);
+  const double threshold = sigma * std::log(1.0 + std::max(stddev_rel, 1e-6));
+  return log_diff >= threshold;
+}
+
+size_t NumRegularObservationsForMinViewGate(const Track& track) {
+  return track.Length();
 }
 
 }  // namespace
@@ -35,6 +103,21 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
     return false;
   }
 
+  // TODO: extend rig branch in AddObservationToProblem to add MetricDepthError
+  // for non-ref images. Until then, fail loud on multi-camera rigs +
+  // use_metric_depth_constraint.
+  if (options_.use_metric_depth_constraint) {
+    for (const auto& [image_id, image] : reconstruction.Images()) {
+      THROW_CHECK(image.IsRefInFrame())
+          << "use_metric_depth_constraint=true is not yet supported with "
+             "multi-camera rigs. Image "
+          << image_id
+          << " is a non-ref sensor in its frame; its depth "
+             "residual would be silently dropped. Either disable "
+             "use_metric_depth_constraint or run on single-camera rigs.";
+    }
+  }
+
   LOG(INFO) << "Setting up the global positioner problem";
 
   // Setup the problem.
@@ -43,6 +126,13 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
   // Initialize camera translations to be random.
   // Also, convert the camera pose translation to be the camera center.
   InitializeRandomPositions(pose_graph, reconstruction);
+
+  // No caller-supplied seed for dmap_scales_; derive one from per-image
+  // median observed z_est/depth_prior.
+  if (options_.use_metric_depth_constraint && options_.use_init &&
+      !options_.initial_dmap_scales.has_value()) {
+    InitializeDepthMapScalesFromObservations(reconstruction);
+  }
 
   // Add the point to camera constraints to the problem.
   AddPointToCameraConstraints(reconstruction);
@@ -83,6 +173,7 @@ void GlobalPositioner::SetupProblem(const PoseGraph& pose_graph,
   // Clear temporary storage from previous runs.
   frame_centers_.clear();
   cams_in_rig_.clear();
+  per_image_scale_losses_.clear();
 
   // Reserve to avoid pointer-invalidating reallocs.
   scales_.clear();
@@ -105,7 +196,7 @@ void GlobalPositioner::InitializeRandomPositions(
   }
 
   for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
-    if (point3D.track.Length() <
+    if (NumRegularObservationsForMinViewGate(point3D.track) <
         static_cast<size_t>(options_.min_num_view_per_track)) {
       continue;
     }
@@ -133,7 +224,8 @@ void GlobalPositioner::InitializeRandomPositions(
     }
     if (options_.generate_random_positions && options_.optimize_positions &&
         !options_.use_init) {
-      frame_centers_[frame_id] = options_.random_init_scale * RandVector3d(-1, 1);
+      frame_centers_[frame_id] =
+          options_.random_init_scale * RandVector3d(-1, 1);
     } else {
       frame_centers_[frame_id] = frame.RigFromWorld().TgtOriginInSrc();
     }
@@ -159,25 +251,102 @@ void GlobalPositioner::AddPointToCameraConstraints(
   }
   loss_function_ptcam_calibrated_ = loss_function_;
 
+  // Initialize cascade losses.
+  cached_loss_normal_geometry_ =
+      options_.loss_normal_geometry.CreateLossFunction();
+  cached_loss_normal_depth_ = options_.loss_normal_depth.CreateLossFunction();
+  cached_loss_lc_geometry_ = options_.loss_lc_geometry.CreateLossFunction();
+  cached_loss_lc_depth_ = options_.loss_lc_depth.CreateLossFunction();
+  cached_loss_normal_geometry_inlier_ =
+      options_.loss_normal_geometry_inlier.CreateLossFunction();
+  cached_loss_normal_depth_inlier_ =
+      options_.loss_normal_depth_inlier.CreateLossFunction();
+  cached_loss_normal_depth_outlier_ =
+      options_.loss_normal_depth_outlier.CreateLossFunction();
+  cached_loss_normal_geometry_trackstart_ =
+      options_.loss_normal_geometry_trackstart.CreateLossFunction();
+  cached_loss_normal_depth_trackstart_ =
+      options_.loss_normal_depth_trackstart.CreateLossFunction();
+  cached_loss_scale_prior_ = options_.loss_scale_prior.CreateLossFunction();
+  soft_outlier_fallback_loss_.reset();
+
+  dmap_scales_.clear();
+  dmap_scale_observation_counts_.clear();
+
+  // Seed dmap_scales_ from initial values before outlier filtering.
+  if (options_.use_metric_depth_constraint &&
+      options_.initial_dmap_scales.has_value()) {
+    for (const auto& [image_id, linear_scale] : *options_.initial_dmap_scales) {
+      const double init_value = options_.use_log_scale_for_depth_map_scales
+                                    ? std::log(std::max(linear_scale, 1e-9))
+                                    : linear_scale;
+      dmap_scales_[image_id] = init_value;
+      dmap_scale_observation_counts_[image_id] = 0;
+    }
+  }
+
+  depth_outliers_.clear();
+  if (options_.use_metric_depth_constraint && options_.filter_depth_outliers) {
+    FilterDepthOutliers(reconstruction);
+  }
+
   for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
-    if (point3D.track.Length() <
+    if (NumRegularObservationsForMinViewGate(point3D.track) <
         static_cast<size_t>(options_.min_num_view_per_track)) {
       continue;
     }
 
     AddPoint3DToProblem(point3D_id, reconstruction);
   }
+
+  // Emit one scale-prior residual per image with depth observations,
+  // weighted by obs_count so dense-depth images get stronger priors.
+  if (options_.use_metric_depth_constraint) {
+    for (auto& [image_id, scale] : dmap_scales_) {
+      auto count_it = dmap_scale_observation_counts_.find(image_id);
+      const double obs_count =
+          (count_it != dmap_scale_observation_counts_.end())
+              ? static_cast<double>(count_it->second)
+              : 1.0;
+
+      // Prior: pulls log_s toward 0 (log-space) or s toward 1 (linear).
+      const Eigen::Matrix<double, 1, 1> prior_vec(
+          options_.use_log_scale_for_depth_map_scales ? 0.0 : 1.0);
+      const Eigen::Matrix<double, 1, 1> cov_1x1(options_.scale_prior_stddev *
+                                                options_.scale_prior_stddev);
+      ceres::CostFunction* scale_prior_cost =
+          CovarianceWeightedCostFunctor<NormalPriorCostFunctor<1>>::Create(
+              cov_1x1, prior_vec);
+      if (scale_prior_cost == nullptr) continue;
+
+      ceres::LossFunction* obs_count_scaled_loss = nullptr;
+      if (cached_loss_scale_prior_) {
+        per_image_scale_losses_.push_back(
+            std::make_unique<ceres::ScaledLoss>(cached_loss_scale_prior_.get(),
+                                                obs_count,
+                                                ceres::DO_NOT_TAKE_OWNERSHIP));
+      } else {
+        per_image_scale_losses_.push_back(std::make_unique<ceres::ScaledLoss>(
+            new ceres::TrivialLoss(), obs_count, ceres::TAKE_OWNERSHIP));
+      }
+      obs_count_scaled_loss = per_image_scale_losses_.back().get();
+
+      problem_->AddResidualBlock(
+          scale_prior_cost, obs_count_scaled_loss, &scale);
+    }
+  }
   VLOG(2) << "GP: residual blocks=" << problem_->NumResidualBlocks()
           << ", parameter blocks=" << problem_->NumParameterBlocks()
           << ", scales=" << scales_.size()
-          << ", frame_centers=" << frame_centers_.size();
+          << ", frame_centers=" << frame_centers_.size()
+          << ", dmap_scales=" << dmap_scales_.size();
 }
 
 void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
                                            Reconstruction& reconstruction) {
-  const bool random_initialization =
-      options_.optimize_points && options_.generate_random_points &&
-      !options_.use_init;
+  const bool random_initialization = options_.optimize_points &&
+                                     options_.generate_random_points &&
+                                     !options_.use_init;
 
   Point3D& point3D = reconstruction.Point3D(point3D_id);
 
@@ -189,17 +358,16 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
   // Walk regular elements then LC elements as separate passes — they
   // share the residual layout but use different loss function groups.
   for (const auto& observation : point3D.track.Elements()) {
-    AddObservationToProblem(point3D_id,
-                            observation,
-                            random_initialization,
-                            reconstruction);
+    AddObservationToProblem(
+        point3D_id, observation, random_initialization, reconstruction);
   }
   if (options_.use_lc_observations) {
     for (const auto& observation : point3D.track.lc_elements) {
       AddObservationToProblem(point3D_id,
                               observation,
                               random_initialization,
-                              reconstruction);
+                              reconstruction,
+                              /*is_lc_observation=*/true);
     }
   }
 }
@@ -207,7 +375,8 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
 void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                                const TrackElement& observation,
                                                bool random_initialization,
-                                               Reconstruction& reconstruction) {
+                                               Reconstruction& reconstruction,
+                                               bool is_lc_observation) {
   Point3D& point3D = reconstruction.Point3D(point3D_id);
   if (!reconstruction.ExistsImage(observation.image_id)) return;
 
@@ -215,13 +384,11 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   if (!image.HasPose()) return;
 
   const std::optional<Eigen::Vector2d> cam_point =
-      image.CameraPtr()->CamFromImg(
-          image.Point2D(observation.point2D_idx).xy);
+      image.CameraPtr()->CamFromImg(image.Point2D(observation.point2D_idx).xy);
   if (!cam_point.has_value()) {
-    LOG(WARNING)
-        << "Ignoring feature because it failed to project: point3D_id="
-        << point3D_id << ", image_id=" << observation.image_id
-        << ", feature_id=" << observation.point2D_idx;
+    LOG(WARNING) << "Ignoring feature because it failed to project: point3D_id="
+                 << point3D_id << ", image_id=" << observation.image_id
+                 << ", feature_id=" << observation.point2D_idx;
     return;
   }
 
@@ -246,20 +413,70 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   // Down weight the uncalibrated cameras
   Camera& camera = reconstruction.Camera(image.CameraId());
   ceres::LossFunction* loss_function =
-      (camera.has_prior_focal_length)
-          ? loss_function_ptcam_calibrated_.get()
-          : loss_function_ptcam_uncalibrated_.get();
+      (camera.has_prior_focal_length) ? loss_function_ptcam_calibrated_.get()
+                                      : loss_function_ptcam_uncalibrated_.get();
+
+  // Geometry-loss cascade. Per-observation route:
+  //   is_lc                         -> cached_loss_lc_geometry_
+  //   TrackElement::is_track_anchor -> cached_loss_normal_geometry_trackstart_
+  //   TrackElement::is_inlier       -> cached_loss_normal_geometry_inlier_
+  //   else                          -> cached_loss_normal_geometry_
+  if (is_lc_observation && cached_loss_lc_geometry_) {
+    loss_function = cached_loss_lc_geometry_.get();
+  } else if (options_.use_metric_depth_constraint) {
+    ceres::LossFunction* cascade = nullptr;
+    if (observation.is_track_anchor) {
+      cascade = cached_loss_normal_geometry_trackstart_.get();
+    } else if (observation.is_inlier) {
+      cascade = cached_loss_normal_geometry_inlier_.get();
+    } else {
+      cascade = cached_loss_normal_geometry_.get();
+    }
+    if (cascade != nullptr) {
+      loss_function = cascade;
+    }
+  }
 
   // If the image is not part of a camera rig, use the standard BATA error
   if (image.IsRefInFrame()) {
-    ceres::CostFunction* cost_function =
-        BATAPairwiseDirectionCostFunctor::Create(cam_from_point3D_dir);
+    // Anisotropic per-keypoint covariance via CovarianceWeightedCostFunctor
+    // when angular_stddevs is populated; otherwise bare BATA functor.
+    // cov_world = R^T diag(sigma^2) R.
+    ceres::CostFunction* cost_function = nullptr;
+    if (observation.point2D_idx < image.angular_stddevs.size()) {
+      const Eigen::Vector2d& angular_std =
+          image.angular_stddevs[observation.point2D_idx];
+      const double sigma_x = std::max(1e-9, angular_std[0]);
+      const double sigma_y = std::max(1e-9, angular_std[1]);
+      const double sigma_z = 0.5 * (sigma_x + sigma_y);
+      const Eigen::Matrix3d R =
+          image.CamFromWorld().rotation().toRotationMatrix();
+      const Eigen::Matrix3d cov_world =
+          R.transpose() *
+          Eigen::Vector3d(
+              sigma_x * sigma_x, sigma_y * sigma_y, sigma_z * sigma_z)
+              .asDiagonal() *
+          R;
+      cost_function = CovarianceWeightedCostFunctor<
+          BATAPairwiseDirectionCostFunctor>::Create(cov_world,
+                                                    cam_from_point3D_dir);
+    }
+    if (cost_function == nullptr) {
+      cost_function =
+          BATAPairwiseDirectionCostFunctor::Create(cam_from_point3D_dir);
+    }
 
     problem_->AddResidualBlock(cost_function,
                                loss_function,
                                frame_centers_[image.FrameId()].data(),
                                point3D.xyz.data(),
                                &scale);
+
+    // 1-D MetricDepthError: anchors absolute scale via depth prior.
+    if (options_.use_metric_depth_constraint) {
+      AddMetricDepthResidual(
+          point3D_id, observation, is_lc_observation, reconstruction);
+    }
   } else {
     // If the image is part of a camera rig, use the RigBATA error.
 
@@ -307,6 +524,104 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   problem_->SetParameterLowerBound(&scale, 0, 1e-5);
 }
 
+void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
+                                              const TrackElement& observation,
+                                              bool is_lc_observation,
+                                              Reconstruction& reconstruction) {
+  if (!reconstruction.ExistsImage(observation.image_id)) return;
+  const Image& image = reconstruction.Image(observation.image_id);
+
+  if (observation.point2D_idx >= image.depth_prior_validity.size() ||
+      !image.depth_prior_validity[observation.point2D_idx]) {
+    return;
+  }
+  THROW_CHECK_LT(observation.point2D_idx, image.depth_priors.size());
+  THROW_CHECK_LT(observation.point2D_idx, image.depth_prior_stddevs.size());
+
+  const double depth_prior = image.depth_priors[observation.point2D_idx];
+  const double depth_sigma = image.depth_prior_stddevs[observation.point2D_idx];
+
+  if (depth_prior <= 0.0 || depth_sigma <= 1e-9) return;
+
+  // Lazy-insert dmap_scales_ on first valid observation per image.
+  if (dmap_scales_.find(observation.image_id) == dmap_scales_.end()) {
+    double init_value = options_.use_log_scale_for_depth_map_scales ? 0.0 : 1.0;
+    if (options_.initial_dmap_scales.has_value()) {
+      const auto& init_map = *options_.initial_dmap_scales;
+      auto it = init_map.find(observation.image_id);
+      if (it != init_map.end()) {
+        // Convert caller-supplied linear value to log if needed.
+        init_value = options_.use_log_scale_for_depth_map_scales
+                         ? std::log(std::max(it->second, 1e-9))
+                         : it->second;
+      }
+    }
+    dmap_scales_[observation.image_id] = init_value;
+    dmap_scale_observation_counts_[observation.image_id] = 0;
+  }
+  dmap_scale_observation_counts_[observation.image_id]++;
+
+  ceres::CostFunction* metric_depth_cost =
+      MetricDepthError::Create(image.CamFromWorld().rotation(),
+                               depth_prior,
+                               depth_sigma,
+                               CreateMetricDepthOptions(options_));
+
+  if (metric_depth_cost == nullptr) return;
+
+  // Outlier dual routing:
+  //   depth_outliers_ = runtime geometry-driven filter
+  //     (Nσ log-residual, N = filter_depth_outlier_sigma),
+  //     populated by FilterDepthOutliers between BA iterations.
+  //   TrackElement::is_depth_outlier = external annotation
+  //     (MDRP/boundary heuristic), populated by Python pipeline
+  //     pre-solve.
+  //   depth_outliers_ is checked first and is strictly more
+  //   aggressive: LC observations skip the depth residual
+  //   entirely, non-LC get a soft fallback loss.
+  //
+  // 5-way depth-loss cascade:
+  //   pre-pass outlier  -> soft fallback (skip on LC)
+  //   is_lc             -> cached_loss_lc_depth_
+  //   TrackElement::is_track_anchor  -> cached_loss_normal_depth_trackstart_
+  //   TrackElement::is_inlier        -> cached_loss_normal_depth_inlier_
+  //   TrackElement::is_depth_outlier -> cached_loss_normal_depth_outlier_
+  //   else              -> cached_loss_normal_depth_
+  ceres::LossFunction* depth_loss = nullptr;
+  const std::pair<image_t, point2D_t> obs_key{observation.image_id,
+                                              observation.point2D_idx};
+  if (depth_outliers_.count(obs_key) > 0) {
+    if (is_lc_observation) {
+      // LC outlier: skip depth residual entirely.
+      delete metric_depth_cost;
+      return;
+    }
+    // Non-LC outlier: soft fallback (HuberLoss(1)).
+    if (!soft_outlier_fallback_loss_) {
+      soft_outlier_fallback_loss_ =
+          options_.loss_soft_outlier_fallback.CreateLossFunction();
+    }
+    depth_loss = soft_outlier_fallback_loss_.get();
+  } else if (is_lc_observation) {
+    depth_loss = cached_loss_lc_depth_.get();
+  } else if (observation.is_track_anchor) {
+    depth_loss = cached_loss_normal_depth_trackstart_.get();
+  } else if (observation.is_inlier) {
+    depth_loss = cached_loss_normal_depth_inlier_.get();
+  } else if (observation.is_depth_outlier) {
+    depth_loss = cached_loss_normal_depth_outlier_.get();
+  } else {
+    depth_loss = cached_loss_normal_depth_.get();
+  }
+
+  Point3D& point3D = reconstruction.Point3D(point3D_id);
+  problem_->AddResidualBlock(metric_depth_cost,
+                             depth_loss,
+                             frame_centers_[image.FrameId()].data(),
+                             point3D.xyz.data(),
+                             &dmap_scales_[observation.image_id]);
+}
+
 void GlobalPositioner::AddCamerasAndPointsToParameterGroups(
     Reconstruction& reconstruction) {
   // Create a custom ordering for Schur-based problems.
@@ -341,6 +656,14 @@ void GlobalPositioner::AddCamerasAndPointsToParameterGroups(
   for (auto& [sensor_id, center] : cams_in_rig_) {
     if (problem_->HasParameterBlock(center.data())) {
       parameter_ordering->AddElementToGroup(center.data(), group_id);
+    }
+  }
+
+  // dmap_scales_ in own group (1-D vs 3-D frame_centers/cams_in_rig).
+  ++group_id;
+  for (auto& [image_id, scale] : dmap_scales_) {
+    if (problem_->HasParameterBlock(&scale)) {
+      parameter_ordering->AddElementToGroup(&scale, group_id);
     }
   }
 }
@@ -385,11 +708,23 @@ void GlobalPositioner::ParameterizeVariables(Reconstruction& reconstruction) {
       }
     }
   }
-  // Set the first scale to be constant to remove the gauge ambiguity.
-  for (double& scale : scales_) {
-    if (problem_->HasParameterBlock(&scale)) {
-      problem_->SetParameterBlockConstant(&scale);
-      break;
+
+  // Lower-bound dmap_scales_ in linear space (no bound needed in log space).
+  if (!options_.use_log_scale_for_depth_map_scales) {
+    for (auto& [image_id, scale] : dmap_scales_) {
+      if (problem_->HasParameterBlock(&scale)) {
+        problem_->SetParameterLowerBound(&scale, 0, 1e-5);
+      }
+    }
+  }
+  // Pin first scale to remove gauge ambiguity. Skip when metric-depth is
+  // active (depth priors + scale priors already anchor the gauge).
+  if (!options_.use_metric_depth_constraint) {
+    for (double& scale : scales_) {
+      if (problem_->HasParameterBlock(&scale)) {
+        problem_->SetParameterBlockConstant(&scale);
+        break;
+      }
     }
   }
 
@@ -478,6 +813,109 @@ void GlobalPositioner::ConvertBackResults(Reconstruction& reconstruction) {
       break;
     }
   }
+}
+
+void GlobalPositioner::FilterDepthOutliers(
+    const Reconstruction& reconstruction) {
+  for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
+    // Regular observations
+    for (const auto& observation : point3D.track.Elements()) {
+      if (!reconstruction.ExistsImage(observation.image_id)) continue;
+      const Image& image = reconstruction.Image(observation.image_id);
+      if (!image.HasPose()) continue;
+      if (DepthOutlierFlag(image,
+                           observation.point2D_idx,
+                           point3D.xyz,
+                           options_.use_log_scale_for_depth_map_scales,
+                           dmap_scales_,
+                           observation.image_id,
+                           options_.filter_depth_outlier_sigma)) {
+        depth_outliers_.insert({observation.image_id, observation.point2D_idx});
+      }
+    }
+    if (options_.use_lc_observations) {
+      for (const auto& observation : point3D.track.lc_elements) {
+        if (!reconstruction.ExistsImage(observation.image_id)) continue;
+        const Image& image = reconstruction.Image(observation.image_id);
+        if (!image.HasPose()) continue;
+        if (DepthOutlierFlag(image,
+                             observation.point2D_idx,
+                             point3D.xyz,
+                             options_.use_log_scale_for_depth_map_scales,
+                             dmap_scales_,
+                             observation.image_id,
+                             options_.filter_depth_outlier_sigma)) {
+          depth_outliers_.insert(
+              {observation.image_id, observation.point2D_idx});
+        }
+      }
+    }
+  }
+  VLOG(2) << "FilterDepthOutliers: flagged " << depth_outliers_.size()
+          << " observations as depth outliers.";
+}
+
+void GlobalPositioner::InitializeDepthMapScalesFromObservations(
+    const Reconstruction& reconstruction) {
+  // Per-image scale estimates: scale = z_est / depth_prior.
+  std::map<image_t, std::vector<double>> image_scale_estimates;
+
+  auto consume_observation = [&](image_t image_id,
+                                 point2D_t feature_id,
+                                 const Eigen::Vector3d& point_world) {
+    if (!reconstruction.ExistsImage(image_id)) return;
+    const Image& image = reconstruction.Image(image_id);
+    if (!image.HasPose()) return;
+
+    if (feature_id >= image.depth_prior_validity.size() ||
+        !image.depth_prior_validity[feature_id]) {
+      return;
+    }
+    if (feature_id >= image.depth_priors.size()) return;
+
+    const double depth_prior = image.depth_priors[feature_id];
+    if (depth_prior <= 1e-6) return;
+
+    // z_est = (cam_from_world * X_world)[2]
+    const Eigen::Vector3d point_cam = image.CamFromWorld() * point_world;
+    const double z_est = point_cam[2];
+    if (z_est <= 1e-6) return;
+
+    const double scale_estimate = z_est / depth_prior;
+    if (scale_estimate > 1e-6 && scale_estimate < 1e6) {
+      image_scale_estimates[image_id].push_back(scale_estimate);
+    }
+  };
+
+  for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
+    for (const auto& observation : point3D.track.Elements()) {
+      consume_observation(
+          observation.image_id, observation.point2D_idx, point3D.xyz);
+    }
+    if (options_.use_lc_observations) {
+      for (const auto& observation : point3D.track.lc_elements) {
+        consume_observation(
+            observation.image_id, observation.point2D_idx, point3D.xyz);
+      }
+    }
+  }
+
+  for (auto& [image_id, scale_estimates] : image_scale_estimates) {
+    if (scale_estimates.empty()) continue;
+
+    std::sort(scale_estimates.begin(), scale_estimates.end());
+    const double median_scale = scale_estimates[scale_estimates.size() / 2];
+
+    const double initial_value = options_.use_log_scale_for_depth_map_scales
+                                     ? std::log(median_scale)
+                                     : median_scale;
+
+    dmap_scales_[image_id] = initial_value;
+    dmap_scale_observation_counts_[image_id] = 0;
+  }
+
+  VLOG(2) << "InitializeDepthMapScalesFromObservations: seeded "
+          << dmap_scales_.size() << " image scales from observations.";
 }
 
 bool RunGlobalPositioning(const GlobalPositionerOptions& options,

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -411,7 +411,8 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
       << "Not enough capacity was reserved for the scales.";
   double& scale = scales_.emplace_back(1);
 
-  if (!options_.generate_scales) {
+  if (!options_.generate_scales &&
+      (random_initialization || options_.initialize_warm_start_scales)) {
     const Eigen::Vector3d cam_from_point3D_translation =
         point3D.xyz - frame_centers_[image.FrameId()];
     scale = std::max(1e-5,

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -232,7 +232,8 @@ void GlobalPositioner::InitializeRandomPositions(
     }
     if (options_.generate_random_positions && options_.optimize_positions &&
         !options_.use_init) {
-      frame_centers_[frame_id] = options_.random_init_scale * RandVector3d(-1, 1);
+      frame_centers_[frame_id] =
+          options_.random_init_scale * RandVector3d(-1, 1);
     } else {
       frame_centers_[frame_id] = frame.RigFromWorld().TgtOriginInSrc();
     }
@@ -354,9 +355,9 @@ void GlobalPositioner::AddPointToCameraConstraints(
 
 void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
                                            Reconstruction& reconstruction) {
-  const bool random_initialization =
-      options_.optimize_points && options_.generate_random_points &&
-      !options_.use_init;
+  const bool random_initialization = options_.optimize_points &&
+                                     options_.generate_random_points &&
+                                     !options_.use_init;
 
   Point3D& point3D = reconstruction.Point3D(point3D_id);
 
@@ -410,7 +411,7 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
       << "Not enough capacity was reserved for the scales.";
   double& scale = scales_.emplace_back(1);
 
-  if (!options_.generate_scales && random_initialization) {
+  if (!options_.generate_scales) {
     const Eigen::Vector3d cam_from_point3D_translation =
         point3D.xyz - frame_centers_[image.FrameId()];
     scale = std::max(1e-5,

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -6,8 +6,11 @@
 
 #include <map>
 #include <memory>
+#include <optional>
+#include <set>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include <ceres/ceres.h>
 
@@ -55,6 +58,9 @@ struct GlobalPositionerOptions {
   // The options for the solver
   ceres::Solver::Options solver_options;
 
+  // Add per-observation MetricDepthError residual alongside BATA.
+  bool use_metric_depth_constraint = false;
+
   // Include loop-closure observations in point3D problems.
   bool use_lc_observations = false;
 
@@ -64,9 +70,40 @@ struct GlobalPositionerOptions {
   // Cube half-extent for random initialization of positions and points.
   double random_init_scale = 100.0;
 
-  // Per-observation loss configs for LC routing.
+  // --- Metric-depth path toggles (only consulted when
+  //     use_metric_depth_constraint == true) ---
+  bool use_log_scale_for_depth_map_scales = false;
+  bool use_log_residual_for_depth = false;
+  bool zero_residual_behind = false;
+  // Selects the log-linear residual shape and implies log residuals.
+  bool smooth_log_linear_transition = false;
+  double log_linear_threshold = 1.0;
+  double scale_prior_stddev = 1.0;
+
+  // Pre-Solve log-space depth-residual filter. Flagged observations
+  // route through a soft fallback in the depth-loss cascade.
+  bool filter_depth_outliers = false;
+  // Number of sigma for the log-space depth-residual outlier threshold.
+  double filter_depth_outlier_sigma = 3.0;
+
+  // Caller-supplied initial dmap_scales (linear space). nullopt = auto.
+  std::optional<std::unordered_map<image_t, double>> initial_dmap_scales;
+
+  // Soft fallback loss for depth outliers flagged by FilterDepthOutliers.
+  LossConfig loss_soft_outlier_fallback = {LossFunctionType::HUBER, 1.0, 1.0};
+
+  // Per-observation loss routing (only active when
+  // use_metric_depth_constraint).
+  LossConfig loss_normal_geometry;
+  LossConfig loss_normal_depth;
   LossConfig loss_lc_geometry;
   LossConfig loss_lc_depth;
+  LossConfig loss_normal_geometry_inlier;
+  LossConfig loss_normal_depth_inlier;
+  LossConfig loss_normal_depth_outlier;
+  LossConfig loss_normal_geometry_trackstart;
+  LossConfig loss_normal_depth_trackstart;
+  LossConfig loss_scale_prior;
 
   GlobalPositionerOptions() {
     solver_options.num_threads = -1;
@@ -91,6 +128,11 @@ class GlobalPositioner {
 
   GlobalPositionerOptions& GetOptions() { return options_; }
 
+  // Per-image dmap_scales_ after Solve() (log or linear per options).
+  const std::map<image_t, double>& GetDmapScales() const {
+    return dmap_scales_;
+  }
+
  protected:
   void SetupProblem(const PoseGraph& pose_graph,
                     const Reconstruction& reconstruction);
@@ -109,7 +151,21 @@ class GlobalPositioner {
   void AddObservationToProblem(point3D_t point3D_id,
                                const TrackElement& observation,
                                bool random_initialization,
-                               Reconstruction& reconstruction);
+                               Reconstruction& reconstruction,
+                               bool is_lc_observation = false);
+
+  // Add a MetricDepthError residual for a single observation.
+  void AddMetricDepthResidual(point3D_t point3D_id,
+                              const TrackElement& observation,
+                              bool is_lc_observation,
+                              Reconstruction& reconstruction);
+
+  // Seed dmap_scales_ from per-image median z_est / depth_prior.
+  void InitializeDepthMapScalesFromObservations(
+      const Reconstruction& reconstruction);
+
+  // Flag observations with depth residual exceeding filter_depth_outlier_sigma.
+  void FilterDepthOutliers(const Reconstruction& reconstruction);
 
   // Set the parameter groups
   void AddCamerasAndPointsToParameterGroups(Reconstruction& reconstruction);
@@ -141,6 +197,33 @@ class GlobalPositioner {
   // Temporary storage for camera-in-rig positions when cam_from_rig is unknown
   // and needs to be estimated.
   std::unordered_map<sensor_t, Eigen::Vector3d> cams_in_rig_;
+
+  // --- Optional extensions ---
+
+  // std::map (not unordered) — Ceres stores &dmap_scales_[id] pointers.
+  std::map<image_t, double> dmap_scales_;
+  std::unordered_map<image_t, int> dmap_scale_observation_counts_;
+  std::set<std::pair<image_t, point2D_t>> depth_outliers_;
+
+  // Cached loss buckets for the depth cascade.
+  std::shared_ptr<ceres::LossFunction> cached_loss_normal_geometry_;
+  std::shared_ptr<ceres::LossFunction> cached_loss_normal_depth_;
+  std::shared_ptr<ceres::LossFunction> cached_loss_lc_geometry_;
+  std::shared_ptr<ceres::LossFunction> cached_loss_lc_depth_;
+  std::shared_ptr<ceres::LossFunction> cached_loss_normal_geometry_inlier_;
+  std::shared_ptr<ceres::LossFunction> cached_loss_normal_depth_inlier_;
+  std::shared_ptr<ceres::LossFunction> cached_loss_normal_depth_outlier_;
+  std::shared_ptr<ceres::LossFunction> cached_loss_normal_geometry_trackstart_;
+  std::shared_ptr<ceres::LossFunction> cached_loss_normal_depth_trackstart_;
+  std::shared_ptr<ceres::LossFunction> cached_loss_scale_prior_;
+
+  // Soft fallback loss for non-LC depth outliers. Lazily allocated from
+  // options_.loss_soft_outlier_fallback.
+  std::shared_ptr<ceres::LossFunction> soft_outlier_fallback_loss_;
+
+  // Per-image ScaledLoss wrappers created in the scale-prior loop.
+  // Owned here because problem_ uses DO_NOT_TAKE_OWNERSHIP.
+  std::vector<std::unique_ptr<ceres::LossFunction>> per_image_scale_losses_;
 };
 
 // Solve global positioning using point-to-camera constraints.

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -23,6 +23,10 @@ struct GlobalPositionerOptions {
   // Whether to initialize the camera scales to a constant 1 or derive them from
   // the initialized camera and point positions.
   bool generate_scales = true;
+  // When generate_scales is false, derive per-observation BATA scales from the
+  // current camera/point geometry even for warm-started solves. Disable only to
+  // reproduce legacy behavior where warm-started solves left these scales at 1.
+  bool initialize_warm_start_scales = true;
 
   // Flags for which parameters to optimize
   bool optimize_positions = true;

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/estimators/global_positioning.h"
 
+#include "colmap/estimators/cost_functions/metric_depth.h"
 #include "colmap/math/random.h"
 #include "colmap/scene/database_cache.h"
 #include "colmap/scene/pose_graph.h"
@@ -36,6 +37,9 @@
 #include "colmap/scene/synthetic.h"
 #include "colmap/util/testing.h"
 
+#include <cmath>
+
+#include <ceres/loss_function.h>
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -135,6 +139,559 @@ TEST(GlobalPositioning, MultiCameraRig) {
                                  /*max_proj_center_error=*/0.5,
                                  /*max_scale_error=*/std::nullopt,
                                  /*num_obs_tolerance=*/0.0));
+}
+
+// ---- LossConfig::CreateLossFunction() dispatch ----
+
+TEST(LossConfig, TrivialDispatch) {
+  LossConfig config;
+  config.type = LossFunctionType::TRIVIAL;
+  config.scale = 1.0;
+  config.weight = 1.0;
+  std::shared_ptr<ceres::LossFunction> loss = config.CreateLossFunction();
+  ASSERT_NE(loss, nullptr);
+
+  // TrivialLoss: rho = (s, 1, 0) for any s.
+  double rho[3];
+  loss->Evaluate(/*sq_norm=*/4.0, rho);
+  EXPECT_NEAR(rho[0], 4.0, 1e-12);
+  EXPECT_NEAR(rho[1], 1.0, 1e-12);
+  EXPECT_NEAR(rho[2], 0.0, 1e-12);
+
+  // dynamic_cast confirms exact type when no ScaledLoss wrap.
+  EXPECT_NE(dynamic_cast<ceres::TrivialLoss*>(loss.get()), nullptr);
+}
+
+TEST(LossConfig, HuberDispatchSemantics) {
+  LossConfig config;
+  config.type = LossFunctionType::HUBER;
+  config.scale = 0.5;
+  config.weight = 1.0;
+  std::shared_ptr<ceres::LossFunction> loss = config.CreateLossFunction();
+  ASSERT_NE(loss, nullptr);
+  EXPECT_NE(dynamic_cast<ceres::HuberLoss*>(loss.get()), nullptr);
+
+  // HuberLoss(a) with sq_norm s:
+  //   s <= a^2: rho[0] = s
+  //   s >  a^2: rho[0] = 2*a*sqrt(s) - a^2
+  const double a = 0.5;
+  const double a2 = a * a;
+
+  double rho_below[3];
+  loss->Evaluate(/*sq_norm=*/0.1, rho_below);  // 0.1 < 0.25 -> quadratic
+  EXPECT_NEAR(rho_below[0], 0.1, 1e-12);
+
+  double rho_above[3];
+  loss->Evaluate(/*sq_norm=*/4.0, rho_above);  // 4.0 > 0.25 -> linear
+  const double expected = 2.0 * a * std::sqrt(4.0) - a2;
+  EXPECT_NEAR(rho_above[0], expected, 1e-12);
+}
+
+TEST(LossConfig, ScaledLossWrapWhenWeightNonOne) {
+  // weight=2.0 over a TrivialLoss → rho[0] = 2 * sq_norm.
+  LossConfig config;
+  config.type = LossFunctionType::TRIVIAL;
+  config.scale = 1.0;
+  config.weight = 2.0;
+  std::shared_ptr<ceres::LossFunction> loss = config.CreateLossFunction();
+  ASSERT_NE(loss, nullptr);
+
+  // After ScaledLoss wrap, the outer pointer is no longer a TrivialLoss.
+  EXPECT_EQ(dynamic_cast<ceres::TrivialLoss*>(loss.get()), nullptr);
+
+  double rho[3];
+  loss->Evaluate(/*sq_norm=*/3.0, rho);
+  EXPECT_NEAR(rho[0], 6.0, 1e-12);  // 2 * sq_norm
+  EXPECT_NEAR(rho[1], 2.0, 1e-12);  // 2 * 1.0
+  EXPECT_NEAR(rho[2], 0.0, 1e-12);
+
+  // Weight=2 over Huber: rho should be exactly 2x the unweighted Huber rho.
+  LossConfig huber_unweighted;
+  huber_unweighted.type = LossFunctionType::HUBER;
+  huber_unweighted.scale = 0.7;
+  huber_unweighted.weight = 1.0;
+  LossConfig huber_weighted = huber_unweighted;
+  huber_weighted.weight = 2.0;
+  auto loss_u = huber_unweighted.CreateLossFunction();
+  auto loss_w = huber_weighted.CreateLossFunction();
+
+  double rho_u[3];
+  double rho_w[3];
+  loss_u->Evaluate(/*sq_norm=*/2.5, rho_u);
+  loss_w->Evaluate(/*sq_norm=*/2.5, rho_w);
+  EXPECT_NEAR(rho_w[0], 2.0 * rho_u[0], 1e-12);
+  EXPECT_NEAR(rho_w[1], 2.0 * rho_u[1], 1e-12);
+  EXPECT_NEAR(rho_w[2], 2.0 * rho_u[2], 1e-12);
+}
+
+TEST(LossConfig, CauchyAndSoftL1Smoke) {
+  for (LossFunctionType type :
+       {LossFunctionType::CAUCHY, LossFunctionType::SOFT_L1}) {
+    LossConfig config;
+    config.type = type;
+    config.scale = 0.5;
+    config.weight = 1.0;
+    std::shared_ptr<ceres::LossFunction> loss = config.CreateLossFunction();
+    ASSERT_NE(loss, nullptr);
+    double rho[3];
+    loss->Evaluate(/*sq_norm=*/1.0, rho);
+    EXPECT_TRUE(std::isfinite(rho[0]));
+    EXPECT_TRUE(std::isfinite(rho[1]));
+    EXPECT_TRUE(std::isfinite(rho[2]));
+  }
+}
+
+// ---- MetricDepthError log-linear C¹ continuity at threshold ----
+
+TEST(MetricDepthError, SmoothLogLinearTransitionC1Continuity) {
+  const Eigen::Quaterniond identity = Eigen::Quaterniond::Identity();
+  const double depth_prior = 1.0;
+  const double sigma_depth = 0.2;
+  const double threshold = 0.5;
+
+  MetricDepthOptions options;
+  options.residual_type = MetricDepthResidualType::kLogLinear;
+  options.log_linear_threshold = threshold;
+
+  MetricDepthError functor(identity, depth_prior, sigma_depth, options);
+
+  // Helper: evaluate residual at z_est with camera at origin, identity
+  // rotation, point at (0, 0, z_est), dmap_scale = 1.0.
+  auto eval = [&](double z_est) -> double {
+    const double c_i[3] = {0.0, 0.0, 0.0};
+    const double X_k[3] = {0.0, 0.0, z_est};
+    const double dmap_scale[1] = {1.0};
+    double residual[1] = {0.0};
+    functor(c_i, X_k, dmap_scale, residual);
+    return residual[0];
+  };
+
+  // --- C⁰: residual values match at threshold ---
+  {
+    const double eps = 1e-8;
+    const double r_above = eval(threshold + eps);
+    const double r_below = eval(threshold - eps);
+    EXPECT_NEAR(r_above, r_below, 1e-5)
+        << "C0 violated: residual discontinuity at threshold";
+  }
+
+  // --- C¹: slopes match at threshold ---
+  // Finite-difference the slope on each side of the boundary.
+  // Use a probe point close to the boundary, then finite-diff around it.
+  {
+    const double delta = 1e-5;  // offset from boundary
+    const double h = 1e-8;      // finite-difference step
+
+    // Slope on the log side (above threshold)
+    const double z_above = threshold + delta;
+    const double slope_above =
+        (eval(z_above + h) - eval(z_above - h)) / (2.0 * h);
+
+    // Slope on the linear side (below threshold)
+    const double z_below = threshold - delta;
+    const double slope_below =
+        (eval(z_below + h) - eval(z_below - h)) / (2.0 * h);
+
+    EXPECT_NEAR(slope_above, slope_below, 1e-3)
+        << "C1 violated: slope discontinuity at threshold";
+  }
+
+  // --- Verify exact residual at threshold matches analytic expectation ---
+  // At z_est = threshold: r_depth = log(threshold / scaled_prior)
+  // weight = 1 / (sigma_depth / depth_prior) = depth_prior / sigma_depth
+  {
+    const double r_at_threshold = eval(threshold);
+    const double expected_weight = depth_prior / sigma_depth;
+    const double expected_r_depth = std::log(threshold / (1.0 * depth_prior));
+    EXPECT_NEAR(r_at_threshold, expected_weight * expected_r_depth, 1e-10);
+  }
+}
+
+// ---- Backward-compat gate: use_lc_observations.
+//
+// Default-constructed ``GlobalPositionerOptions`` keeps the gate ``false``
+// so vanilla pycolmap callers get vanilla colmap4 GP behaviour even when
+// ``track.lc_elements`` carry non-empty values left over from upstream code
+// paths. These tests verify both directions of the gate by counting BATA
+// residual blocks added during ``Solve``.
+
+namespace {
+
+// Test-only subclass exposing ``scales_`` (one entry per BATA residual
+// block added by ``AddObservationToProblem``) so we can count residuals
+// without instrumenting the production class.
+class TestableGlobalPositioner : public GlobalPositioner {
+ public:
+  using GlobalPositioner::GlobalPositioner;
+  size_t NumScales() const { return scales_.size(); }
+  size_t NumFrameCenters() const { return frame_centers_.size(); }
+  void SetupOnlyForTest(const PoseGraph& pose_graph,
+                        Reconstruction& reconstruction) {
+    SetupProblem(pose_graph, reconstruction);
+    InitializeRandomPositions(pose_graph, reconstruction);
+    AddPointToCameraConstraints(reconstruction);
+  }
+};
+
+// Build a small synthetic GP problem with rigs of a single ref camera so
+// every observation routes through the BATA branch in
+// ``AddObservationToProblem``. Returns a freshly loaded ``Reconstruction``
+// with rotations from GT and zero translations (mirrors the nominal test).
+struct GpTestData {
+  std::shared_ptr<Database> database;
+  Reconstruction gt_reconstruction;
+  Reconstruction reconstruction;
+  PoseGraph pose_graph;
+  DatabaseCache database_cache;
+};
+
+GpTestData BuildGpTestData() {
+  GpTestData data;
+  const auto database_path = CreateTestDir() / "database.db";
+  data.database = Database::Open(database_path);
+
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 5;
+  synthetic_dataset_options.num_points3D = 30;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  SynthesizeDataset(
+      synthetic_dataset_options, &data.gt_reconstruction, data.database.get());
+
+  DatabaseCache::Options cache_options;
+  data.database_cache.Load(*data.database, cache_options);
+
+  data.pose_graph.Load(*data.database_cache.CorrespondenceGraph());
+
+  data.reconstruction = data.gt_reconstruction;
+  for (const auto& [frame_id, _] : data.reconstruction.Frames()) {
+    Frame& frame = data.reconstruction.Frame(frame_id);
+    frame.SetRigFromWorld(
+        Rigid3d(frame.RigFromWorld().rotation(), Eigen::Vector3d::Zero()));
+  }
+  return data;
+}
+
+GlobalPositionerOptions BaselineGpOptions() {
+  GlobalPositionerOptions options;
+  options.use_gpu = false;
+  options.random_seed = 42;
+  options.solver_options.minimizer_progress_to_stdout = false;
+  // Solve with a single iteration: we only care about residual blocks
+  // attached during setup, not convergence.
+  options.solver_options.max_num_iterations = 1;
+  return options;
+}
+
+// Sum of valid track elements across tracks long enough to be added by
+// ``AddPointToCameraConstraints`` (i.e. ``track.Length() >=
+// min_num_view_per_track``).
+size_t CountValidObservations(const Reconstruction& reconstruction,
+                              int min_num_view_per_track) {
+  size_t total = 0;
+  for (const auto& [_, point3D] : reconstruction.Points3D()) {
+    if (static_cast<int>(point3D.track.Length()) < min_num_view_per_track) {
+      continue;
+    }
+    total += point3D.track.Length();
+  }
+  return total;
+}
+
+// Sum of LC elements in tracks long enough to participate in GP.
+size_t CountLcObservations(const Reconstruction& reconstruction,
+                           int min_num_view_per_track) {
+  size_t total = 0;
+  for (const auto& [_, point3D] : reconstruction.Points3D()) {
+    if (static_cast<int>(point3D.track.Length()) < min_num_view_per_track) {
+      continue;
+    }
+    total += point3D.track.lc_elements.size();
+  }
+  return total;
+}
+
+// Copy regular track elements into ``lc_elements`` for every track that
+// participates in GP and return the total LC elements added.
+size_t DuplicateElementsAsLc(Reconstruction& reconstruction,
+                             int min_num_view_per_track) {
+  size_t total_lc = 0;
+  std::vector<point3D_t> point3D_ids;
+  point3D_ids.reserve(reconstruction.NumPoints3D());
+  for (const auto& [point3D_id, _] : reconstruction.Points3D()) {
+    point3D_ids.push_back(point3D_id);
+  }
+  for (point3D_t point3D_id : point3D_ids) {
+    Point3D& point3D = reconstruction.Point3D(point3D_id);
+    if (static_cast<int>(point3D.track.Length()) < min_num_view_per_track) {
+      continue;
+    }
+    point3D.track.lc_elements = point3D.track.Elements();
+    total_lc += point3D.track.lc_elements.size();
+  }
+  return total_lc;
+}
+
+// Keep exactly one point with one regular observation plus two LC observations.
+// LC residuals may augment admitted points, but they must not satisfy the
+// min-view admission gate.
+void KeepSingleRegularPlusLcPoint(Reconstruction& reconstruction) {
+  std::vector<point3D_t> point3D_ids;
+  point3D_ids.reserve(reconstruction.NumPoints3D());
+  for (const point3D_t point3D_id : reconstruction.Point3DIds()) {
+    point3D_ids.push_back(point3D_id);
+  }
+  for (const point3D_t point3D_id : point3D_ids) {
+    reconstruction.DeletePoint3D(point3D_id);
+  }
+
+  const std::vector<image_t> image_ids = reconstruction.RegImageIds();
+  THROW_CHECK_GE(image_ids.size(), 3);
+  THROW_CHECK_GT(reconstruction.Image(image_ids[0]).NumPoints2D(), 0);
+  THROW_CHECK_GT(reconstruction.Image(image_ids[1]).NumPoints2D(), 0);
+  THROW_CHECK_GT(reconstruction.Image(image_ids[2]).NumPoints2D(), 0);
+
+  Point3D point3D;
+  point3D.xyz = Eigen::Vector3d(0.1, 0.2, 4.0);
+  point3D.track.AddElement(image_ids[0], 0);
+  point3D.track.lc_elements.emplace_back(image_ids[1], 0);
+  point3D.track.lc_elements.emplace_back(image_ids[2], 0);
+  reconstruction.AddPoint3D(0, std::move(point3D));
+}
+
+}  // namespace
+
+TEST(GlobalPositioning, MetricDepthConstraintConverges) {
+  SetPRNGSeed(0);
+
+  GpTestData data = BuildGpTestData();
+
+  // Stamp ground-truth z-depths as depth priors on every image.
+  for (const auto& [image_id, _] : data.gt_reconstruction.Images()) {
+    Image& image = data.gt_reconstruction.Image(image_id);
+    const size_t num_points2D = image.NumPoints2D();
+    image.depth_priors.assign(num_points2D, 0.0);
+    image.depth_prior_stddevs.assign(num_points2D, 0.0);
+    image.depth_prior_validity.assign(num_points2D, false);
+
+    for (point2D_t idx = 0; idx < num_points2D; ++idx) {
+      if (!image.Point2D(idx).HasPoint3D()) continue;
+      const auto& point3D =
+          data.gt_reconstruction.Point3D(image.Point2D(idx).point3D_id);
+      const Eigen::Vector3d point_cam = image.CamFromWorld() * point3D.xyz;
+      const double z = point_cam[2];
+      if (z > 0) {
+        image.depth_priors[idx] = z;
+        image.depth_prior_stddevs[idx] = 0.1 * z;
+        image.depth_prior_validity[idx] = true;
+      }
+    }
+  }
+
+  // Copy depth priors into the working reconstruction (which has zero
+  // translations but GT rotations -- mirrors BuildGpTestData).
+  for (const auto& [image_id, _] : data.reconstruction.Images()) {
+    const Image& gt_image = data.gt_reconstruction.Image(image_id);
+    Image& image = data.reconstruction.Image(image_id);
+    image.depth_priors = gt_image.depth_priors;
+    image.depth_prior_stddevs = gt_image.depth_prior_stddevs;
+    image.depth_prior_validity = gt_image.depth_prior_validity;
+  }
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  options.use_init = false;
+  options.generate_random_positions = true;
+  options.generate_random_points = true;
+  options.solver_options.max_num_iterations = 100;
+
+  GlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  const auto& dmap_scales = positioner.GetDmapScales();
+  ASSERT_FALSE(dmap_scales.empty());
+
+  for (const auto& [image_id, scale] : dmap_scales) {
+    EXPECT_NEAR(scale, 1.0, 0.5) << "dmap_scale for image " << image_id << " = "
+                                 << scale << ", expected ~1.0";
+  }
+}
+
+TEST(GlobalPositioning, Gate_UseLcObservations_Off_IgnoresLcElements) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  ASSERT_FALSE(options.use_lc_observations);
+
+  // Duplicate the regular elements as LC elements so every track has both
+  // sets populated. Off-gate -> only regular elements added.
+  const size_t expected_lc = DuplicateElementsAsLc(
+      data.reconstruction, options.min_num_view_per_track);
+  ASSERT_GT(expected_lc, 0u);
+
+  const size_t expected_regular = CountValidObservations(
+      data.reconstruction, options.min_num_view_per_track);
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  EXPECT_EQ(positioner.NumScales(), expected_regular);
+}
+
+TEST(GlobalPositioning, Gate_UseLcObservations_On_IteratesLcElements) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_lc_observations = true;
+
+  // Same setup as the OFF test; ON should now add both passes.
+  DuplicateElementsAsLc(data.reconstruction, options.min_num_view_per_track);
+
+  const size_t expected_regular = CountValidObservations(
+      data.reconstruction, options.min_num_view_per_track);
+  const size_t expected_lc =
+      CountLcObservations(data.reconstruction, options.min_num_view_per_track);
+  ASSERT_GT(expected_lc, 0u);
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  EXPECT_EQ(positioner.NumScales(), expected_regular + expected_lc);
+}
+
+TEST(GlobalPositioning, MinViewGate_UseLcObservationsOff_IgnoresLcElements) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  KeepSingleRegularPlusLcPoint(data.reconstruction);
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.min_num_view_per_track = 3;
+  ASSERT_FALSE(options.use_lc_observations);
+
+  PoseGraph empty_pose_graph;
+  TestableGlobalPositioner positioner(options);
+  positioner.SetupOnlyForTest(empty_pose_graph, data.reconstruction);
+
+  EXPECT_EQ(positioner.NumFrameCenters(), 0u);
+  EXPECT_EQ(positioner.NumScales(), 0u);
+}
+
+TEST(GlobalPositioning,
+     MinViewGate_UseLcObservationsOn_RequiresRegularElements) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  KeepSingleRegularPlusLcPoint(data.reconstruction);
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.min_num_view_per_track = 3;
+  options.use_lc_observations = true;
+
+  PoseGraph empty_pose_graph;
+  TestableGlobalPositioner positioner(options);
+  positioner.SetupOnlyForTest(empty_pose_graph, data.reconstruction);
+
+  EXPECT_EQ(positioner.NumFrameCenters(), 0u);
+  EXPECT_EQ(positioner.NumScales(), 0u);
+}
+
+// ---- Depth-prior integration tests ----
+
+// Stamp GT z-depth priors on every image in the reconstruction.
+void StampGtDepthPriors(Reconstruction& reconstruction) {
+  for (const auto& [image_id, _] : reconstruction.Images()) {
+    Image& image = reconstruction.Image(image_id);
+    const size_t n = image.NumPoints2D();
+    image.depth_priors.assign(n, 0.0);
+    image.depth_prior_stddevs.assign(n, 0.0);
+    image.depth_prior_validity.assign(n, false);
+    for (point2D_t idx = 0; idx < static_cast<point2D_t>(n); ++idx) {
+      if (!image.Point2D(idx).HasPoint3D()) continue;
+      const auto& p3d = reconstruction.Point3D(image.Point2D(idx).point3D_id);
+      const Eigen::Vector3d pc = image.CamFromWorld() * p3d.xyz;
+      if (pc[2] > 0) {
+        image.depth_priors[idx] = pc[2];
+        image.depth_prior_stddevs[idx] = 0.1 * pc[2];
+        image.depth_prior_validity[idx] = true;
+      }
+    }
+  }
+}
+
+TEST(GlobalPositioning, FilterDepthOutliersRoutesSoftFallback) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+
+  // Stamp GT depth priors on every image.
+  StampGtDepthPriors(data.reconstruction);
+
+  // Corrupt one valid observation to create a depth outlier.
+  {
+    bool corrupted = false;
+    for (const auto& [image_id, _] : data.reconstruction.Images()) {
+      Image& image = data.reconstruction.Image(image_id);
+      for (point2D_t idx = 0; idx < static_cast<point2D_t>(image.NumPoints2D());
+           ++idx) {
+        if (image.depth_prior_validity[idx]) {
+          image.depth_priors[idx] *= 100.0;  // wildly wrong
+          corrupted = true;
+          break;
+        }
+      }
+      if (corrupted) break;
+    }
+    ASSERT_TRUE(corrupted) << "No valid depth prior found to corrupt";
+  }
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  options.filter_depth_outliers = true;
+  options.filter_depth_outlier_sigma = 3.0;
+  options.use_init = false;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  // BATA residual blocks should have been added.
+  EXPECT_GT(positioner.NumScales(), 0u);
+
+  // dmap_scales must be populated (one entry per image with valid depth obs).
+  EXPECT_FALSE(positioner.GetDmapScales().empty());
+}
+
+TEST(GlobalPositioning, CallerSuppliedInitialDmapScales) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+
+  // Stamp GT depth priors.
+  StampGtDepthPriors(data.reconstruction);
+
+  // Build initial dmap_scales with a non-default value.
+  std::unordered_map<image_t, double> init_scales;
+  for (const auto& [image_id, _] : data.reconstruction.Images()) {
+    init_scales[image_id] = 2.5;
+  }
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  options.initial_dmap_scales = init_scales;
+  options.optimize_scales = false;                // freeze BATA scales
+  options.solver_options.max_num_iterations = 0;  // no optimization
+  options.use_init = false;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  // With 0 iterations and frozen scales, dmap_scales should preserve the
+  // initial 2.5 value exactly.
+  const auto& dmap_scales = positioner.GetDmapScales();
+  EXPECT_FALSE(dmap_scales.empty());
+  for (const auto& [image_id, scale] : dmap_scales) {
+    EXPECT_NEAR(scale, 2.5, 0.01) << "dmap_scale for image " << image_id
+                                  << " deviated from initial value";
+  }
 }
 
 }  // namespace

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -531,6 +531,7 @@ TEST(GlobalPositioning, WarmStartGenerateScalesFalseInitializesBataScales) {
   GlobalPositionerOptions options = BaselineGpOptions();
   options.use_init = true;
   options.generate_scales = false;
+  options.initialize_warm_start_scales = true;
 
   TestableGlobalPositioner positioner(options);
   positioner.SetupOnlyForTest(data.pose_graph, data.gt_reconstruction);
@@ -540,6 +541,24 @@ TEST(GlobalPositioning, WarmStartGenerateScalesFalseInitializesBataScales) {
       << "Warm-started GP with generate_scales=false must initialize BATA "
          "scales from current camera/point geometry instead of leaving every "
          "scale at the constructor default 1.0.";
+}
+
+TEST(GlobalPositioning, LegacyWarmStartScaleInitializationCanBeReproduced) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_init = true;
+  options.generate_scales = false;
+  options.initialize_warm_start_scales = false;
+
+  TestableGlobalPositioner positioner(options);
+  positioner.SetupOnlyForTest(data.pose_graph, data.gt_reconstruction);
+
+  EXPECT_GT(positioner.NumScales(), 0u);
+  EXPECT_EQ(positioner.NumNonUnitScales(), 0u)
+      << "Legacy warm-started GP behavior should leave BATA scales at 1.0 "
+         "when generate_scales=false.";
 }
 
 TEST(GlobalPositioning, Gate_UseLcObservations_Off_IgnoresLcElements) {

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -37,6 +37,7 @@
 #include "colmap/scene/synthetic.h"
 #include "colmap/util/testing.h"
 
+#include <algorithm>
 #include <cmath>
 
 #include <ceres/loss_function.h>
@@ -325,6 +326,11 @@ class TestableGlobalPositioner : public GlobalPositioner {
   using GlobalPositioner::GlobalPositioner;
   size_t NumScales() const { return scales_.size(); }
   size_t NumFrameCenters() const { return frame_centers_.size(); }
+  size_t NumNonUnitScales(double eps = 1e-9) const {
+    return std::count_if(scales_.begin(), scales_.end(), [eps](double scale) {
+      return std::abs(scale - 1.0) > eps;
+    });
+  }
   void SetupOnlyForTest(const PoseGraph& pose_graph,
                         Reconstruction& reconstruction) {
     SetupProblem(pose_graph, reconstruction);
@@ -516,6 +522,24 @@ TEST(GlobalPositioning, MetricDepthConstraintConverges) {
     EXPECT_NEAR(scale, 1.0, 0.5) << "dmap_scale for image " << image_id << " = "
                                  << scale << ", expected ~1.0";
   }
+}
+
+TEST(GlobalPositioning, WarmStartGenerateScalesFalseInitializesBataScales) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_init = true;
+  options.generate_scales = false;
+
+  TestableGlobalPositioner positioner(options);
+  positioner.SetupOnlyForTest(data.pose_graph, data.gt_reconstruction);
+
+  EXPECT_GT(positioner.NumScales(), 0u);
+  EXPECT_GT(positioner.NumNonUnitScales(), 0u)
+      << "Warm-started GP with generate_scales=false must initialize BATA "
+         "scales from current camera/point geometry instead of leaving every "
+         "scale at the constructor default 1.0.";
 }
 
 TEST(GlobalPositioning, Gate_UseLcObservations_Off_IgnoresLcElements) {

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -42,6 +42,26 @@ bool AllSensorsFromRigKnown(const std::unordered_map<rig_t, Rig>& rigs) {
   return all_known;
 }
 
+template <typename IdT>
+std::vector<IdT> LegacyPyglomapMapOrder(std::vector<IdT> ids) {
+  // pyglomap's Python bindings materialized Python dicts as std::unordered_map:
+  // reserve(final_size), insert sorted ids, then iterate buckets. Mirror that
+  // order for parity where legacy code consumed unordered_map iteration.
+  std::sort(ids.begin(), ids.end());
+  std::unordered_map<IdT, char> legacy_map;
+  legacy_map.reserve(ids.size());
+  for (const IdT id : ids) {
+    legacy_map.emplace(id, 0);
+  }
+
+  std::vector<IdT> ordered_ids;
+  ordered_ids.reserve(ids.size());
+  for (const auto& [id, _] : legacy_map) {
+    ordered_ids.push_back(id);
+  }
+  return ordered_ids;
+}
+
 }  // namespace
 
 image_t ComputeMaximumPoseGraphSpanningTree(
@@ -56,7 +76,9 @@ image_t ComputeMaximumPoseGraphSpanningTree(
   image_id_to_idx.reserve(image_ids.size());
   idx_to_image_id.reserve(image_ids.size());
 
-  for (const image_t image_id : image_ids) {
+  std::vector<image_t> ordered_image_ids(image_ids.begin(), image_ids.end());
+  ordered_image_ids = LegacyPyglomapMapOrder(std::move(ordered_image_ids));
+  for (const image_t image_id : ordered_image_ids) {
     image_id_to_idx[image_id] = static_cast<int>(idx_to_image_id.size());
     idx_to_image_id.push_back(image_id);
   }
@@ -80,7 +102,14 @@ image_t ComputeMaximumPoseGraphSpanningTree(
                                ? &correspondence_graph->ImagePairsMap()
                                : nullptr;
 
+  std::vector<image_pair_t> ordered_pair_ids;
+  ordered_pair_ids.reserve(pose_graph.NumEdges());
   for (const auto& [pair_id, edge] : pose_graph.ValidEdges()) {
+    ordered_pair_ids.push_back(pair_id);
+  }
+  ordered_pair_ids = LegacyPyglomapMapOrder(std::move(ordered_pair_ids));
+  for (const image_pair_t pair_id : ordered_pair_ids) {
+    const auto& edge = pose_graph.Edges().at(pair_id);
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
     const auto it1 = image_id_to_idx.find(image_id1);
     const auto it2 = image_id_to_idx.find(image_id2);

--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include <Eigen/Core>
+#include <ceres/ceres.h>
 
 // Code is adapted from Theia's RobustRotationEstimator
 // (http://www.theia-sfm.org/). For gravity aligned rotation averaging, refer
@@ -70,6 +71,15 @@ struct RotationEstimatorOptions {
 
   // Drop pairs where LC inliers exceed tracking inliers.
   bool skip_risky_lc_pairs = false;
+
+  // Ceres solver options for the video-aware SolveCeres path.
+  // Defaults match the previously hardcoded values.
+  ceres::Solver::Options solver_options = []() {
+    ceres::Solver::Options opts;
+    opts.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
+    opts.max_num_iterations = 100;
+    return opts;
+  }();
 
   // Use Ceres solver with per-pair Huber/Cauchy loss instead of L1+IRLS.
   // Mutually exclusive with use_gravity.

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -5,6 +5,7 @@
 #include "colmap/math/random.h"
 #include "colmap/optim/least_absolute_deviations.h"
 
+#include <algorithm>
 #include <limits>
 
 #include <Eigen/CholmodSupport>
@@ -26,6 +27,33 @@ bool IsTrackingPair(const CorrespondenceGraph::ImagePair& image_pair) {
 }
 
 namespace {
+
+template <typename IdT>
+std::vector<IdT> LegacyPyglomapMapOrder(std::vector<IdT> ids) {
+  std::sort(ids.begin(), ids.end());
+  std::unordered_map<IdT, char> legacy_map;
+  legacy_map.reserve(ids.size());
+  for (const IdT id : ids) {
+    legacy_map.emplace(id, 0);
+  }
+
+  std::vector<IdT> ordered_ids;
+  ordered_ids.reserve(ids.size());
+  for (const auto& [id, _] : legacy_map) {
+    ordered_ids.push_back(id);
+  }
+  return ordered_ids;
+}
+
+std::vector<image_pair_t> LegacyOrderedValidPairIds(
+    const PoseGraph& pose_graph) {
+  std::vector<image_pair_t> pair_ids;
+  pair_ids.reserve(pose_graph.NumEdges());
+  for (const auto& [pair_id, edge] : pose_graph.ValidEdges()) {
+    pair_ids.push_back(pair_id);
+  }
+  return LegacyPyglomapMapOrder(std::move(pair_ids));
+}
 
 // Computes the 1-DOF residual for gravity-aligned rotation constraints.
 // Returns (angle_2 - angle_1) - angle_12, wrapped to [-π, π] with jitter
@@ -129,6 +157,27 @@ size_t RotationAveragingProblem::AllocateParameters(
   camera_id_to_param_idx_.reserve(reconstruction.NumCameras());
   estimated_rotations_.resize(6 * reconstruction.NumImages());
 
+  std::vector<image_t> ordered_active_image_ids;
+  ordered_active_image_ids.reserve(image_id_to_frame_id_.size());
+  for (const auto& [image_id, frame_id] : image_id_to_frame_id_) {
+    if (active_frame_ids_.count(frame_id)) {
+      ordered_active_image_ids.push_back(image_id);
+    }
+  }
+  ordered_active_image_ids =
+      LegacyPyglomapMapOrder(std::move(ordered_active_image_ids));
+
+  std::vector<frame_t> ordered_active_frame_ids;
+  ordered_active_frame_ids.reserve(active_frame_ids_.size());
+  std::unordered_set<frame_t> seen_frame_ids;
+  seen_frame_ids.reserve(active_frame_ids_.size());
+  for (const image_t image_id : ordered_active_image_ids) {
+    const frame_t frame_id = image_id_to_frame_id_.at(image_id);
+    if (seen_frame_ids.emplace(frame_id).second) {
+      ordered_active_frame_ids.push_back(frame_id);
+    }
+  }
+
   // Identify cameras that need cam_from_rig estimation
   // (non-reference cameras without calibrated extrinsics).
   std::unordered_map<camera_t, Eigen::AngleAxisd> cam_from_rig_rotations;
@@ -153,7 +202,7 @@ size_t RotationAveragingProblem::AllocateParameters(
   }
 
   // Cache camera_id -> frame_id mapping for UpdateState cam_from_rig averaging.
-  for (const frame_t frame_id : active_frame_ids_) {
+  for (const frame_t frame_id : ordered_active_frame_ids) {
     const auto& frame = reconstruction.Frame(frame_id);
     for (const auto& data_id : frame.ImageIds()) {
       const auto it = camera_id_to_param_idx_.find(
@@ -166,7 +215,7 @@ size_t RotationAveragingProblem::AllocateParameters(
 
   // Allocate frame parameters and cache frame info.
   size_t num_params = 0;
-  for (const frame_t frame_id : active_frame_ids_) {
+  for (const frame_t frame_id : ordered_active_frame_ids) {
     const auto& frame = reconstruction.Frame(frame_id);
     frame_id_to_param_idx_[frame_id] = num_params;
 
@@ -224,7 +273,7 @@ size_t RotationAveragingProblem::AllocateParameters(
 
   // If no gravity-aligned frame found, use first active frame as fixed.
   if (fixed_frame_id_ == kInvalidFrameId) {
-    for (const frame_t frame_id : active_frame_ids_) {
+    for (const frame_t frame_id : ordered_active_frame_ids) {
       const auto& frame = reconstruction.Frame(frame_id);
       fixed_frame_id_ = frame_id;
       // Use identity rotation if frame doesn't have a pose yet.
@@ -247,7 +296,8 @@ void RotationAveragingProblem::BuildPairConstraints(
     const PoseGraph& pose_graph, const Reconstruction& reconstruction) {
   int gravity_aligned_count = 0;
 
-  for (const auto& [pair_id, edge] : pose_graph.ValidEdges()) {
+  for (const image_pair_t pair_id : LegacyOrderedValidPairIds(pose_graph)) {
+    const auto& edge = pose_graph.Edges().at(pair_id);
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
 
     // Skip LC-dominated pairs.
@@ -368,7 +418,7 @@ void RotationAveragingProblem::BuildConstraintMatrix(
 
   size_t curr_row = 0;
 
-  for (const auto& [pair_id, edge] : pose_graph.ValidEdges()) {
+  for (const image_pair_t pair_id : LegacyOrderedValidPairIds(pose_graph)) {
     if (pair_constraints_.find(pair_id) == pair_constraints_.end()) continue;
 
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
@@ -888,7 +938,14 @@ bool RotationAveragingSolver::SolveCeres(RotationAveragingProblem& problem) {
   const frame_t fixed_frame_id = problem.FixedFrameId();
 
   // Add parameter blocks for all active frames (3-DOF angle-axis).
-  for (const auto& [frame_id, param_idx] : frame_id_to_param_idx) {
+  std::vector<std::pair<frame_t, int>> ordered_frame_params(
+      frame_id_to_param_idx.begin(), frame_id_to_param_idx.end());
+  std::sort(ordered_frame_params.begin(),
+            ordered_frame_params.end(),
+            [](const auto& lhs, const auto& rhs) {
+              return lhs.second < rhs.second;
+            });
+  for (const auto& [frame_id, param_idx] : ordered_frame_params) {
     double* param = estimated_rotations.data() + param_idx;
     ceres_problem.AddParameterBlock(param, 3);
     if (frame_id == fixed_frame_id) {
@@ -897,7 +954,14 @@ bool RotationAveragingSolver::SolveCeres(RotationAveragingProblem& problem) {
   }
 
   // Add residual blocks for each pair_constraint.
+  std::vector<image_pair_t> ordered_pair_ids;
+  ordered_pair_ids.reserve(problem.PairConstraints().size());
   for (const auto& [pair_id, constraint] : problem.PairConstraints()) {
+    ordered_pair_ids.push_back(pair_id);
+  }
+  ordered_pair_ids = LegacyPyglomapMapOrder(std::move(ordered_pair_ids));
+  for (const image_pair_t pair_id : ordered_pair_ids) {
+    const auto& constraint = problem.PairConstraints().at(pair_id);
     const auto* full_3dof =
         std::get_if<RotationAveragingProblem::Full3DOF>(&constraint.constraint);
     if (full_3dof == nullptr) {

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -935,9 +935,7 @@ bool RotationAveragingSolver::SolveCeres(RotationAveragingProblem& problem) {
         estimated_rotations.data() + idx_it2->second);
   }
 
-  ceres::Solver::Options solver_options;
-  solver_options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
-  solver_options.max_num_iterations = 100;
+  ceres::Solver::Options solver_options = options_.solver_options;
   solver_options.minimizer_progress_to_stdout = VLOG_IS_ON(2);
   ceres::Solver::Summary summary;
   ceres::Solve(solver_options, &ceres_problem, &summary);

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -401,7 +401,6 @@ LcMstFixture BuildLcMstFixture() {
   auto& cg_pair = data.correspondence_graph.MutableImagePairs()[pair_12];
   cg_pair.image_id1 = 1;
   cg_pair.image_id2 = 2;
-  cg_pair.pair_id = pair_12;
   cg_pair.inliers.resize(100);
   std::iota(cg_pair.inliers.begin(), cg_pair.inliers.end(), 0);
   // 80 of 100 inliers are LC -> dominated.
@@ -418,7 +417,6 @@ LcMstFixture BuildLcMstFixture() {
     auto& other = data.correspondence_graph.MutableImagePairs()[pair_id];
     other.image_id1 = a;
     other.image_id2 = b;
-    other.pair_id = pair_id;
     other.inliers.resize(10);
     std::iota(other.inliers.begin(), other.inliers.end(), 0);
     other.are_lc.assign(10, false);
@@ -445,12 +443,12 @@ TEST(RotationAveraging, Gate_LcPenaltyMst_Off_KeepsLcDominantEdge) {
   LcMstFixture data = BuildLcMstFixture();
 
   std::unordered_map<image_t, image_t> parents;
-  const image_t root = ComputeMaximumPoseGraphSpanningTree(
-      data.pose_graph,
-      data.image_ids,
-      parents,
-      /*prioritize_tracking=*/false,
-      &data.correspondence_graph);
+  const image_t root =
+      ComputeMaximumPoseGraphSpanningTree(data.pose_graph,
+                                          data.image_ids,
+                                          parents,
+                                          /*prioritize_tracking=*/false,
+                                          &data.correspondence_graph);
 
   // 3 nodes -> 3 entries in the parent map (one is the root self-loop).
   EXPECT_EQ(parents.size(), 3u);
@@ -469,12 +467,12 @@ TEST(RotationAveraging, Gate_LcPenaltyMst_On_RoutesAroundLcEdge) {
   LcMstFixture data = BuildLcMstFixture();
 
   std::unordered_map<image_t, image_t> parents;
-  const image_t root = ComputeMaximumPoseGraphSpanningTree(
-      data.pose_graph,
-      data.image_ids,
-      parents,
-      /*prioritize_tracking=*/true,
-      &data.correspondence_graph);
+  const image_t root =
+      ComputeMaximumPoseGraphSpanningTree(data.pose_graph,
+                                          data.image_ids,
+                                          parents,
+                                          /*prioritize_tracking=*/true,
+                                          &data.correspondence_graph);
 
   // With the LC penalty active, the 1-2 edge's effective weight is
   // 100 - kLCPenalty (=1e9), so the MST must pick the 1-3 + 2-3 path.
@@ -491,8 +489,7 @@ TEST(RotationAveraging, Gate_LcPenaltyMst_On_RoutesAroundLcEdge) {
   EXPECT_TRUE(root == 1 || root == 2 || root == 3);
 }
 
-TEST(RotationAveraging,
-     Gate_LcPenaltyMst_OnWithoutCgFallsBackToVanilla) {
+TEST(RotationAveraging, Gate_LcPenaltyMst_OnWithoutCgFallsBackToVanilla) {
   // With the gate ON but no correspondence graph, the helper should ignore
   // the LC penalty entirely (the second guard in the ``cg_map_ptr`` ternary).
   // Verifies that the gate alone — without a CG — does not silently change
@@ -640,7 +637,8 @@ TEST(RelativeRotationError, SymmetryUnderSwapAndInvert) {
     const Eigen::Vector3d aa1 = QuaternionToAngleAxisVec(q1);
     const Eigen::Vector3d aa2 = QuaternionToAngleAxisVec(q2);
     const Eigen::Vector3d rel_aa = QuaternionToAngleAxisVec(q_rel);
-    const Eigen::Vector3d rel_aa_inv = QuaternionToAngleAxisVec(q_rel.conjugate());
+    const Eigen::Vector3d rel_aa_inv =
+        QuaternionToAngleAxisVec(q_rel.conjugate());
 
     RelativeRotationError functor_orig(rel_aa);
     RelativeRotationError functor_swap(rel_aa_inv);
@@ -656,6 +654,141 @@ TEST(RelativeRotationError, SymmetryUnderSwapAndInvert) {
     EXPECT_LT((residual_orig + residual_swap).norm(), 1e-9)
         << "trial=" << trial;
   }
+}
+
+TEST(RotationAveraging, WithNoiseAndOutliersHalfNorm) {
+  SetPRNGSeed(1);
+
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 2;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 7;
+  synthetic_dataset_options.num_points3D = 100;
+  synthetic_dataset_options.inlier_match_ratio = 0.6;
+  synthetic_dataset_options.prior_gravity = true;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  SyntheticNoiseOptions synthetic_noise_options;
+  synthetic_noise_options.point2D_stddev = 1;
+  synthetic_noise_options.prior_gravity_stddev = 3e-1;
+  auto data =
+      CreateTestData(synthetic_dataset_options, &synthetic_noise_options);
+
+  RotationEstimatorOptions options = CreateRATestOptions(/*use_gravity=*/false);
+  options.weight_type = RotationEstimatorOptions::HALF_NORM;
+
+  Reconstruction reconstruction_copy = data.reconstruction;
+  PoseGraph pose_graph_copy = data.pose_graph;
+  EXPECT_TRUE(RunRotationAveraging(
+      options, pose_graph_copy, reconstruction_copy, data.pose_priors));
+
+  ExpectEqualRotations(data.gt_reconstruction,
+                       reconstruction_copy,
+                       /*max_rotation_error_deg=*/3);
+}
+
+// End-to-end test for use_video_constraints path (Ceres solver with
+// per-pair Huber/Cauchy loss). Uses the LcMstFixture infrastructure to
+// provide a CorrespondenceGraph with tracking + LC annotations.
+TEST(RotationAveraging, VideoConstraints) {
+  SetPRNGSeed(1);
+
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 5;
+  synthetic_dataset_options.num_points3D = 50;
+  synthetic_dataset_options.sensor_from_rig_rotation_stddev = 20.;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  auto data = CreateTestData(synthetic_dataset_options);
+
+  // Build a minimal CorrespondenceGraph with tracking annotations for all
+  // pairs so the Ceres solver can classify them.
+  CorrespondenceGraph correspondence_graph;
+  for (const auto& [image_id, image] : data.reconstruction.Images()) {
+    correspondence_graph.AddImage(image_id, /*num_points=*/0);
+  }
+  for (const auto& [pair_id, edge] : data.pose_graph.Edges()) {
+    auto& cg_pair = correspondence_graph.MutableImagePairs()[pair_id];
+    const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
+    cg_pair.image_id1 = image_id1;
+    cg_pair.image_id2 = image_id2;
+    cg_pair.inliers.resize(edge.num_matches);
+    std::iota(cg_pair.inliers.begin(), cg_pair.inliers.end(), 0);
+    cg_pair.are_lc.assign(edge.num_matches, false);  // all tracking
+  }
+
+  RotationEstimatorOptions options = CreateRATestOptions(/*use_gravity=*/false);
+  options.use_video_constraints = true;
+
+  Reconstruction reconstruction_copy = data.reconstruction;
+  PoseGraph pose_graph_copy = data.pose_graph;
+  EXPECT_TRUE(RunRotationAveraging(options,
+                                   pose_graph_copy,
+                                   reconstruction_copy,
+                                   data.pose_priors,
+                                   /*final_weights=*/nullptr,
+                                   &correspondence_graph));
+
+  ExpectEqualRotations(data.gt_reconstruction,
+                       reconstruction_copy,
+                       /*max_rotation_error_deg=*/1e-2);
+}
+
+// Verify skip_risky_lc_pairs excludes LC-dominated pairs without breaking
+// convergence on a clean synthetic dataset.
+TEST(RotationAveraging, SkipRiskyLcPairs) {
+  SetPRNGSeed(1);
+
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 5;
+  synthetic_dataset_options.num_points3D = 50;
+  synthetic_dataset_options.sensor_from_rig_rotation_stddev = 20.;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  auto data = CreateTestData(synthetic_dataset_options);
+
+  // Build a CorrespondenceGraph. Mark one pair as LC-dominated so
+  // skip_risky_lc_pairs will exclude it. The remaining tracking pairs must
+  // still form a connected graph for the solver to converge.
+  CorrespondenceGraph correspondence_graph;
+  for (const auto& [image_id, image] : data.reconstruction.Images()) {
+    correspondence_graph.AddImage(image_id, /*num_points=*/0);
+  }
+
+  bool first_pair = true;
+  for (const auto& [pair_id, edge] : data.pose_graph.Edges()) {
+    auto& cg_pair = correspondence_graph.MutableImagePairs()[pair_id];
+    const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
+    cg_pair.image_id1 = image_id1;
+    cg_pair.image_id2 = image_id2;
+    cg_pair.inliers.resize(edge.num_matches);
+    std::iota(cg_pair.inliers.begin(), cg_pair.inliers.end(), 0);
+
+    if (first_pair) {
+      // LC-dominated: more than half the inliers are LC.
+      cg_pair.are_lc.assign(edge.num_matches, true);
+      first_pair = false;
+    } else {
+      cg_pair.are_lc.assign(edge.num_matches, false);  // tracking
+    }
+  }
+
+  RotationEstimatorOptions options = CreateRATestOptions(/*use_gravity=*/false);
+  options.skip_risky_lc_pairs = true;
+
+  Reconstruction reconstruction_copy = data.reconstruction;
+  PoseGraph pose_graph_copy = data.pose_graph;
+  EXPECT_TRUE(RunRotationAveraging(options,
+                                   pose_graph_copy,
+                                   reconstruction_copy,
+                                   data.pose_priors,
+                                   /*final_weights=*/nullptr,
+                                   &correspondence_graph));
+
+  ExpectEqualRotations(data.gt_reconstruction,
+                       reconstruction_copy,
+                       /*max_rotation_error_deg=*/1e-2);
 }
 
 }  // namespace

--- a/src/colmap/scene/correspondence_graph.cc
+++ b/src/colmap/scene/correspondence_graph.cc
@@ -127,7 +127,6 @@ void CorrespondenceGraph::AddTwoViewGeometry(
   auto& image_pair = image_pair_it->second;
   image_pair.image_id1 = image_id1;
   image_pair.image_id2 = image_id2;
-  image_pair.pair_id = pair_id;
   image_pair.num_matches =
       static_cast<point2D_t>(two_view_geometry.inlier_matches.size());
 
@@ -216,7 +215,7 @@ void CorrespondenceGraph::AddTwoViewGeometry(
     two_view_geometry.Invert();
   }
 
-  image_pair.two_view_geometry = std::move(two_view_geometry);
+  image_pair_it->second.two_view_geometry = std::move(two_view_geometry);
 }
 
 CorrespondenceGraph::CorrespondenceRange

--- a/src/colmap/scene/correspondence_graph.h
+++ b/src/colmap/scene/correspondence_graph.h
@@ -66,24 +66,19 @@ class CorrespondenceGraph {
   };
 
   // Two-view image pair with geometry, matches, and metadata.
-  // Extends colmap core with image IDs, validity flags,
-  // loop closure markers, covariance, and full match data.
+  // Extends colmap core with image IDs, validity flags, loop closure markers,
+  // and full match data.
   struct ImagePair {
     // Default constructor.
     ImagePair() = default;
 
-    // Constructor from image IDs. Sets pair_id via ImagePairToPairId.
+    // Constructor from image IDs.
     ImagePair(image_t img_id1, image_t img_id2)
-        : image_id1(img_id1),
-          image_id2(img_id2),
-          pair_id(ImagePairToPairId(img_id1, img_id2)) {}
+        : image_id1(img_id1), image_id2(img_id2) {}
 
     // Image identifiers.
     image_t image_id1 = kInvalidImageId;
     image_t image_id2 = kInvalidImageId;
-
-    // Unique pair identifier derived from image_id1 and image_id2.
-    image_pair_t pair_id = 0;
 
     // Indicator whether the image pair is valid.
     bool is_valid = true;
@@ -93,13 +88,6 @@ class CorrespondenceGraph {
 
     // The two-view geometry of the image pair without matches.
     struct TwoViewGeometry two_view_geometry;
-
-    // Weight is the initial inlier rate.
-    double weight = 0.0;
-
-    // Covariance matrix (3x3) for the relative translation.
-    // Initialized to zero matrix to indicate it hasn't been computed yet.
-    Eigen::Matrix3d cov_t = Eigen::Matrix3d::Zero();
 
     // All matches between the two images (not just inliers).
     // First column is feature index in image1, second column in image2.

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -41,11 +41,17 @@ Image::Image()
       num_points3D_(0) {}
 
 Image::Image(const Image& other)
-    : is_inlier(other.is_inlier),
+    // Public extension fields (declaration order).
+    : depth_priors(other.depth_priors),
+      depth_prior_stddevs(other.depth_prior_stddevs),
+      depth_prior_validity(other.depth_prior_validity),
+      is_inlier(other.is_inlier),
+      is_depth_outlier(other.is_depth_outlier),
       is_track_anchor(other.is_track_anchor),
       angular_stddevs(other.angular_stddevs),
       features(other.features),
       features_undist(other.features_undist),
+      // Private fields (in declaration order).
       name_(other.Name()),
       camera_ptr_(other.HasCameraPtr() ? other.CameraPtr() : nullptr),
       frame_ptr_(other.HasFramePtr() ? other.FramePtr() : nullptr),
@@ -75,7 +81,11 @@ Image& Image::operator=(const Image& other) {
     num_points3D_ = other.NumPoints3D();
     points2D_ = other.Points2D();
     pixel_cholesky_xy_ = other.PixelCholeskyXY();
+    depth_priors = other.depth_priors;
+    depth_prior_stddevs = other.depth_prior_stddevs;
+    depth_prior_validity = other.depth_prior_validity;
     is_inlier = other.is_inlier;
+    is_depth_outlier = other.is_depth_outlier;
     is_track_anchor = other.is_track_anchor;
     angular_stddevs = other.angular_stddevs;
     features = other.features;

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -154,13 +154,19 @@ class Image {
   inline bool operator==(const Image& other) const;
   inline bool operator!=(const Image& other) const;
 
+  // Per-feature monocular depth priors.
+  std::vector<double> depth_priors;
+  std::vector<double> depth_prior_stddevs;
+  std::vector<bool> depth_prior_validity;
+
   // Per-feature inlier flag for GP loss routing.
   std::vector<bool> is_inlier;
+  // Per-feature depth outlier flag for GP loss routing.
+  std::vector<bool> is_depth_outlier;
   // Per-feature track-anchor flag for GP loss routing.
   std::vector<bool> is_track_anchor;
   // Per-feature angular standard deviations (sigma_x, sigma_y) in radians.
   std::vector<Eigen::Vector2d> angular_stddevs;
-
   // Raw 2D keypoints (xy), separate from points2D_.
   std::vector<Eigen::Vector2d> features;
   // Undistorted 3D rays per feature.
@@ -317,10 +323,12 @@ std::vector<struct Point2D>& Image::Points2D() { return points2D_; }
 
 bool Image::operator==(const Image& other) const {
   // Identity-equality (NOT bit-equality across pipeline state). Mutable
-  // per-pipeline-phase fields (is_inlier, features_undist, ...) are
-  // intentionally NOT compared — two Images at different pipeline stages
-  // with the same identity should compare equal. pixel_cholesky_xy_ is
-  // included because it's a per-feature immutable property.
+  // per-pipeline-phase fields (depth_priors, is_inlier, cam_from_world,
+  // features_undist, ...) are intentionally NOT compared — two Images
+  // at different pipeline stages with the same identity should compare
+  // equal. ``pixel_cholesky_xy_`` is included because it's a per-feature
+  // immutable property of the image (this field surfaced a copy-ctor
+  // field-drop regression — keep it in the comparison).
   const bool result = image_id_ == other.image_id_ &&          //
                       camera_id_ == other.camera_id_ &&        //
                       frame_id_ == other.frame_id_ &&          //

--- a/src/colmap/scene/pose_graph_test.cc
+++ b/src/colmap/scene/pose_graph_test.cc
@@ -351,6 +351,44 @@ TEST(PoseGraph, ComputeLargestConnectedFrameComponentEmpty) {
   EXPECT_TRUE(result.empty());
 }
 
+TEST(PoseGraph, ComputeLargestConnectedFrameComponentFilterUnregistered) {
+  SyntheticDatasetOptions synthetic_options;
+  synthetic_options.num_rigs = 5;
+  synthetic_options.num_cameras_per_rig = 1;
+  synthetic_options.num_frames_per_rig = 1;
+  synthetic_options.num_points3D = 10;
+  Reconstruction reconstruction;
+  SynthesizeDataset(synthetic_options, &reconstruction);
+
+  const auto reg_image_ids = reconstruction.RegImageIds();
+  ASSERT_EQ(reg_image_ids.size(), 5);
+
+  // Build a fully connected pose graph over all 5 images.
+  PoseGraph pose_graph;
+  pose_graph.AddEdge(reg_image_ids[0], reg_image_ids[1], SynthesizeEdge());
+  pose_graph.AddEdge(reg_image_ids[1], reg_image_ids[2], SynthesizeEdge());
+  pose_graph.AddEdge(reg_image_ids[2], reg_image_ids[3], SynthesizeEdge());
+  pose_graph.AddEdge(reg_image_ids[3], reg_image_ids[4], SynthesizeEdge());
+
+  // Without filtering, all 5 frames should be in the component.
+  const auto unfiltered = pose_graph.ComputeLargestConnectedFrameComponent(
+      reconstruction, /*filter_unregistered=*/false);
+  EXPECT_EQ(unfiltered.size(), 5);
+
+  // Unregister one frame by resetting its pose.
+  const frame_t frame_to_reset =
+      reconstruction.Image(reg_image_ids[2]).FrameId();
+  reconstruction.Frame(frame_to_reset).ResetPose();
+
+  // With filter_unregistered=true, pairs touching the unregistered frame are
+  // skipped, splitting the graph into two components {0,1} and {3,4}.
+  const auto filtered = pose_graph.ComputeLargestConnectedFrameComponent(
+      reconstruction, /*filter_unregistered=*/true);
+  EXPECT_LT(filtered.size(), unfiltered.size());
+  EXPECT_EQ(filtered.size(), 2);
+  EXPECT_EQ(filtered.count(frame_to_reset), 0);
+}
+
 TEST(PoseGraph, InvalidatePairsOutsideActiveImageIds) {
   PoseGraph pose_graph;
   pose_graph.AddEdge(1, 2, SynthesizeEdge());

--- a/src/colmap/scene/track.h
+++ b/src/colmap/scene/track.h
@@ -44,6 +44,11 @@ struct TrackElement {
   image_t image_id;
   // The point in the image that the track element is observed.
   point2D_t point2D_idx;
+  // Per-observation global-positioning routing metadata. These flags describe
+  // this track observation, not the underlying image keypoint globally.
+  bool is_inlier = false;
+  bool is_depth_outlier = false;
+  bool is_track_anchor = false;
 
   inline bool operator==(const TrackElement& other) const;
   inline bool operator!=(const TrackElement& other) const;
@@ -101,6 +106,8 @@ std::ostream& operator<<(std::ostream& stream, const Track& track);
 ////////////////////////////////////////////////////////////////////////////////
 
 bool TrackElement::operator==(const TrackElement& other) const {
+  // Observation identity only. GP-routing flags are mutable annotations and
+  // intentionally excluded from track equality.
   return image_id == other.image_id && point2D_idx == other.point2D_idx;
 }
 

--- a/src/colmap/scene/track_test.cc
+++ b/src/colmap/scene/track_test.cc
@@ -38,6 +38,9 @@ TEST(TrackElement, Empty) {
   TrackElement track_el;
   EXPECT_EQ(track_el.image_id, kInvalidImageId);
   EXPECT_EQ(track_el.point2D_idx, kInvalidPoint2DIdx);
+  EXPECT_FALSE(track_el.is_inlier);
+  EXPECT_FALSE(track_el.is_depth_outlier);
+  EXPECT_FALSE(track_el.is_track_anchor);
 }
 
 TEST(TrackElement, Equals) {
@@ -47,6 +50,10 @@ TEST(TrackElement, Equals) {
   track_el.image_id = 1;
   EXPECT_NE(track_el, other);
   other.image_id = 1;
+  EXPECT_EQ(track_el, other);
+  track_el.is_inlier = true;
+  track_el.is_depth_outlier = true;
+  track_el.is_track_anchor = true;
   EXPECT_EQ(track_el, other);
 }
 

--- a/src/colmap/sfm/global_mapper_test.cc
+++ b/src/colmap/sfm/global_mapper_test.cc
@@ -1,10 +1,22 @@
 #include "colmap/sfm/global_mapper.h"
 
+#include "colmap/feature/types.h"
+#include "colmap/geometry/rigid3.h"
 #include "colmap/scene/database_cache.h"
+#include "colmap/scene/frame.h"
+#include "colmap/scene/image.h"
 #include "colmap/scene/reconstruction_matchers.h"
 #include "colmap/scene/synthetic.h"
+#include "colmap/scene/two_view_geometry.h"
+#include "colmap/sensor/models.h"
+#include "colmap/sensor/rig.h"
 #include "colmap/util/testing.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Core>
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -15,6 +27,61 @@ namespace {
 std::shared_ptr<DatabaseCache> CreateDatabaseCache(const Database& database) {
   DatabaseCache::Options options;
   return DatabaseCache::Create(database, options);
+}
+
+std::shared_ptr<DatabaseCache> CreateThreeViewTrackCache(
+    const point2D_t num_tracks) {
+  auto cache = std::make_shared<DatabaseCache>();
+
+  Camera camera = Camera::CreateFromModelId(
+      /*camera_id=*/1, CameraModelId::kSimplePinhole, 1000.0, 1024, 768);
+  const sensor_t camera_sensor = camera.SensorId();
+  cache->AddCamera(std::move(camera));
+
+  Rig rig;
+  rig.SetRigId(1);
+  rig.AddRefSensor(camera_sensor);
+  cache->AddRig(std::move(rig));
+
+  for (image_t image_id = 1; image_id <= 3; ++image_id) {
+    Image image;
+    image.SetImageId(image_id);
+    image.SetName(std::to_string(image_id) + ".jpg");
+    image.SetCameraId(1);
+    image.SetFrameId(image_id);
+
+    std::vector<Eigen::Vector2d> keypoints;
+    keypoints.reserve(num_tracks);
+    for (point2D_t point2D_idx = 0; point2D_idx < num_tracks; ++point2D_idx) {
+      keypoints.emplace_back(100.0 * point2D_idx, 100.0 * point2D_idx);
+    }
+    image.SetPoints2D(keypoints);
+
+    Frame frame;
+    frame.SetFrameId(image_id);
+    frame.SetRigId(1);
+    frame.AddDataId(image.DataId());
+    frame.SetRigFromWorld(Rigid3d());
+    cache->AddFrame(std::move(frame));
+    cache->AddImage(std::move(image));
+  }
+
+  auto add_image_pair = [&](const image_t image_id1, const image_t image_id2) {
+    TwoViewGeometry two_view_geometry;
+    two_view_geometry.config = TwoViewGeometry::CALIBRATED;
+    two_view_geometry.cam2_from_cam1 = Rigid3d();
+    two_view_geometry.inlier_matches.reserve(num_tracks);
+    for (point2D_t point2D_idx = 0; point2D_idx < num_tracks; ++point2D_idx) {
+      two_view_geometry.inlier_matches.emplace_back(point2D_idx, point2D_idx);
+    }
+    cache->CorrespondenceGraph()->AddTwoViewGeometry(
+        image_id1, image_id2, std::move(two_view_geometry));
+  };
+  add_image_pair(1, 2);
+  add_image_pair(1, 3);
+  add_image_pair(2, 3);
+
+  return cache;
 }
 
 TEST(GlobalMapper, WithoutNoise) {
@@ -150,6 +217,19 @@ TEST(GlobalMapper, WithNoiseAndOutliers) {
                                  /*max_proj_center_error=*/1e-1,
                                  /*max_scale_error=*/std::nullopt,
                                  /*num_obs_tolerance=*/0.02));
+}
+
+TEST(GlobalMapper, EstablishTracksAppliesRequiredTracksPerView) {
+  auto reconstruction = std::make_shared<Reconstruction>();
+  GlobalMapper global_mapper(CreateThreeViewTrackCache(/*num_tracks=*/5));
+  global_mapper.BeginReconstruction(reconstruction);
+
+  GlobalMapperOptions options;
+  options.track_required_tracks_per_view = 1;
+  options.track_min_num_views_per_track = 3;
+
+  global_mapper.EstablishTracks(options);
+  EXPECT_EQ(reconstruction->NumPoints3D(), 2);
 }
 
 }  // namespace

--- a/src/colmap/sfm/image_pair_inliers_test.cc
+++ b/src/colmap/sfm/image_pair_inliers_test.cc
@@ -4,8 +4,10 @@
 #include "colmap/geometry/rigid3.h"
 #include "colmap/scene/camera.h"
 #include "colmap/scene/correspondence_graph.h"
+#include "colmap/scene/frame.h"
 #include "colmap/scene/image.h"
 #include "colmap/scene/reconstruction.h"
+#include "colmap/scene/rig.h"
 #include "colmap/scene/two_view_geometry.h"
 #include "colmap/sensor/models.h"
 #include "colmap/util/types.h"
@@ -57,7 +59,7 @@ TwoViewSetup MakeTwoView(const std::vector<Eigen::Vector3d>& cam1_points,
   img2.SetFrameId(2);
 
   for (const auto& p1 : cam1_points) {
-    Eigen::Vector3d p2 = cam2_from_cam1 * p1;
+    const Eigen::Vector3d p2 = cam2_from_cam1 * p1;
     img1.features_undist.push_back(p1.normalized());
     img2.features_undist.push_back(p2.normalized());
     img1.features.emplace_back(p1.x() / p1.z(), p1.y() / p1.z());
@@ -91,11 +93,11 @@ TwoViewSetup MakeTwoView(const std::vector<Eigen::Vector3d>& cam1_points,
   image_pair.two_view_geometry.cam2_from_cam1 = cam2_from_cam1;
   image_pair.two_view_geometry.E = EssentialMatrixFromPose(cam2_from_cam1);
 
-  const int n = static_cast<int>(cam1_points.size());
-  Eigen::MatrixXi matches(n, 2);
-  for (int k = 0; k < n; ++k) {
-    matches(k, 0) = k;
-    matches(k, 1) = k;
+  const int num_points = static_cast<int>(cam1_points.size());
+  Eigen::MatrixXi matches(num_points, 2);
+  for (int idx = 0; idx < num_points; ++idx) {
+    matches(idx, 0) = idx;
+    matches(idx, 1) = idx;
   }
   image_pair.matches = std::move(matches);
 
@@ -124,22 +126,22 @@ InlierThresholdOptions DefaultOptions() {
 }
 
 TEST(ImagePairInlierCount, AllInliersPassFourGates) {
-  std::vector<Eigen::Vector3d> pts = {
+  const std::vector<Eigen::Vector3d> points = {
       {0.0, 0.0, 5.0},
       {0.0, 0.5, 5.0},
       {0.0, -0.5, 5.0},
       {-0.3, 0.4, 5.0},
       {-0.4, -0.3, 5.0},
   };
-  auto setup = MakeTwoView(pts, DefaultPose());
+  auto setup = MakeTwoView(points, DefaultPose());
   ImagePairsInlierCount(
       setup.corr_graph, setup.reconstruction, DefaultOptions(), true);
   const auto& pair = GetPair(setup);
-  EXPECT_EQ(pair.inliers.size(), pts.size());
+  EXPECT_EQ(pair.inliers.size(), points.size());
 }
 
 TEST(ImagePairInlierCount, EpipolarGateDrops) {
-  std::vector<Eigen::Vector3d> pts = {
+  const std::vector<Eigen::Vector3d> points = {
       {0.0, 0.0, 5.0},
       {0.0, 0.5, 5.0},
       {0.0, -0.5, 5.0},
@@ -147,33 +149,33 @@ TEST(ImagePairInlierCount, EpipolarGateDrops) {
       {-0.4, -0.3, 5.0},
       {0.2, 0.2, 5.0},
   };
-  auto setup = MakeTwoView(pts, DefaultPose());
+  auto setup = MakeTwoView(points, DefaultPose());
 
-  auto& img2 = setup.reconstruction.Image(setup.image_id2);
-  for (int k : {0, 2, 4}) {
-    img2.features_undist[k] += Eigen::Vector3d(0.0, 0.5, 0.0);
-    img2.features_undist[k].normalize();
+  auto& image2 = setup.reconstruction.Image(setup.image_id2);
+  for (const int idx : {0, 2, 4}) {
+    image2.features_undist[idx] += Eigen::Vector3d(0.0, 0.5, 0.0);
+    image2.features_undist[idx].normalize();
   }
   ImagePairsInlierCount(
       setup.corr_graph, setup.reconstruction, DefaultOptions(), true);
   const auto& pair = GetPair(setup);
   EXPECT_EQ(pair.inliers.size(), 3u);
-  for (int k : pair.inliers) {
-    EXPECT_TRUE(k == 1 || k == 3 || k == 5) << "k=" << k;
+  for (const int idx : pair.inliers) {
+    EXPECT_TRUE(idx == 1 || idx == 3 || idx == 5) << "idx=" << idx;
   }
 }
 
 TEST(ImagePairInlierCount, CheiralityGateDrops) {
-  std::vector<Eigen::Vector3d> pts = {
+  const std::vector<Eigen::Vector3d> points = {
       {0.0, 0.0, 5.0},
       {0.0, 0.5, 5.0},
   };
-  auto setup = MakeTwoView(pts, DefaultPose());
+  auto setup = MakeTwoView(points, DefaultPose());
 
-  auto& img1 = setup.reconstruction.Image(setup.image_id1);
-  auto& img2 = setup.reconstruction.Image(setup.image_id2);
-  img1.features_undist[0] = -img1.features_undist[0];
-  img2.features_undist[0] = -img2.features_undist[0];
+  auto& image1 = setup.reconstruction.Image(setup.image_id1);
+  auto& image2 = setup.reconstruction.Image(setup.image_id2);
+  image1.features_undist[0] = -image1.features_undist[0];
+  image2.features_undist[0] = -image2.features_undist[0];
 
   ImagePairsInlierCount(
       setup.corr_graph, setup.reconstruction, DefaultOptions(), true);
@@ -183,11 +185,11 @@ TEST(ImagePairInlierCount, CheiralityGateDrops) {
 }
 
 TEST(ImagePairInlierCount, EpipoleGateDrops) {
-  std::vector<Eigen::Vector3d> pts = {
+  const std::vector<Eigen::Vector3d> points = {
       {100.0, 0.0, 1.0},
       {0.0, 0.5, 5.0},
   };
-  auto setup = MakeTwoView(pts, DefaultPose());
+  auto setup = MakeTwoView(points, DefaultPose());
 
   InlierThresholdOptions options = DefaultOptions();
   options.min_angle_from_epipole = 30.0;

--- a/src/colmap/sfm/image_pair_inliers_test.cc
+++ b/src/colmap/sfm/image_pair_inliers_test.cc
@@ -4,10 +4,8 @@
 #include "colmap/geometry/rigid3.h"
 #include "colmap/scene/camera.h"
 #include "colmap/scene/correspondence_graph.h"
-#include "colmap/scene/frame.h"
 #include "colmap/scene/image.h"
 #include "colmap/scene/reconstruction.h"
-#include "colmap/scene/rig.h"
 #include "colmap/scene/two_view_geometry.h"
 #include "colmap/sensor/models.h"
 #include "colmap/util/types.h"
@@ -35,11 +33,9 @@ TwoViewSetup MakeTwoView(const std::vector<Eigen::Vector3d>& cam1_points,
   TwoViewSetup setup;
   setup.cam2_from_cam1 = cam2_from_cam1;
 
-  Camera cam = Camera::CreateFromModelId(setup.camera_id,
-                                         CameraModelId::kSimplePinhole,
-                                         /*focal_length=*/1.0,
-                                         /*width=*/100,
-                                         /*height=*/100);
+  Camera cam = Camera::CreateFromModelId(
+      setup.camera_id, CameraModelId::kSimplePinhole,
+      /*focal_length=*/1.0, /*width=*/100, /*height=*/100);
   setup.reconstruction.AddCamera(std::move(cam));
 
   const rig_t rig_id = 1;
@@ -59,11 +55,15 @@ TwoViewSetup MakeTwoView(const std::vector<Eigen::Vector3d>& cam1_points,
   img2.SetFrameId(2);
 
   for (const auto& p1 : cam1_points) {
-    const Eigen::Vector3d p2 = cam2_from_cam1 * p1;
+    Eigen::Vector3d p2 = cam2_from_cam1 * p1;
     img1.features_undist.push_back(p1.normalized());
     img2.features_undist.push_back(p2.normalized());
     img1.features.emplace_back(p1.x() / p1.z(), p1.y() / p1.z());
     img2.features.emplace_back(p2.x() / p2.z(), p2.y() / p2.z());
+    img1.depth_prior_validity.push_back(true);
+    img2.depth_prior_validity.push_back(true);
+    img1.depth_priors.push_back(p1.z());
+    img2.depth_priors.push_back(p2.z());
   }
 
   Frame frame1;
@@ -89,11 +89,11 @@ TwoViewSetup MakeTwoView(const std::vector<Eigen::Vector3d>& cam1_points,
   image_pair.two_view_geometry.cam2_from_cam1 = cam2_from_cam1;
   image_pair.two_view_geometry.E = EssentialMatrixFromPose(cam2_from_cam1);
 
-  const int num_points = static_cast<int>(cam1_points.size());
-  Eigen::MatrixXi matches(num_points, 2);
-  for (int idx = 0; idx < num_points; ++idx) {
-    matches(idx, 0) = idx;
-    matches(idx, 1) = idx;
+  const int n = static_cast<int>(cam1_points.size());
+  Eigen::MatrixXi matches(n, 2);
+  for (int k = 0; k < n; ++k) {
+    matches(k, 0) = k;
+    matches(k, 1) = k;
   }
   image_pair.matches = std::move(matches);
 
@@ -122,55 +122,52 @@ InlierThresholdOptions DefaultOptions() {
 }
 
 TEST(ImagePairInlierCount, AllInliersPassFourGates) {
-  const std::vector<Eigen::Vector3d> points = {
+  std::vector<Eigen::Vector3d> pts = {
       {0.0, 0.0, 5.0},
       {0.0, 0.5, 5.0},
       {0.0, -0.5, 5.0},
       {-0.3, 0.4, 5.0},
       {-0.4, -0.3, 5.0},
   };
-  auto setup = MakeTwoView(points, DefaultPose());
+  auto setup = MakeTwoView(pts, DefaultPose());
   ImagePairsInlierCount(
       setup.corr_graph, setup.reconstruction, DefaultOptions(), true);
-  EXPECT_EQ(GetPair(setup).inliers.size(), points.size());
+  const auto& pair = GetPair(setup);
+  EXPECT_EQ(pair.inliers.size(), pts.size());
 }
 
 TEST(ImagePairInlierCount, EpipolarGateDrops) {
-  const std::vector<Eigen::Vector3d> points = {
-      {0.0, 0.0, 5.0},
-      {0.0, 0.5, 5.0},
-      {0.0, -0.5, 5.0},
-      {-0.3, 0.4, 5.0},
-      {-0.4, -0.3, 5.0},
-      {0.2, 0.2, 5.0},
+  std::vector<Eigen::Vector3d> pts = {
+      {0.0, 0.0, 5.0},  {0.0, 0.5, 5.0},  {0.0, -0.5, 5.0},
+      {-0.3, 0.4, 5.0},  {-0.4, -0.3, 5.0},  {0.2, 0.2, 5.0},
   };
-  auto setup = MakeTwoView(points, DefaultPose());
+  auto setup = MakeTwoView(pts, DefaultPose());
 
-  auto& image2 = setup.reconstruction.Image(setup.image_id2);
-  for (const int idx : {0, 2, 4}) {
-    image2.features_undist[idx] += Eigen::Vector3d(0.0, 0.5, 0.0);
-    image2.features_undist[idx].normalize();
+  auto& img2 = setup.reconstruction.Image(setup.image_id2);
+  for (int k : {0, 2, 4}) {
+    img2.features_undist[k] += Eigen::Vector3d(0.0, 0.5, 0.0);
+    img2.features_undist[k].normalize();
   }
   ImagePairsInlierCount(
       setup.corr_graph, setup.reconstruction, DefaultOptions(), true);
   const auto& pair = GetPair(setup);
   EXPECT_EQ(pair.inliers.size(), 3u);
-  for (const int idx : pair.inliers) {
-    EXPECT_TRUE(idx == 1 || idx == 3 || idx == 5) << "idx=" << idx;
+  for (int k : pair.inliers) {
+    EXPECT_TRUE(k == 1 || k == 3 || k == 5) << "k=" << k;
   }
 }
 
 TEST(ImagePairInlierCount, CheiralityGateDrops) {
-  const std::vector<Eigen::Vector3d> points = {
+  std::vector<Eigen::Vector3d> pts = {
       {0.0, 0.0, 5.0},
       {0.0, 0.5, 5.0},
   };
-  auto setup = MakeTwoView(points, DefaultPose());
+  auto setup = MakeTwoView(pts, DefaultPose());
 
-  auto& image1 = setup.reconstruction.Image(setup.image_id1);
-  auto& image2 = setup.reconstruction.Image(setup.image_id2);
-  image1.features_undist[0] = -image1.features_undist[0];
-  image2.features_undist[0] = -image2.features_undist[0];
+  auto& img1 = setup.reconstruction.Image(setup.image_id1);
+  auto& img2 = setup.reconstruction.Image(setup.image_id2);
+  img1.features_undist[0] = -img1.features_undist[0];
+  img2.features_undist[0] = -img2.features_undist[0];
 
   ImagePairsInlierCount(
       setup.corr_graph, setup.reconstruction, DefaultOptions(), true);
@@ -180,16 +177,17 @@ TEST(ImagePairInlierCount, CheiralityGateDrops) {
 }
 
 TEST(ImagePairInlierCount, EpipoleGateDrops) {
-  const std::vector<Eigen::Vector3d> points = {
+  std::vector<Eigen::Vector3d> pts = {
       {100.0, 0.0, 1.0},
       {0.0, 0.5, 5.0},
   };
-  auto setup = MakeTwoView(points, DefaultPose());
+  auto setup = MakeTwoView(pts, DefaultPose());
 
   InlierThresholdOptions options = DefaultOptions();
   options.min_angle_from_epipole = 30.0;
 
-  ImagePairsInlierCount(setup.corr_graph, setup.reconstruction, options, true);
+  ImagePairsInlierCount(
+      setup.corr_graph, setup.reconstruction, options, true);
   const auto& pair = GetPair(setup);
   EXPECT_EQ(pair.inliers.size(), 1u);
   EXPECT_EQ(pair.inliers.front(), 1);

--- a/src/colmap/sfm/track_establishment.cc
+++ b/src/colmap/sfm/track_establishment.cc
@@ -35,6 +35,21 @@ void ValidateLoopClosureImagePairMetadata(
   }
 }
 
+bool HasValidDepthPrior(
+    const TrackElement& observation,
+    const std::unordered_map<image_t, std::vector<double>>& depth_priors,
+    const std::unordered_map<image_t, std::vector<bool>>&
+        depth_prior_validity) {
+  const auto valid_it = depth_prior_validity.find(observation.image_id);
+  const auto prior_it = depth_priors.find(observation.image_id);
+  return valid_it != depth_prior_validity.end() &&
+         prior_it != depth_priors.end() &&
+         observation.point2D_idx < valid_it->second.size() &&
+         valid_it->second[observation.point2D_idx] &&
+         observation.point2D_idx < prior_it->second.size() &&
+         prior_it->second[observation.point2D_idx] > 1e-6;
+}
+
 }  // namespace
 
 MatchPredicate MakeLoopClosureMatchPredicate(
@@ -320,6 +335,8 @@ void AppendLoopClosureObservations(
 std::unordered_map<point3D_t, Point3D> FilterTracksForProblem(
     const TrackProblemFilterOptions& options,
     const std::unordered_set<image_t>& registered_image_ids,
+    const std::unordered_map<image_t, std::vector<double>>& depth_priors,
+    const std::unordered_map<image_t, std::vector<bool>>& depth_prior_validity,
     const std::unordered_map<point3D_t, Point3D>& tracks_full) {
   // Track admission is based on regular observations only. LC observations may
   // augment an admitted track, but they must not make a one-view regular track
@@ -350,18 +367,37 @@ std::unordered_map<point3D_t, Point3D> FilterTracksForProblem(
 
     // Restrict to selection domain + lc-elements that fall in the
     // selection domain.
+    std::unordered_set<image_t> distinct_image_ids;
     Point3D candidate;
     for (const auto& el : src.track.Elements()) {
       if (registered_image_id_set.count(el.image_id) == 0) continue;
       candidate.track.AddElement(el);
+      distinct_image_ids.insert(el.image_id);
     }
     for (const auto& lc_el : src.track.lc_elements) {
       if (registered_image_id_set.count(lc_el.image_id) == 0) continue;
       candidate.track.lc_elements.emplace_back(lc_el);
+      distinct_image_ids.insert(lc_el.image_id);
     }
     if (candidate.track.Length() <
         static_cast<size_t>(options.min_num_views_per_track)) {
       continue;
+    }
+    if (options.two_view_depth_gate && distinct_image_ids.size() == 2) {
+      bool depth_ok = true;
+      for (const auto& el : candidate.track.Elements()) {
+        if (!HasValidDepthPrior(el, depth_priors, depth_prior_validity)) {
+          depth_ok = false;
+          break;
+        }
+      }
+      for (const auto& el : candidate.track.lc_elements) {
+        if (!HasValidDepthPrior(el, depth_priors, depth_prior_validity)) {
+          depth_ok = false;
+          break;
+        }
+      }
+      if (!depth_ok) continue;
     }
 
     selected.emplace(track_id, candidate);

--- a/src/colmap/sfm/track_establishment.h
+++ b/src/colmap/sfm/track_establishment.h
@@ -65,13 +65,15 @@ void AppendLoopClosureObservations(
 struct TrackProblemFilterOptions {
   int min_num_views_per_track = 3;
   int max_num_views_per_track = std::numeric_limits<int>::max();
+  bool two_view_depth_gate = false;
 };
 
-// Filter tracks for the optimization problem. LC observations may augment an
-// admitted regular track, but do not satisfy the regular-view admission gate.
+// Filter tracks for the optimization problem with optional 2-view depth gate.
 std::unordered_map<point3D_t, Point3D> FilterTracksForProblem(
     const TrackProblemFilterOptions& options,
     const std::unordered_set<image_t>& registered_image_ids,
+    const std::unordered_map<image_t, std::vector<double>>& depth_priors,
+    const std::unordered_map<image_t, std::vector<bool>>& depth_prior_validity,
     const std::unordered_map<point3D_t, Point3D>& tracks_full);
 
 }  // namespace colmap

--- a/src/colmap/sfm/track_establishment_test.cc
+++ b/src/colmap/sfm/track_establishment_test.cc
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -179,14 +180,24 @@ TEST(TrackEstablishment, EmptyInputReturnsEmpty) {
 }
 
 // ============================================================================
-// FindTracksForProblem (greedy subsample + 2-view depth gate)
+// FindTracksForProblem (problem-track filter + 2-view depth gate)
 // ============================================================================
 
-// Build an Image with N features.
-Image MakeImage(image_t image_id, int num_features) {
+// Build an Image with N features and (optionally) all-valid depth
+// priors. Each prior is set to (idx + 1) so they are strictly > 1e-6.
+Image MakeImage(image_t image_id,
+                int num_features,
+                bool with_valid_depths = true) {
   Image image;
   image.SetImageId(image_id);
   image.features.assign(num_features, Eigen::Vector2d::Zero());
+  if (with_valid_depths) {
+    image.depth_priors.assign(num_features, 1.0);
+    image.depth_prior_validity.assign(num_features, true);
+  } else {
+    image.depth_priors.assign(num_features, 0.0);
+    image.depth_prior_validity.assign(num_features, false);
+  }
   return image;
 }
 
@@ -201,19 +212,39 @@ Point3D MakePoint3DFromElements(
   return p;
 }
 
-// Collect image ids from a filtered-image test fixture.
-std::unordered_set<image_t> MakeImageIds(
-    const std::unordered_map<image_t, Image>& images) {
-  std::unordered_set<image_t> ids;
-  for (const auto& [image_id, image] : images) {
-    ids.insert(image_id);
+Point3D MakePoint3DFromElementsAndLC(
+    const std::vector<std::pair<image_t, point2D_t>>& elements,
+    const std::vector<std::pair<image_t, point2D_t>>& lc_elements) {
+  Point3D p = MakePoint3DFromElements(elements);
+  for (const auto& [image_id, point2D_idx] : lc_elements) {
+    p.track.lc_elements.emplace_back(image_id, point2D_idx);
   }
-  return ids;
+  return p;
+}
+
+// Project an ``images`` test fixture into the three dict inputs consumed by
+// FilterTracksForProblem: registered_image_ids, depth_priors, and
+// depth_prior_validity.
+struct ProblemFilterInputs {
+  std::unordered_set<image_t> registered_image_ids;
+  std::unordered_map<image_t, std::vector<double>> depth_priors;
+  std::unordered_map<image_t, std::vector<bool>> depth_prior_validity;
+};
+
+ProblemFilterInputs MakeProblemFilterInputs(
+    const std::unordered_map<image_t, Image>& images) {
+  ProblemFilterInputs inputs;
+  for (const auto& [image_id, image] : images) {
+    inputs.registered_image_ids.insert(image_id);
+    inputs.depth_priors.emplace(image_id, image.depth_priors);
+    inputs.depth_prior_validity.emplace(image_id, image.depth_prior_validity);
+  }
+  return inputs;
 }
 
 // LengthFilter: with ``min_num_views_per_track=10`` every track here is too
-// short, so FilterTracksForProblem returns empty. Loosening to 2 surfaces every
-// input track.
+// short, so FilterTracksForProblem returns empty. Loosening to 2 surfaces
+// every input track.
 //
 // Drives FilterTracksForProblem.
 TEST(FindTracksForProblem, LengthFilter) {
@@ -227,13 +258,17 @@ TEST(FindTracksForProblem, LengthFilter) {
     tracks_full.emplace(f, MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
   }
 
-  const auto reg_ids = MakeImageIds(images);
+  const auto inputs = MakeProblemFilterInputs(images);
 
   // High-min variant: tracks have length 3, demand 10.
   {
     TrackProblemFilterOptions options;
     options.min_num_views_per_track = 10;
-    const auto selected = FilterTracksForProblem(options, reg_ids, tracks_full);
+    const auto selected = FilterTracksForProblem(options,
+                                                 inputs.registered_image_ids,
+                                                 inputs.depth_priors,
+                                                 inputs.depth_prior_validity,
+                                                 tracks_full);
     EXPECT_EQ(selected.size(), 0u);
     EXPECT_TRUE(selected.empty());
   }
@@ -242,28 +277,32 @@ TEST(FindTracksForProblem, LengthFilter) {
   {
     TrackProblemFilterOptions options;
     options.min_num_views_per_track = 2;
-    const auto selected = FilterTracksForProblem(options, reg_ids, tracks_full);
+    const auto selected = FilterTracksForProblem(options,
+                                                 inputs.registered_image_ids,
+                                                 inputs.depth_priors,
+                                                 inputs.depth_prior_validity,
+                                                 tracks_full);
     EXPECT_EQ(selected.size(), 5u);
   }
 }
 
-TEST(FindTracksForProblem, LcOnlyTrackDoesNotSatisfyMinViews) {
+TEST(FindTracksForProblem, LengthFilterRequiresRegularElements) {
   std::unordered_map<image_t, Image> images;
   images.emplace(1, MakeImage(1, 5));
   images.emplace(2, MakeImage(2, 5));
 
-  Point3D point3D;
-  point3D.track.AddElement(1, 0);
-  point3D.track.lc_elements.emplace_back(2, 0);
-
   std::unordered_map<point3D_t, Point3D> tracks_full;
-  tracks_full.emplace(0, std::move(point3D));
+  tracks_full.emplace(0, MakePoint3DFromElementsAndLC({{1, 0}}, {{2, 0}}));
 
-  const auto reg_ids = MakeImageIds(images);
+  const auto inputs = MakeProblemFilterInputs(images);
 
   TrackProblemFilterOptions options;
   options.min_num_views_per_track = 2;
-  const auto selected = FilterTracksForProblem(options, reg_ids, tracks_full);
+  const auto selected = FilterTracksForProblem(options,
+                                               inputs.registered_image_ids,
+                                               inputs.depth_priors,
+                                               inputs.depth_prior_validity,
+                                               tracks_full);
 
   EXPECT_TRUE(selected.empty());
 }
@@ -283,13 +322,174 @@ TEST(FindTracksForProblem, MaxLengthFilter) {
         f, MakePoint3DFromElements({{1, f}, {2, f}, {3, f}, {4, f}, {5, f}}));
   }
 
-  const auto reg_ids = MakeImageIds(images);
+  const auto inputs = MakeProblemFilterInputs(images);
 
   TrackProblemFilterOptions options;
   options.min_num_views_per_track = 2;
   options.max_num_views_per_track = 4;
-  const auto selected = FilterTracksForProblem(options, reg_ids, tracks_full);
+  const auto selected = FilterTracksForProblem(options,
+                                               inputs.registered_image_ids,
+                                               inputs.depth_priors,
+                                               inputs.depth_prior_validity,
+                                               tracks_full);
   EXPECT_EQ(selected.size(), 0u);
+  EXPECT_TRUE(selected.empty());
+}
+
+// TwoViewDepthGate_Drop: a length-2 track where image 1's feature 0 has no
+// valid depth prior is dropped by the 2-view depth gate.
+//
+// Drives FilterTracksForProblem.
+TEST(FindTracksForProblem, TwoViewDepthGate_Drop) {
+  std::unordered_map<image_t, Image> images;
+  // Image 1: feature 0 has *invalid* depth prior; feature 1+ are valid.
+  Image img1 = MakeImage(1, 3);
+  img1.depth_prior_validity[0] = false;
+  img1.depth_priors[0] = 0.0;
+  images.emplace(1, std::move(img1));
+  images.emplace(2, MakeImage(2, 3));  // all valid
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  // Length-2 track on (1, 2) using feature 0 of each image -> invalid.
+  tracks_full.emplace(0, MakePoint3DFromElements({{1, 0}, {2, 0}}));
+
+  const auto inputs = MakeProblemFilterInputs(images);
+
+  TrackProblemFilterOptions options;
+  options.min_num_views_per_track = 2;
+  options.two_view_depth_gate = true;
+  const auto selected = FilterTracksForProblem(options,
+                                               inputs.registered_image_ids,
+                                               inputs.depth_priors,
+                                               inputs.depth_prior_validity,
+                                               tracks_full);
+  EXPECT_EQ(selected.size(), 0u);
+  EXPECT_TRUE(selected.empty());
+}
+
+// TwoViewDepthGate_Keep: both endpoints have valid depth -> track kept.
+// Also covers the depth-near-zero edge: feature 1 has prior == 1e-6 (gate
+// uses ``<= 1e-6`` so the feature 1 track must drop while feature 0 stays).
+//
+// Drives FilterTracksForProblem.
+TEST(FindTracksForProblem, TwoViewDepthGate_Keep) {
+  std::unordered_map<image_t, Image> images;
+  Image img1 = MakeImage(1, 3);
+  // Feature 0: valid, prior=1.0  -> survives
+  // Feature 1: valid flag true, prior=1e-6 -> caught by ``<= 1e-6`` -> drops
+  img1.depth_priors[1] = 1e-6;
+  images.emplace(1, std::move(img1));
+  images.emplace(2, MakeImage(2, 3));
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  tracks_full.emplace(0, MakePoint3DFromElements({{1, 0}, {2, 0}}));
+  tracks_full.emplace(1, MakePoint3DFromElements({{1, 1}, {2, 1}}));
+
+  const auto inputs = MakeProblemFilterInputs(images);
+
+  TrackProblemFilterOptions options;
+  options.min_num_views_per_track = 2;
+  options.two_view_depth_gate = true;
+  const auto selected = FilterTracksForProblem(options,
+                                               inputs.registered_image_ids,
+                                               inputs.depth_priors,
+                                               inputs.depth_prior_validity,
+                                               tracks_full);
+  EXPECT_EQ(selected.size(), 1u);
+  ASSERT_EQ(selected.count(0), 1u);
+  EXPECT_EQ(selected.count(1), 0u);
+}
+
+// LC-only two-observation tracks have one regular element and one LC element.
+// LC observations may augment admitted tracks but must not satisfy the
+// post-domain regular-observation lower-bound check.
+//
+// Drives FilterTracksForProblem.
+TEST(FindTracksForProblem, LcElementsDoNotSatisfyPostDomainMinViews) {
+  std::unordered_map<image_t, Image> images;
+  images.emplace(1, MakeImage(1, 3));
+  images.emplace(2, MakeImage(2, 3));
+
+  Point3D lc_only;
+  lc_only.track.AddElement(1, 0);
+  lc_only.track.lc_elements.emplace_back(2, 0);
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  tracks_full.emplace(0, std::move(lc_only));
+
+  const auto inputs = MakeProblemFilterInputs(images);
+
+  TrackProblemFilterOptions options;
+  options.min_num_views_per_track = 2;
+  options.two_view_depth_gate = true;
+  const auto selected = FilterTracksForProblem(options,
+                                               inputs.registered_image_ids,
+                                               inputs.depth_priors,
+                                               inputs.depth_prior_validity,
+                                               tracks_full);
+  EXPECT_TRUE(selected.empty());
+}
+
+// A one-regular + one-LC two-view candidate does not satisfy the post-domain
+// regular-observation lower-bound check.
+TEST(FindTracksForProblem, TwoViewDepthGate_DropsInvalidRegularLcCandidate) {
+  std::unordered_map<image_t, Image> images;
+  Image img1 = MakeImage(1, 3);
+  img1.depth_prior_validity[0] = false;
+  img1.depth_priors[0] = 0.0;
+  images.emplace(1, std::move(img1));
+  images.emplace(2, MakeImage(2, 3));
+
+  Point3D point3D;
+  point3D.track.AddElement(1, 0);
+  point3D.track.lc_elements.emplace_back(2, 0);
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  tracks_full.emplace(0, std::move(point3D));
+
+  const auto inputs = MakeProblemFilterInputs(images);
+
+  TrackProblemFilterOptions options;
+  options.min_num_views_per_track = 2;
+  options.two_view_depth_gate = true;
+  const auto selected = FilterTracksForProblem(options,
+                                               inputs.registered_image_ids,
+                                               inputs.depth_priors,
+                                               inputs.depth_prior_validity,
+                                               tracks_full);
+  EXPECT_TRUE(selected.empty());
+}
+
+// Invalid depth on an LC endpoint still matters once the regular track is
+// already admitted. The LC endpoint shares one of the two distinct images so
+// the 2-view depth gate checks it.
+TEST(FindTracksForProblem, TwoViewDepthGate_DropsInvalidLcEndpoint) {
+  std::unordered_map<image_t, Image> images;
+  Image img1 = MakeImage(1, 3);
+  img1.depth_prior_validity[1] = false;
+  img1.depth_priors[1] = 0.0;
+  images.emplace(1, std::move(img1));
+  Image img2 = MakeImage(2, 3);
+  images.emplace(2, std::move(img2));
+
+  Point3D point3D;
+  point3D.track.AddElement(1, 0);
+  point3D.track.AddElement(2, 0);
+  point3D.track.lc_elements.emplace_back(1, 1);
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  tracks_full.emplace(0, std::move(point3D));
+
+  const auto inputs = MakeProblemFilterInputs(images);
+
+  TrackProblemFilterOptions options;
+  options.min_num_views_per_track = 2;
+  options.two_view_depth_gate = true;
+  const auto selected = FilterTracksForProblem(options,
+                                               inputs.registered_image_ids,
+                                               inputs.depth_priors,
+                                               inputs.depth_prior_validity,
+                                               tracks_full);
   EXPECT_TRUE(selected.empty());
 }
 
@@ -302,10 +502,11 @@ TEST(FindTracksForProblem, MaxLengthFilter) {
 // ``ImagePair.are_lc`` to attach LC observations as ``Track::lc_elements``.
 // The post-condition tracks dict is what we assert on.
 
-// Variant of ``AddImagePair`` that also populates ``are_lc``. Each
-// ``lc_match_indices`` entry is a row index into ``matches`` (NOT an index
-// into ``inliers``); matching the indexing convention used inside
-// ``AppendLoopClosureObservations``.
+// Variant of ``AddImagePair`` for LC tests. Adds non-LC inlier matches via
+// AddTwoViewGeometry (so ExtractMatchesBetweenImages finds them), then sets
+// the ImagePair's matches/inliers/are_lc fields for
+// AppendLoopClosureObservations. ``lc_match_indices`` are row indices into
+// ``matches`` flagged as LC.
 void AddImagePairWithLC(CorrespondenceGraph& corr_graph,
                         image_t image_id1,
                         image_t image_id2,
@@ -319,6 +520,8 @@ void AddImagePairWithLC(CorrespondenceGraph& corr_graph,
   // created.
   const image_pair_t pair_id = ImagePairToPairId(image_id1, image_id2);
   auto& image_pair = corr_graph.MutableImagePairs().at(pair_id);
+  image_pair.image_id1 = image_id1;
+  image_pair.image_id2 = image_id2;
   Eigen::MatrixXi matches_mat(static_cast<int>(matches.size()), 2);
   for (size_t i = 0; i < matches.size(); ++i) {
     matches_mat(static_cast<int>(i), 0) = matches[i].first;
@@ -667,6 +870,60 @@ TEST(ProcessLoopClosurePairs, BothSameTrack) {
   // No new tracks minted, no lc_elements added (same-track skip).
   EXPECT_EQ(tracks.size(), 1u);
   EXPECT_EQ(tracks.at(0).track.lc_elements.size(), 0u);
+}
+
+TEST(ProcessLoopClosurePairs, PredicateThrowsOnMalformedLcLength) {
+  CorrespondenceGraph corr_graph;
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(2, 5);
+  AddLCOnlyPair(corr_graph, 1, 2, {{0, 0}}, {0});
+
+  const image_pair_t pair_id = ImagePairToPairId(1, 2);
+  corr_graph.MutableImagePairs().at(pair_id).are_lc.clear();
+
+  const std::vector<image_pair_t> pair_ids = {pair_id};
+  EXPECT_THROW(MakeLoopClosureMatchPredicate(pair_ids, corr_graph),
+               std::invalid_argument);
+}
+
+TEST(ProcessLoopClosurePairs, AppendThrowsOnMalformedLcLength) {
+  CorrespondenceGraph corr_graph;
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(2, 5);
+  AddLCOnlyPair(corr_graph, 1, 2, {{0, 0}}, {0});
+
+  const image_pair_t pair_id = ImagePairToPairId(1, 2);
+  corr_graph.MutableImagePairs().at(pair_id).are_lc.clear();
+
+  std::unordered_map<point3D_t, Point3D> tracks;
+  const std::vector<image_pair_t> pair_ids = {pair_id};
+  EXPECT_THROW(AppendLoopClosureObservations(pair_ids, corr_graph, tracks),
+               std::invalid_argument);
+}
+
+TEST(ProcessLoopClosurePairs, PredicateThrowsOnOutOfRangeInlierIndex) {
+  CorrespondenceGraph corr_graph;
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(2, 5);
+  AddLCOnlyPair(corr_graph, 1, 2, {{0, 0}}, {1});
+
+  const image_pair_t pair_id = ImagePairToPairId(1, 2);
+  const std::vector<image_pair_t> pair_ids = {pair_id};
+  EXPECT_THROW(MakeLoopClosureMatchPredicate(pair_ids, corr_graph),
+               std::invalid_argument);
+}
+
+TEST(ProcessLoopClosurePairs, AppendThrowsOnOutOfRangeInlierIndex) {
+  CorrespondenceGraph corr_graph;
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(2, 5);
+  AddLCOnlyPair(corr_graph, 1, 2, {{0, 0}}, {1});
+
+  const image_pair_t pair_id = ImagePairToPairId(1, 2);
+  std::unordered_map<point3D_t, Point3D> tracks;
+  const std::vector<image_pair_t> pair_ids = {pair_id};
+  EXPECT_THROW(AppendLoopClosureObservations(pair_ids, corr_graph, tracks),
+               std::invalid_argument);
 }
 
 }  // namespace

--- a/src/colmap/sfm/track_establishment_test.cc
+++ b/src/colmap/sfm/track_establishment_test.cc
@@ -180,11 +180,10 @@ TEST(TrackEstablishment, EmptyInputReturnsEmpty) {
 }
 
 // ============================================================================
-// FindTracksForProblem (problem-track filter + 2-view depth gate)
+// FindTracksForProblem (greedy subsample + 2-view depth gate)
 // ============================================================================
 
-// Build an Image with N features and (optionally) all-valid depth
-// priors. Each prior is set to (idx + 1) so they are strictly > 1e-6.
+// Build an Image with N features.
 Image MakeImage(image_t image_id,
                 int num_features,
                 bool with_valid_depths = true) {
@@ -222,9 +221,6 @@ Point3D MakePoint3DFromElementsAndLC(
   return p;
 }
 
-// Project an ``images`` test fixture into the three dict inputs consumed by
-// FilterTracksForProblem: registered_image_ids, depth_priors, and
-// depth_prior_validity.
 struct ProblemFilterInputs {
   std::unordered_set<image_t> registered_image_ids;
   std::unordered_map<image_t, std::vector<double>> depth_priors;
@@ -243,8 +239,8 @@ ProblemFilterInputs MakeProblemFilterInputs(
 }
 
 // LengthFilter: with ``min_num_views_per_track=10`` every track here is too
-// short, so FilterTracksForProblem returns empty. Loosening to 2 surfaces
-// every input track.
+// short, so FilterTracksForProblem returns empty. Loosening to 2 surfaces every
+// input track.
 //
 // Drives FilterTracksForProblem.
 TEST(FindTracksForProblem, LengthFilter) {
@@ -336,21 +332,15 @@ TEST(FindTracksForProblem, MaxLengthFilter) {
   EXPECT_TRUE(selected.empty());
 }
 
-// TwoViewDepthGate_Drop: a length-2 track where image 1's feature 0 has no
-// valid depth prior is dropped by the 2-view depth gate.
-//
-// Drives FilterTracksForProblem.
 TEST(FindTracksForProblem, TwoViewDepthGate_Drop) {
   std::unordered_map<image_t, Image> images;
-  // Image 1: feature 0 has *invalid* depth prior; feature 1+ are valid.
   Image img1 = MakeImage(1, 3);
   img1.depth_prior_validity[0] = false;
   img1.depth_priors[0] = 0.0;
   images.emplace(1, std::move(img1));
-  images.emplace(2, MakeImage(2, 3));  // all valid
+  images.emplace(2, MakeImage(2, 3));
 
   std::unordered_map<point3D_t, Point3D> tracks_full;
-  // Length-2 track on (1, 2) using feature 0 of each image -> invalid.
   tracks_full.emplace(0, MakePoint3DFromElements({{1, 0}, {2, 0}}));
 
   const auto inputs = MakeProblemFilterInputs(images);
@@ -367,16 +357,9 @@ TEST(FindTracksForProblem, TwoViewDepthGate_Drop) {
   EXPECT_TRUE(selected.empty());
 }
 
-// TwoViewDepthGate_Keep: both endpoints have valid depth -> track kept.
-// Also covers the depth-near-zero edge: feature 1 has prior == 1e-6 (gate
-// uses ``<= 1e-6`` so the feature 1 track must drop while feature 0 stays).
-//
-// Drives FilterTracksForProblem.
 TEST(FindTracksForProblem, TwoViewDepthGate_Keep) {
   std::unordered_map<image_t, Image> images;
   Image img1 = MakeImage(1, 3);
-  // Feature 0: valid, prior=1.0  -> survives
-  // Feature 1: valid flag true, prior=1e-6 -> caught by ``<= 1e-6`` -> drops
   img1.depth_priors[1] = 1e-6;
   images.emplace(1, std::move(img1));
   images.emplace(2, MakeImage(2, 3));
@@ -400,11 +383,6 @@ TEST(FindTracksForProblem, TwoViewDepthGate_Keep) {
   EXPECT_EQ(selected.count(1), 0u);
 }
 
-// LC-only two-observation tracks have one regular element and one LC element.
-// LC observations may augment admitted tracks but must not satisfy the
-// post-domain regular-observation lower-bound check.
-//
-// Drives FilterTracksForProblem.
 TEST(FindTracksForProblem, LcElementsDoNotSatisfyPostDomainMinViews) {
   std::unordered_map<image_t, Image> images;
   images.emplace(1, MakeImage(1, 3));
@@ -430,8 +408,6 @@ TEST(FindTracksForProblem, LcElementsDoNotSatisfyPostDomainMinViews) {
   EXPECT_TRUE(selected.empty());
 }
 
-// A one-regular + one-LC two-view candidate does not satisfy the post-domain
-// regular-observation lower-bound check.
 TEST(FindTracksForProblem, TwoViewDepthGate_DropsInvalidRegularLcCandidate) {
   std::unordered_map<image_t, Image> images;
   Image img1 = MakeImage(1, 3);
@@ -460,9 +436,6 @@ TEST(FindTracksForProblem, TwoViewDepthGate_DropsInvalidRegularLcCandidate) {
   EXPECT_TRUE(selected.empty());
 }
 
-// Invalid depth on an LC endpoint still matters once the regular track is
-// already admitted. The LC endpoint shares one of the two distinct images so
-// the 2-view depth gate checks it.
 TEST(FindTracksForProblem, TwoViewDepthGate_DropsInvalidLcEndpoint) {
   std::unordered_map<image_t, Image> images;
   Image img1 = MakeImage(1, 3);
@@ -502,11 +475,10 @@ TEST(FindTracksForProblem, TwoViewDepthGate_DropsInvalidLcEndpoint) {
 // ``ImagePair.are_lc`` to attach LC observations as ``Track::lc_elements``.
 // The post-condition tracks dict is what we assert on.
 
-// Variant of ``AddImagePair`` for LC tests. Adds non-LC inlier matches via
-// AddTwoViewGeometry (so ExtractMatchesBetweenImages finds them), then sets
-// the ImagePair's matches/inliers/are_lc fields for
-// AppendLoopClosureObservations. ``lc_match_indices`` are row indices into
-// ``matches`` flagged as LC.
+// Variant of ``AddImagePair`` that also populates ``are_lc``. Each
+// ``lc_match_indices`` entry is a row index into ``matches`` (NOT an index
+// into ``inliers``); matching the indexing convention used inside
+// ``AppendLoopClosureObservations``.
 void AddImagePairWithLC(CorrespondenceGraph& corr_graph,
                         image_t image_id1,
                         image_t image_id2,

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -344,43 +344,52 @@ void BindBundleAdjuster(py::module& m) {
            }),
            "options"_a,
            "config"_a)
-      .def_property_readonly("problem", &CeresBundleAdjuster::Problem);
+      .def_property_readonly("problem",
+                             &CeresBundleAdjuster::Problem,
+                             py::return_value_policy::reference_internal);
 
-  m.def("create_default_bundle_adjuster",
-        [](const BundleAdjustmentOptions& options,
-           const BundleAdjustmentConfig& config,
-           Reconstruction& reconstruction)
-            -> std::shared_ptr<CeresBundleAdjuster> {
-          auto ba = CreateDefaultBundleAdjuster(options, config, reconstruction);
-          auto* ceres_ba = dynamic_cast<CeresBundleAdjuster*>(ba.get());
-          if (!ceres_ba) {
-            throw std::runtime_error(
-                "CreateDefaultBundleAdjuster did not return a CeresBundleAdjuster");
-          }
-          ba.release();
-          return std::shared_ptr<CeresBundleAdjuster>(ceres_ba);
-        },
-        "options"_a,
-        "config"_a,
-        "reconstruction"_a);
+  m.def(
+      "create_default_bundle_adjuster",
+      [](const BundleAdjustmentOptions& options,
+         const BundleAdjustmentConfig& config,
+         Reconstruction& reconstruction)
+          -> std::shared_ptr<CeresBundleAdjuster> {
+        auto ba = CreateDefaultBundleAdjuster(options, config, reconstruction);
+        auto* ceres_ba = dynamic_cast<CeresBundleAdjuster*>(ba.get());
+        if (!ceres_ba) {
+          throw std::runtime_error(
+              "CreateDefaultBundleAdjuster did not return a "
+              "CeresBundleAdjuster");
+        }
+        ba.release();
+        return std::shared_ptr<CeresBundleAdjuster>(ceres_ba);
+      },
+      "options"_a,
+      "config"_a,
+      "reconstruction"_a,
+      py::keep_alive<0, 3>());
 
-  m.def("create_default_ceres_bundle_adjuster",
-        [](const BundleAdjustmentOptions& options,
-           const BundleAdjustmentConfig& config,
-           Reconstruction& reconstruction)
-            -> std::shared_ptr<CeresBundleAdjuster> {
-          auto ba = CreateDefaultCeresBundleAdjuster(options, config, reconstruction);
-          auto* ceres_ba = dynamic_cast<CeresBundleAdjuster*>(ba.get());
-          if (!ceres_ba) {
-            throw std::runtime_error(
-                "CreateDefaultCeresBundleAdjuster did not return a CeresBundleAdjuster");
-          }
-          ba.release();
-          return std::shared_ptr<CeresBundleAdjuster>(ceres_ba);
-        },
-        "options"_a,
-        "config"_a,
-        "reconstruction"_a);
+  m.def(
+      "create_default_ceres_bundle_adjuster",
+      [](const BundleAdjustmentOptions& options,
+         const BundleAdjustmentConfig& config,
+         Reconstruction& reconstruction)
+          -> std::shared_ptr<CeresBundleAdjuster> {
+        auto ba =
+            CreateDefaultCeresBundleAdjuster(options, config, reconstruction);
+        auto* ceres_ba = dynamic_cast<CeresBundleAdjuster*>(ba.get());
+        if (!ceres_ba) {
+          throw std::runtime_error(
+              "CreateDefaultCeresBundleAdjuster did not return a "
+              "CeresBundleAdjuster");
+        }
+        ba.release();
+        return std::shared_ptr<CeresBundleAdjuster>(ceres_ba);
+      },
+      "options"_a,
+      "config"_a,
+      "reconstruction"_a,
+      py::keep_alive<0, 3>());
 
   m.def("create_pose_prior_bundle_adjuster",
         CreatePosePriorBundleAdjuster,
@@ -388,7 +397,8 @@ void BindBundleAdjuster(py::module& m) {
         "prior_options"_a,
         "config"_a,
         "pose_priors"_a,
-        "reconstruction"_a);
+        "reconstruction"_a,
+        py::keep_alive<0, 5>());
 
   m.def("create_pose_prior_ceres_bundle_adjuster",
         CreatePosePriorCeresBundleAdjuster,
@@ -396,50 +406,52 @@ void BindBundleAdjuster(py::module& m) {
         "prior_options"_a,
         "config"_a,
         "pose_priors"_a,
-        "reconstruction"_a);
-
-  m.def("create_depth_bundle_adjuster",
-        [](ceres::Problem* problem,
-           image_t image_id,
-           const std::vector<point3D_t>& point3D_ids,
-           const std::vector<double>& depths,
-           const std::vector<double>& loss_magnitudes,
-           const std::vector<double>& loss_params,
-           const std::vector<CeresBundleAdjustmentOptions::LossFunctionType>&
-               loss_types,
-           py::array_t<double> shift_scale,
-           Reconstruction& reconstruction,
-           bool logloss,
-           bool fix_shift,
-           bool fix_scale) {
-          auto buf = shift_scale.request();
-          if (buf.ndim != 1 || buf.shape[0] != 2)
-            throw std::runtime_error(
-                "shift_scale must have exactly 2 elements.");
-          double* shift_scale_ptr = static_cast<double*>(buf.ptr);
-          DepthPriorBundleAdjuster(problem,
-                                   image_id,
-                                   point3D_ids,
-                                   depths,
-                                   loss_magnitudes,
-                                   loss_params,
-                                   loss_types,
-                                   shift_scale_ptr,
-                                   reconstruction,
-                                   logloss,
-                                   fix_shift,
-                                   fix_scale);
-        },
-        "problem"_a,
-        "image_id"_a,
-        "point3D_ids"_a,
-        "depths"_a,
-        "loss_magnitudes"_a,
-        "loss_params"_a,
-        "loss_types"_a,
-        "shift_scale"_a,
         "reconstruction"_a,
-        "logloss"_a = false,
-        "fix_shift"_a = false,
-        "fix_scale"_a = false);
+        py::keep_alive<0, 5>());
+
+  m.def(
+      "create_depth_bundle_adjuster",
+      [](ceres::Problem* problem,
+         image_t image_id,
+         const std::vector<point3D_t>& point3D_ids,
+         const std::vector<double>& depths,
+         const std::vector<double>& loss_magnitudes,
+         const std::vector<double>& loss_params,
+         const std::vector<CeresBundleAdjustmentOptions::LossFunctionType>&
+             loss_types,
+         py::array_t<double> shift_scale,
+         Reconstruction& reconstruction,
+         bool logloss,
+         bool fix_shift,
+         bool fix_scale) {
+        auto buf = shift_scale.request();
+        if (buf.ndim != 1 || buf.shape[0] != 2)
+          throw std::runtime_error("shift_scale must have exactly 2 elements.");
+        double* shift_scale_ptr = static_cast<double*>(buf.ptr);
+        DepthPriorBundleAdjuster(problem,
+                                 image_id,
+                                 point3D_ids,
+                                 depths,
+                                 loss_magnitudes,
+                                 loss_params,
+                                 loss_types,
+                                 shift_scale_ptr,
+                                 reconstruction,
+                                 logloss,
+                                 fix_shift,
+                                 fix_scale);
+      },
+      "problem"_a,
+      "image_id"_a,
+      "point3D_ids"_a,
+      "depths"_a,
+      "loss_magnitudes"_a,
+      "loss_params"_a,
+      "loss_types"_a,
+      "shift_scale"_a,
+      "reconstruction"_a,
+      "logloss"_a = false,
+      "fix_shift"_a = false,
+      "fix_scale"_a = false,
+      py::keep_alive<1, 8>());
 }

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -179,7 +179,10 @@ void BindBundleAdjuster(py::module& m) {
           .value("HUBER", CeresBAOpts::LossFunctionType::HUBER);
   AddStringToEnumConstructor(PyCeresLossFunctionType);
 
-  // LossConfig bound here (BA runs first); referenced by GP and pose priors.
+  // Shared (type, scale, weight) loss config struct used by BA, GP, and
+  // pose-prior options. Bound here in the BA binding because BA runs
+  // before motion-averaging in BindEstimators ordering, and GP / pose
+  // prior options reference this Python class via def_readwrite.
   py::classh<LossConfig>(m, "LossConfig")
       .def(py::init<>())
       .def_readwrite("type", &LossConfig::type)
@@ -348,48 +351,43 @@ void BindBundleAdjuster(py::module& m) {
                              &CeresBundleAdjuster::Problem,
                              py::return_value_policy::reference_internal);
 
-  m.def(
-      "create_default_bundle_adjuster",
-      [](const BundleAdjustmentOptions& options,
-         const BundleAdjustmentConfig& config,
-         Reconstruction& reconstruction)
-          -> std::shared_ptr<CeresBundleAdjuster> {
-        auto ba = CreateDefaultBundleAdjuster(options, config, reconstruction);
-        auto* ceres_ba = dynamic_cast<CeresBundleAdjuster*>(ba.get());
-        if (!ceres_ba) {
-          throw std::runtime_error(
-              "CreateDefaultBundleAdjuster did not return a "
-              "CeresBundleAdjuster");
-        }
-        ba.release();
-        return std::shared_ptr<CeresBundleAdjuster>(ceres_ba);
-      },
-      "options"_a,
-      "config"_a,
-      "reconstruction"_a,
-      py::keep_alive<0, 3>());
+  m.def("create_default_bundle_adjuster",
+        [](const BundleAdjustmentOptions& options,
+           const BundleAdjustmentConfig& config,
+           Reconstruction& reconstruction)
+            -> std::shared_ptr<CeresBundleAdjuster> {
+          auto ba = CreateDefaultBundleAdjuster(options, config, reconstruction);
+          auto* ceres_ba = dynamic_cast<CeresBundleAdjuster*>(ba.get());
+          if (!ceres_ba) {
+            throw std::runtime_error(
+                "CreateDefaultBundleAdjuster did not return a CeresBundleAdjuster");
+          }
+          ba.release();
+          return std::shared_ptr<CeresBundleAdjuster>(ceres_ba);
+        },
+        "options"_a,
+        "config"_a,
+        "reconstruction"_a,
+        py::keep_alive<0, 3>());
 
-  m.def(
-      "create_default_ceres_bundle_adjuster",
-      [](const BundleAdjustmentOptions& options,
-         const BundleAdjustmentConfig& config,
-         Reconstruction& reconstruction)
-          -> std::shared_ptr<CeresBundleAdjuster> {
-        auto ba =
-            CreateDefaultCeresBundleAdjuster(options, config, reconstruction);
-        auto* ceres_ba = dynamic_cast<CeresBundleAdjuster*>(ba.get());
-        if (!ceres_ba) {
-          throw std::runtime_error(
-              "CreateDefaultCeresBundleAdjuster did not return a "
-              "CeresBundleAdjuster");
-        }
-        ba.release();
-        return std::shared_ptr<CeresBundleAdjuster>(ceres_ba);
-      },
-      "options"_a,
-      "config"_a,
-      "reconstruction"_a,
-      py::keep_alive<0, 3>());
+  m.def("create_default_ceres_bundle_adjuster",
+        [](const BundleAdjustmentOptions& options,
+           const BundleAdjustmentConfig& config,
+           Reconstruction& reconstruction)
+            -> std::shared_ptr<CeresBundleAdjuster> {
+          auto ba = CreateDefaultCeresBundleAdjuster(options, config, reconstruction);
+          auto* ceres_ba = dynamic_cast<CeresBundleAdjuster*>(ba.get());
+          if (!ceres_ba) {
+            throw std::runtime_error(
+                "CreateDefaultCeresBundleAdjuster did not return a CeresBundleAdjuster");
+          }
+          ba.release();
+          return std::shared_ptr<CeresBundleAdjuster>(ceres_ba);
+        },
+        "options"_a,
+        "config"_a,
+        "reconstruction"_a,
+        py::keep_alive<0, 3>());
 
   m.def("create_pose_prior_bundle_adjuster",
         CreatePosePriorBundleAdjuster,
@@ -409,49 +407,49 @@ void BindBundleAdjuster(py::module& m) {
         "reconstruction"_a,
         py::keep_alive<0, 5>());
 
-  m.def(
-      "create_depth_bundle_adjuster",
-      [](ceres::Problem* problem,
-         image_t image_id,
-         const std::vector<point3D_t>& point3D_ids,
-         const std::vector<double>& depths,
-         const std::vector<double>& loss_magnitudes,
-         const std::vector<double>& loss_params,
-         const std::vector<CeresBundleAdjustmentOptions::LossFunctionType>&
-             loss_types,
-         py::array_t<double> shift_scale,
-         Reconstruction& reconstruction,
-         bool logloss,
-         bool fix_shift,
-         bool fix_scale) {
-        auto buf = shift_scale.request();
-        if (buf.ndim != 1 || buf.shape[0] != 2)
-          throw std::runtime_error("shift_scale must have exactly 2 elements.");
-        double* shift_scale_ptr = static_cast<double*>(buf.ptr);
-        DepthPriorBundleAdjuster(problem,
-                                 image_id,
-                                 point3D_ids,
-                                 depths,
-                                 loss_magnitudes,
-                                 loss_params,
-                                 loss_types,
-                                 shift_scale_ptr,
-                                 reconstruction,
-                                 logloss,
-                                 fix_shift,
-                                 fix_scale);
-      },
-      "problem"_a,
-      "image_id"_a,
-      "point3D_ids"_a,
-      "depths"_a,
-      "loss_magnitudes"_a,
-      "loss_params"_a,
-      "loss_types"_a,
-      "shift_scale"_a,
-      "reconstruction"_a,
-      "logloss"_a = false,
-      "fix_shift"_a = false,
-      "fix_scale"_a = false,
-      py::keep_alive<1, 8>());
+  m.def("create_depth_bundle_adjuster",
+        [](ceres::Problem* problem,
+           image_t image_id,
+           const std::vector<point3D_t>& point3D_ids,
+           const std::vector<double>& depths,
+           const std::vector<double>& loss_magnitudes,
+           const std::vector<double>& loss_params,
+           const std::vector<CeresBundleAdjustmentOptions::LossFunctionType>&
+               loss_types,
+           py::array_t<double> shift_scale,
+           Reconstruction& reconstruction,
+           bool logloss,
+           bool fix_shift,
+           bool fix_scale) {
+          auto buf = shift_scale.request();
+          if (buf.ndim != 1 || buf.shape[0] != 2)
+            throw std::runtime_error(
+                "shift_scale must have exactly 2 elements.");
+          double* shift_scale_ptr = static_cast<double*>(buf.ptr);
+          DepthPriorBundleAdjuster(problem,
+                                   image_id,
+                                   point3D_ids,
+                                   depths,
+                                   loss_magnitudes,
+                                   loss_params,
+                                   loss_types,
+                                   shift_scale_ptr,
+                                   reconstruction,
+                                   logloss,
+                                   fix_shift,
+                                   fix_scale);
+        },
+        "problem"_a,
+        "image_id"_a,
+        "point3D_ids"_a,
+        "depths"_a,
+        "loss_magnitudes"_a,
+        "loss_params"_a,
+        "loss_types"_a,
+        "shift_scale"_a,
+        "reconstruction"_a,
+        "logloss"_a = false,
+        "fix_shift"_a = false,
+        "fix_scale"_a = false,
+        py::keep_alive<1, 8>());
 }

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -451,5 +451,6 @@ void BindBundleAdjuster(py::module& m) {
         "logloss"_a = false,
         "fix_shift"_a = false,
         "fix_scale"_a = false,
-        py::keep_alive<1, 8>());
+        py::keep_alive<1, 8>(),
+        py::keep_alive<1, 9>());
 }

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -125,23 +125,61 @@ void BindGlobalPositioner(py::module& m) {
                          &GlobalPositionerOptions::use_init,
                          "If true, skip random init for both camera centers "
                          "and track xyz.")
-          .def_readwrite(
-              "use_lc_observations",
-              &GlobalPositionerOptions::use_lc_observations,
-              "If true, AddPoint3DToProblem also iterates "
-              "track.lc_elements (loop-closure observations).")
+          .def_readwrite("use_lc_observations",
+                         &GlobalPositionerOptions::use_lc_observations,
+                         "If true, AddPoint3DToProblem also iterates "
+                         "track.lc_elements (loop-closure observations).")
           .def_readwrite(
               "random_init_scale",
               &GlobalPositionerOptions::random_init_scale,
               "Cube size for random init of camera centers / points (linear).");
 
-  // LC per-bucket loss configs. ``LossConfig`` carries
-  // (type=LossFunctionType enum, scale, weight). Defaults give
-  // unweighted TrivialLoss — equivalent to no override.
+  // Full-branch metric-depth and LC extensions. ``LossConfig`` carries
+  // (type=LossFunctionType enum, scale, weight). Defaults give unweighted
+  // TrivialLoss — equivalent to no override.
   PyGlobalPositionerOptions
+      .def_readwrite("use_metric_depth_constraint",
+                     &GlobalPositionerOptions::use_metric_depth_constraint)
+      .def_readwrite(
+          "use_log_scale_for_depth_map_scales",
+          &GlobalPositionerOptions::use_log_scale_for_depth_map_scales)
+      .def_readwrite("use_log_residual_for_depth",
+                     &GlobalPositionerOptions::use_log_residual_for_depth)
+      .def_readwrite("zero_residual_behind",
+                     &GlobalPositionerOptions::zero_residual_behind)
+      .def_readwrite("smooth_log_linear_transition",
+                     &GlobalPositionerOptions::smooth_log_linear_transition)
+      .def_readwrite("log_linear_threshold",
+                     &GlobalPositionerOptions::log_linear_threshold)
+      .def_readwrite("scale_prior_stddev",
+                     &GlobalPositionerOptions::scale_prior_stddev)
+      .def_readwrite("filter_depth_outliers",
+                     &GlobalPositionerOptions::filter_depth_outliers)
+      .def_readwrite("initial_dmap_scales",
+                     &GlobalPositionerOptions::initial_dmap_scales)
+      .def_readwrite("loss_normal_geometry",
+                     &GlobalPositionerOptions::loss_normal_geometry)
+      .def_readwrite("loss_normal_depth",
+                     &GlobalPositionerOptions::loss_normal_depth)
       .def_readwrite("loss_lc_geometry",
                      &GlobalPositionerOptions::loss_lc_geometry)
-      .def_readwrite("loss_lc_depth", &GlobalPositionerOptions::loss_lc_depth);
+      .def_readwrite("loss_lc_depth", &GlobalPositionerOptions::loss_lc_depth)
+      .def_readwrite("loss_normal_geometry_inlier",
+                     &GlobalPositionerOptions::loss_normal_geometry_inlier)
+      .def_readwrite("loss_normal_depth_inlier",
+                     &GlobalPositionerOptions::loss_normal_depth_inlier)
+      .def_readwrite("loss_normal_depth_outlier",
+                     &GlobalPositionerOptions::loss_normal_depth_outlier)
+      .def_readwrite("loss_normal_geometry_trackstart",
+                     &GlobalPositionerOptions::loss_normal_geometry_trackstart)
+      .def_readwrite("loss_normal_depth_trackstart",
+                     &GlobalPositionerOptions::loss_normal_depth_trackstart)
+      .def_readwrite("loss_scale_prior",
+                     &GlobalPositionerOptions::loss_scale_prior)
+      .def_readwrite("filter_depth_outlier_sigma",
+                     &GlobalPositionerOptions::filter_depth_outlier_sigma)
+      .def_readwrite("loss_soft_outlier_fallback",
+                     &GlobalPositionerOptions::loss_soft_outlier_fallback);
 
   MakeDataclass(PyGlobalPositionerOptions);
 
@@ -156,7 +194,12 @@ void BindGlobalPositioner(py::module& m) {
           py::gil_scoped_release release;
           success = positioner.Solve(pose_graph, reconstruction);
         }
-        return success;
+        py::dict output;
+        output["success"] = success;
+        output["dmap_scale_map"] = positioner.GetDmapScales();
+        output["dmap_scale_map_nested"] = positioner.GetDmapScales();
+        output["dmap_scales"] = positioner.GetDmapScales();
+        return output;
       },
       "options"_a,
       "pose_graph"_a,
@@ -257,10 +300,12 @@ void BindRotationEstimator(py::module& m) {
               "Filter pairs with rotation error exceeding this threshold "
               "(degrees).")
           // --- Video / loop-closure extensions ---
-          .def_readwrite(
-              "skip_risky_lc_pairs",
-              &RotationEstimatorOptions::skip_risky_lc_pairs,
-              "Drop pairs whose LC inliers exceed non-LC inliers.")
+          .def_readwrite("skip_risky_lc_pairs",
+                         &RotationEstimatorOptions::skip_risky_lc_pairs,
+                         "Drop pairs whose LC inliers exceed non-LC inliers.")
+          .def_readwrite("skip_risky_LC_pairs",
+                         &RotationEstimatorOptions::skip_risky_lc_pairs,
+                         "Legacy spelling for skip_risky_lc_pairs.")
           .def_readwrite(
               "use_video_constraints",
               &RotationEstimatorOptions::use_video_constraints,
@@ -275,7 +320,26 @@ void BindRotationEstimator(py::module& m) {
               "video_lc_cauchy_scale",
               &RotationEstimatorOptions::video_lc_cauchy_scale,
               "Cauchy loss scale for loop-closure pairs in the video "
-              "solver.");
+              "solver.")
+          // --- Ceres solver_options (SolveCeres path) ---
+          .def_property(
+              "num_threads",
+              [](const RotationEstimatorOptions& self) {
+                return self.solver_options.num_threads;
+              },
+              [](RotationEstimatorOptions& self, int v) {
+                self.solver_options.num_threads = v;
+              },
+              "Ceres solver thread count.")
+          .def_property(
+              "max_num_iterations",
+              [](const RotationEstimatorOptions& self) {
+                return self.solver_options.max_num_iterations;
+              },
+              [](RotationEstimatorOptions& self, int v) {
+                self.solver_options.max_num_iterations = v;
+              },
+              "Ceres solver max iterations (SolveCeres path).");
   MakeDataclass(PyRotationEstimatorOptions);
 
   m.def(
@@ -288,13 +352,12 @@ void BindRotationEstimator(py::module& m) {
         bool success = false;
         {
           py::gil_scoped_release release;
-          success = RunRotationAveraging(
-              options,
-              pose_graph,
-              reconstruction,
-              pose_priors,
-              nullptr,
-              correspondence_graph);
+          success = RunRotationAveraging(options,
+                                         pose_graph,
+                                         reconstruction,
+                                         pose_priors,
+                                         nullptr,
+                                         correspondence_graph);
         }
         return py::cast(success);
       },

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -28,6 +28,12 @@ void BindGlobalPositioner(py::module& m) {
                          &GlobalPositionerOptions::generate_scales,
                          "Whether to initialize scales to constant 1 or derive "
                          "from positions.")
+          .def_readwrite(
+              "initialize_warm_start_scales",
+              &GlobalPositionerOptions::initialize_warm_start_scales,
+              "When generate_scales is false, derive BATA scales from current "
+              "camera/point geometry even for warm-started solves. Set false "
+              "only to reproduce legacy warm-start behavior.")
           .def_readwrite("optimize_positions",
                          &GlobalPositionerOptions::optimize_positions,
                          "Whether to optimize camera positions.")

--- a/src/pycolmap/scene/correspondence_graph.cc
+++ b/src/pycolmap/scene/correspondence_graph.cc
@@ -48,9 +48,7 @@ void BindCorrespondenceGraph(py::module& m) {
       .def(py::init<image_t, image_t>(), "image_id1"_a, "image_id2"_a)
       .def_readwrite("image_id1", &CorrespondenceGraph::ImagePair::image_id1)
       .def_readwrite("image_id2", &CorrespondenceGraph::ImagePair::image_id2)
-      .def_readwrite("pair_id", &CorrespondenceGraph::ImagePair::pair_id)
       .def_readwrite("is_valid", &CorrespondenceGraph::ImagePair::is_valid)
-      .def_readwrite("weight", &CorrespondenceGraph::ImagePair::weight)
       .def_property(
           "matches",
           [](const CorrespondenceGraph::ImagePair& p)
@@ -77,7 +75,6 @@ void BindCorrespondenceGraph(py::module& m) {
             }
             p.inliers = std::move(v);
           })
-      .def_readwrite("cov_t", &CorrespondenceGraph::ImagePair::cov_t)
       .def_property(
           "are_lc",
           [](const CorrespondenceGraph::ImagePair& p)

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -26,6 +26,22 @@ namespace py = pybind11;
 namespace {
 
 template <typename PyClass>
+void DefDoubleVectorProperty(PyClass& cls,
+                             const char* name,
+                             std::vector<double> Image::*member) {
+  cls.def_property(
+      name,
+      [member](const Image& self) -> Eigen::VectorXd {
+        const auto& vec = self.*member;
+        return Eigen::Map<const Eigen::VectorXd>(vec.data(), vec.size());
+      },
+      [member](Image& self, const Eigen::VectorXd& v) {
+        auto& vec = self.*member;
+        vec.assign(v.data(), v.data() + v.size());
+      });
+}
+
+template <typename PyClass>
 void DefBoolVectorProperty(PyClass& cls,
                            const char* name,
                            std::vector<bool> Image::*member) {
@@ -99,7 +115,9 @@ void BindSceneImage(py::module& m) {
               return py::none();
             }
           },
-          &Image::SetCameraPtr,
+          py::cpp_function(
+              [](Image& self, Camera* camera) { self.SetCameraPtr(camera); },
+              py::keep_alive<1, 2>()),
           "The associated camera object.")
       .def_property(
           "frame",
@@ -110,16 +128,26 @@ void BindSceneImage(py::module& m) {
               return py::none();
             }
           },
-          &Image::SetFramePtr,
+          py::cpp_function(
+              [](Image& self, Frame* frame) { self.SetFramePtr(frame); },
+              py::keep_alive<1, 2>()),
           "The associated frame object.")
       .def_property("name",
                     py::overload_cast<>(&Image::Name),
                     &Image::SetName,
                     "Name of the image.")
-      .def("cam_from_world",
-           &Image::CamFromWorld,
-           "The pose of the image, defined as the transformation from world to "
-           "camera space. Read-only; supports non-trivial frame (rig).")
+      .def_property_readonly(
+          "cam_from_world",
+          [](const Image& self) -> py::object {
+            if (self.HasPose()) {
+              return py::cast(self.CamFromWorld());
+            } else {
+              return py::none();
+            }
+          },
+          "The pose of the image, defined as the transformation from world to "
+          "camera space. Read-only; supports non-trivial frame (rig). "
+          "Returns None if the image has no valid pose.")
       .def_property_readonly(
           "has_pose", &Image::HasPose, "Whether the image has a valid pose.")
       .def_property(
@@ -234,9 +262,35 @@ void BindSceneImage(py::module& m) {
             return points2D;
           },
           "Get the 2D points that observe a 3D point.");
+  DefDoubleVectorProperty(PyImage, "depth_priors", &Image::depth_priors);
+  DefDoubleVectorProperty(
+      PyImage, "depth_prior_stddevs", &Image::depth_prior_stddevs);
+  DefBoolVectorProperty(
+      PyImage, "depth_prior_validity", &Image::depth_prior_validity);
   DefBoolVectorProperty(PyImage, "is_inlier", &Image::is_inlier);
+  DefBoolVectorProperty(PyImage, "is_depth_outlier", &Image::is_depth_outlier);
   DefBoolVectorProperty(PyImage, "is_track_anchor", &Image::is_track_anchor);
-  MakeDataclass(PyImage);
+  MakeDataclass(PyImage,
+                {"angular_stddevs",
+                 "camera",
+                 "camera_id",
+                 "data_id",
+                 "depth_prior_stddevs",
+                 "depth_prior_validity",
+                 "depth_priors",
+                 "features",
+                 "features_undist",
+                 "frame",
+                 "frame_id",
+                 "has_pose",
+                 "image_id",
+                 "is_depth_outlier",
+                 "is_inlier",
+                 "is_track_anchor",
+                 "name",
+                 "num_points3D",
+                 "pixel_cholesky_xy",
+                 "points2D"});
 
   py::bind_map<ImageMap>(m, "ImageMap");
 }

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -51,6 +51,15 @@ void AssignBoolVector(
   }
 }
 
+Eigen::VectorXd DoubleVectorToEigen(const std::vector<double>& values) {
+  return Eigen::Map<const Eigen::VectorXd>(values.data(), values.size());
+}
+
+void AssignDoubleVector(std::vector<double>& target,
+                        const Eigen::VectorXd& values) {
+  target.assign(values.data(), values.data() + values.size());
+}
+
 template <typename PyClass>
 void DefDoubleVectorProperty(PyClass& cls,
                              const char* name,
@@ -58,12 +67,10 @@ void DefDoubleVectorProperty(PyClass& cls,
   cls.def_property(
       name,
       [member](const Image& self) -> Eigen::VectorXd {
-        const auto& vec = self.*member;
-        return Eigen::Map<const Eigen::VectorXd>(vec.data(), vec.size());
+        return DoubleVectorToEigen(self.*member);
       },
       [member](Image& self, const Eigen::VectorXd& v) {
-        auto& vec = self.*member;
-        vec.assign(v.data(), v.data() + v.size());
+        AssignDoubleVector(self.*member, v);
       });
 }
 

--- a/src/pycolmap/scene/track.cc
+++ b/src/pycolmap/scene/track.cc
@@ -22,7 +22,10 @@ void BindTrack(py::module& m) {
   PyTrackElement.def(py::init<>())
       .def(py::init<image_t, point2D_t>(), "image_id"_a, "point2D_idx"_a)
       .def_readwrite("image_id", &TrackElement::image_id)
-      .def_readwrite("point2D_idx", &TrackElement::point2D_idx);
+      .def_readwrite("point2D_idx", &TrackElement::point2D_idx)
+      .def_readwrite("is_inlier", &TrackElement::is_inlier)
+      .def_readwrite("is_depth_outlier", &TrackElement::is_depth_outlier)
+      .def_readwrite("is_track_anchor", &TrackElement::is_track_anchor);
   MakeDataclass(PyTrackElement);
 
   py::classh<Track> PyTrack(m, "Track");

--- a/src/pycolmap/sfm/track_establishment.cc
+++ b/src/pycolmap/sfm/track_establishment.cc
@@ -49,6 +49,10 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
     images.emplace(py::cast<image_t>(item.first), py::cast<Image>(item.second));
   }
 
+  // Build keypoints map from ``Image::features``. The Reconstruction-based
+  // helper reads ``image.Points2D()`` instead; this dict-based entry point
+  // operates without a Reconstruction so it consumes the per-image
+  // ``features`` vector directly.
   std::unordered_map<image_t, std::vector<Eigen::Vector2d>>
       image_id_to_keypoints;
   image_id_to_keypoints.reserve(images.size());
@@ -65,6 +69,8 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
     TrackEstablishmentOptions to = options;
     MatchPredicate ignore_match;
     if (lc_second_pass) {
+      // When the LC pass is enabled, the caller owns subsampling, so the
+      // helper-side greedy gate is bypassed here.
       to.required_tracks_per_view = std::numeric_limits<int>::max();
       CorrespondenceGraph& lc_cg = lc_correspondence_graph
                                        ? *lc_correspondence_graph
@@ -78,6 +84,8 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
                                           to,
                                           ignore_match);
     if (lc_second_pass) {
+      // LC observations come from the separate LC correspondence graph which
+      // retains the matches/inliers/are_lc ImagePair fields.
       CorrespondenceGraph& lc_cg = lc_correspondence_graph
                                        ? *lc_correspondence_graph
                                        : correspondence_graph;
@@ -97,8 +105,16 @@ py::dict RunFindTracksForProblem(py::dict images_py,
                                  py::dict tracks_full_py,
                                  const TrackProblemFilterOptions& options) {
   std::unordered_set<image_t> registered_image_ids;
+  std::unordered_map<image_t, std::vector<double>> depth_priors;
+  std::unordered_map<image_t, std::vector<bool>> depth_prior_validity;
   for (auto item : images_py) {
-    registered_image_ids.insert(py::cast<image_t>(item.first));
+    const auto image_id = py::cast<image_t>(item.first);
+    const auto image = py::cast<Image>(item.second);
+    registered_image_ids.insert(image_id);
+    if (options.two_view_depth_gate) {
+      depth_priors.emplace(image_id, image.depth_priors);
+      depth_prior_validity.emplace(image_id, image.depth_prior_validity);
+    }
   }
 
   std::unordered_map<point3D_t, Point3D> tracks_full;
@@ -111,8 +127,11 @@ py::dict RunFindTracksForProblem(py::dict images_py,
   std::unordered_map<point3D_t, Point3D> selected;
   {
     py::gil_scoped_release release;
-    selected =
-        FilterTracksForProblem(options, registered_image_ids, tracks_full);
+    selected = FilterTracksForProblem(options,
+                                      registered_image_ids,
+                                      depth_priors,
+                                      depth_prior_validity,
+                                      tracks_full);
   }
 
   py::dict tracks_out;
@@ -143,7 +162,9 @@ void BindTrackEstablishment(py::module& m) {
           .def_readwrite("min_num_views_per_track",
                          &TrackProblemFilterOptions::min_num_views_per_track)
           .def_readwrite("max_num_views_per_track",
-                         &TrackProblemFilterOptions::max_num_views_per_track);
+                         &TrackProblemFilterOptions::max_num_views_per_track)
+          .def_readwrite("two_view_depth_gate",
+                         &TrackProblemFilterOptions::two_view_depth_gate);
   MakeDataclass(PySubOpts);
 
   m.def("establish_full_tracks",
@@ -154,17 +175,21 @@ void BindTrackEstablishment(py::module& m) {
         "lc_second_pass"_a = false,
         "lc_correspondence_graph"_a = nullptr,
         "Build tracks from a CorrespondenceGraph + dict-of-images via "
-        "the union-find helper. When ``lc_second_pass=True``, "
+        "the union-find helper. The ``correspondence_graph`` should "
+        "contain only inlier correspondences (populated via "
+        "``add_two_view_geometry``). When ``lc_second_pass=True``, "
         "AppendLoopClosureObservations runs after to populate "
         "``Track::lc_elements`` from inliers flagged "
         "``ImagePair::are_lc==true`` in ``lc_correspondence_graph`` "
-        "(falls back to ``correspondence_graph`` if not provided).");
+        "(falls back to ``correspondence_graph`` if not provided). "
+        "The helper-side greedy selection is bypassed in LC mode.");
 
   m.def("find_tracks_for_problem",
         &RunFindTracksForProblem,
         "images"_a,
         "tracks_full"_a,
         "options"_a,
-        "Filter ``tracks_full`` for the optimization problem. Reads "
+        "Filter ``tracks_full`` to tracks eligible for the GP problem. Reads "
+        "``Image::depth_priors`` / ``Image::depth_prior_validity`` / "
         "registered image ids from the keys of the filtered ``images`` dict.");
 }

--- a/src/pycolmap/sfm/track_establishment.cc
+++ b/src/pycolmap/sfm/track_establishment.cc
@@ -49,10 +49,6 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
     images.emplace(py::cast<image_t>(item.first), py::cast<Image>(item.second));
   }
 
-  // Build keypoints map from ``Image::features``. The Reconstruction-based
-  // helper reads ``image.Points2D()`` instead; this dict-based entry point
-  // operates without a Reconstruction so it consumes the per-image
-  // ``features`` vector directly.
   std::unordered_map<image_t, std::vector<Eigen::Vector2d>>
       image_id_to_keypoints;
   image_id_to_keypoints.reserve(images.size());
@@ -69,8 +65,6 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
     TrackEstablishmentOptions to = options;
     MatchPredicate ignore_match;
     if (lc_second_pass) {
-      // When the LC pass is enabled, the caller owns subsampling, so the
-      // helper-side greedy gate is bypassed here.
       to.required_tracks_per_view = std::numeric_limits<int>::max();
       CorrespondenceGraph& lc_cg = lc_correspondence_graph
                                        ? *lc_correspondence_graph
@@ -84,8 +78,6 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
                                           to,
                                           ignore_match);
     if (lc_second_pass) {
-      // LC observations come from the separate LC correspondence graph which
-      // retains the matches/inliers/are_lc ImagePair fields.
       CorrespondenceGraph& lc_cg = lc_correspondence_graph
                                        ? *lc_correspondence_graph
                                        : correspondence_graph;
@@ -175,21 +167,18 @@ void BindTrackEstablishment(py::module& m) {
         "lc_second_pass"_a = false,
         "lc_correspondence_graph"_a = nullptr,
         "Build tracks from a CorrespondenceGraph + dict-of-images via "
-        "the union-find helper. The ``correspondence_graph`` should "
-        "contain only inlier correspondences (populated via "
-        "``add_two_view_geometry``). When ``lc_second_pass=True``, "
+        "the union-find helper. When ``lc_second_pass=True``, "
         "AppendLoopClosureObservations runs after to populate "
         "``Track::lc_elements`` from inliers flagged "
         "``ImagePair::are_lc==true`` in ``lc_correspondence_graph`` "
-        "(falls back to ``correspondence_graph`` if not provided). "
-        "The helper-side greedy selection is bypassed in LC mode.");
+        "(falls back to ``correspondence_graph`` if not provided).");
 
   m.def("find_tracks_for_problem",
         &RunFindTracksForProblem,
         "images"_a,
         "tracks_full"_a,
         "options"_a,
-        "Filter ``tracks_full`` to tracks eligible for the GP problem. Reads "
+        "Filter ``tracks_full`` for the optimization problem. Reads "
         "``Image::depth_priors`` / ``Image::depth_prior_validity`` / "
         "registered image ids from the keys of the filtered ``images`` dict.");
 }


### PR DESCRIPTION
## Summary

Full VideoSfM runtime slice on top of `move_upstream_lc`. This is the branch the current VideoSfM pipeline runs against. It keeps depth-specific behavior out of the lower PRs while preserving the complete runtime surface needed by VideoSfM.

## Main changes

- Adds depth runtime fields on native colmap image/track types: image depth priors, validity/stddev/outlier vectors, and per-observation GP routing flags on `TrackElement`.
- Adds metric-depth GP support: `MetricDepthError`, depth-map scale parameters, depth-outlier filtering, depth/loss cascade routing, split metric-depth constraints, and LC/depth loss routing.
- Adds the top-only track filtering extension: `TrackProblemFilterOptions` / `FindTracksForProblem` can apply the optional `two_view_depth_gate`.
- Keeps LC functionality inherited from #10 and generic helper/refactor work inherited from #8.
- Exposes depth/full-runtime options and fields through pycolmap for the VideoSfM caller migration.
- Keeps obsolete top-branch ImagePair fields (`pair_id`, `weight`, `cov_t`) out of the current runtime shape.

## Stack

- Base: #10, `move_upstream_lc` -> `move_upstream`
- This PR: `glomap-refactor-3` -> `move_upstream_lc`
- Below #10: #8, `move_upstream` -> `colmap4`

## Verification

Latest verified branch tip: `957a9329`.

- `build_cpp.sh` passed.
- `build_py.sh` passed.
- Targeted C++ tests passed: `rotation_averaging_test`, `global_mapper_test`, `correspondence_graph_test`, `track_establishment_test`, `image_pair_inliers_test`, `global_positioning_test`, `track_test`, `metric_depth_test`, `depth_prior_test`.
- Python depth/full API smoke passed.
- LC-only lower-branch smoke passed separately on #10 without depth.
- LaMAR HGE sample-10 passed: 25/25 registered, AUC `39.92 | 68.61 | 93.72 | 96.86 | 99.69`, recall `80 | 100 | 100 | 100 | 100`.
