### PR TITLE
move_upstream_lc: LC/sequence extensions on top of move_upstream

### DIFF
--- a/src/colmap/controllers/option_manager.cc
+++ b/src/colmap/controllers/option_manager.cc
@@ -715,6 +715,8 @@ void OptionManager::AddGlobalMapperOptions() {
                    &global_mapper->mapper.track_required_tracks_per_view);
   AddDefaultOption("GlobalMapper.track_min_num_views_per_track",
                    &global_mapper->mapper.track_min_num_views_per_track);
+  AddDefaultOption("GlobalMapper.track_lc_second_pass",
+                   &global_mapper->mapper.track_lc_second_pass);
 
   // Global positioning options.
   AddDefaultOption("GlobalMapper.gp_use_gpu",
@@ -728,9 +730,8 @@ void OptionManager::AddGlobalMapperOptions() {
                    &global_mapper->mapper.global_positioning.optimize_points);
   AddDefaultOption("GlobalMapper.gp_optimize_scales",
                    &global_mapper->mapper.global_positioning.optimize_scales);
-  AddDefaultOption(
-      "GlobalMapper.gp_loss_function_scale",
-      &global_mapper->mapper.global_positioning.loss.scale);
+  AddDefaultOption("GlobalMapper.gp_loss_function_scale",
+                   &global_mapper->mapper.global_positioning.loss.scale);
   AddDefaultOption("GlobalMapper.gp_max_num_iterations",
                    &global_mapper->mapper.global_positioning.solver_options
                         .max_num_iterations);
@@ -760,9 +761,8 @@ void OptionManager::AddGlobalMapperOptions() {
                    &global_mapper->mapper.bundle_adjustment.ceres->use_gpu);
   AddDefaultOption("GlobalMapper.ba_ceres_gpu_index",
                    &global_mapper->mapper.bundle_adjustment.ceres->gpu_index);
-  AddDefaultOption(
-      "GlobalMapper.ba_ceres_loss_function_scale",
-      &global_mapper->mapper.bundle_adjustment.ceres->loss.scale);
+  AddDefaultOption("GlobalMapper.ba_ceres_loss_function_scale",
+                   &global_mapper->mapper.bundle_adjustment.ceres->loss.scale);
   AddDefaultOption("GlobalMapper.ba_ceres_max_num_iterations",
                    &global_mapper->mapper.bundle_adjustment.ceres
                         ->solver_options.max_num_iterations);

--- a/src/colmap/controllers/option_manager_test.cc
+++ b/src/colmap/controllers/option_manager_test.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/controllers/option_manager.h"
 
+#include "colmap/controllers/global_pipeline.h"
 #include "colmap/controllers/image_reader.h"
 #include "colmap/controllers/incremental_pipeline.h"
 #include "colmap/feature/sift.h"
@@ -135,6 +136,7 @@ TEST(OptionManager, WriteAndRead) {
   options_write.feature_extraction->max_image_size = 2048;
   options_write.feature_extraction->sift->max_num_features = 4096;
   options_write.mapper->min_num_matches = 20;
+  options_write.global_mapper->mapper.track_lc_second_pass = true;
 
   // Write to file
   options_write.Write(config_path);
@@ -159,6 +161,8 @@ TEST(OptionManager, WriteAndRead) {
             options_write.feature_extraction->sift->max_num_features);
   EXPECT_EQ(options_read.mapper->min_num_matches,
             options_write.mapper->min_num_matches);
+  EXPECT_EQ(options_read.global_mapper->mapper.track_lc_second_pass,
+            options_write.global_mapper->mapper.track_lc_second_pass);
 }
 
 TEST(OptionManager, ReRead) {

--- a/src/colmap/controllers/rotation_averaging.cc
+++ b/src/colmap/controllers/rotation_averaging.cc
@@ -125,7 +125,9 @@ void RotationAveragingPipeline::Run() {
   if (!RunRotationAveraging(options.rotation_estimation,
                             pose_graph,
                             *reconstruction_,
-                            pose_priors)) {
+                            pose_priors,
+                            nullptr,
+                            database_cache_->CorrespondenceGraph().get())) {
     LOG(ERROR) << "Failed to solve rotation averaging";
     return;
   }

--- a/src/colmap/controllers/rotation_averaging_test.cc
+++ b/src/colmap/controllers/rotation_averaging_test.cc
@@ -115,6 +115,33 @@ TEST(RotationAveragingPipeline, WithNoiseAndOutliers) {
                        /*max_rotation_error_deg=*/3);
 }
 
+TEST(RotationAveragingPipeline, SkipRiskyLcPairsForwardsCorrespondenceGraph) {
+  SetPRNGSeed(1);
+
+  const auto database_path = CreateTestDir() / "database.db";
+
+  auto database = Database::Open(database_path);
+  Reconstruction gt_reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 5;
+  synthetic_dataset_options.num_points3D = 50;
+  SynthesizeDataset(
+      synthetic_dataset_options, &gt_reconstruction, database.get());
+
+  auto reconstruction = std::make_shared<Reconstruction>();
+
+  RotationAveragingPipelineOptions options;
+  options.rotation_estimation.skip_risky_lc_pairs = true;
+  RotationAveragingPipeline controller(options, database, reconstruction);
+  controller.Run();
+
+  ExpectEqualRotations(gt_reconstruction,
+                       *reconstruction,
+                       /*max_rotation_error_deg=*/1e-2);
+}
+
 void ExpectExactEqualRotations(const Reconstruction& reconstruction1,
                                const Reconstruction& reconstruction2) {
   const std::vector<image_t> reg_image_ids = reconstruction1.RegImageIds();

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -93,7 +93,10 @@ void GlobalPositioner::SetupProblem(const PoseGraph& pose_graph,
   frame_centers_.clear();
   cams_in_rig_.clear();
 
-  // Reserve to avoid pointer-invalidating reallocs.
+  // Reserve scales_ for both regular observations and lc_elements.
+  // Underestimating triggers ``vector::push_back`` reallocation mid-build,
+  // which invalidates the ``&scale`` data pointers that earlier residual
+  // blocks already stored.
   scales_.clear();
   size_t total_observations = 0;
   for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -84,13 +84,15 @@ void GlobalPositioner::SetupProblem(const PoseGraph& pose_graph,
   frame_centers_.clear();
   cams_in_rig_.clear();
 
-  // Allocate enough memory for the scales. One for each residual.
-  // Due to possibly invalid tracks, the actual number of residuals may be
-  // smaller.
+  // Reserve scales_ for both regular observations and lc_elements.
+  // Underestimating triggers ``vector::push_back`` reallocation mid-build,
+  // which invalidates the ``&scale`` data pointers that earlier residual
+  // blocks already stored.
   scales_.clear();
   size_t total_observations = 0;
   for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
     total_observations += point3D.track.Length();
+    total_observations += point3D.track.lc_elements.size();
   }
   scales_.reserve(total_observations);
 }
@@ -158,6 +160,10 @@ void GlobalPositioner::AddPointToCameraConstraints(
 
     AddPoint3DToProblem(point3D_id, reconstruction);
   }
+  VLOG(2) << "GP: residual blocks=" << problem_->NumResidualBlocks()
+          << ", parameter blocks=" << problem_->NumParameterBlocks()
+          << ", scales=" << scales_.size()
+          << ", frame_centers=" << frame_centers_.size();
 }
 
 void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
@@ -173,105 +179,128 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
     point3D.xyz = options_.random_init_scale * RandVector3d(-1, 1);
   }
 
-  // For each view in the track add the point to camera correspondences.
+  // Walk regular elements then LC elements as separate passes — they
+  // share the residual layout but route to different cascade buckets.
   for (const auto& observation : point3D.track.Elements()) {
-    if (!reconstruction.ExistsImage(observation.image_id)) continue;
-
-    Image& image = reconstruction.Image(observation.image_id);
-    if (!image.HasPose()) continue;
-
-    const std::optional<Eigen::Vector2d> cam_point =
-        image.CameraPtr()->CamFromImg(
-            image.Point2D(observation.point2D_idx).xy);
-    if (!cam_point.has_value()) {
-      LOG(WARNING)
-          << "Ignoring feature because it failed to project: point3D_id="
-          << point3D_id << ", image_id=" << observation.image_id
-          << ", feature_id=" << observation.point2D_idx;
-      continue;
+    AddObservationToProblem(point3D_id,
+                            observation,
+                            /*is_lc_observation=*/false,
+                            random_initialization,
+                            reconstruction);
+  }
+  if (options_.use_lc_observations) {
+    for (const auto& observation : point3D.track.lc_elements) {
+      AddObservationToProblem(point3D_id,
+                              observation,
+                              /*is_lc_observation=*/true,
+                              random_initialization,
+                              reconstruction);
     }
+  }
+}
 
-    const Eigen::Vector3d cam_from_point3D_dir =
-        image.CamFromWorld().rotation().inverse() *
-        cam_point->homogeneous().normalized();
+void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
+                                               const TrackElement& observation,
+                                               bool is_lc_observation,
+                                               bool random_initialization,
+                                               Reconstruction& reconstruction) {
+  Point3D& point3D = reconstruction.Point3D(point3D_id);
+  if (!reconstruction.ExistsImage(observation.image_id)) return;
 
-    CHECK_GE(scales_.capacity(), scales_.size())
-        << "Not enough capacity was reserved for the scales.";
-    double& scale = scales_.emplace_back(1);
+  Image& image = reconstruction.Image(observation.image_id);
+  if (!image.HasPose()) return;
 
-    if (!options_.generate_scales && random_initialization) {
-      const Eigen::Vector3d cam_from_point3D_translation =
-          point3D.xyz - frame_centers_[image.FrameId()];
-      scale = std::max(1e-5,
-                       cam_from_point3D_dir.dot(cam_from_point3D_translation) /
-                           cam_from_point3D_translation.squaredNorm());
-    }
+  const std::optional<Eigen::Vector2d> cam_point =
+      image.CameraPtr()->CamFromImg(
+          image.Point2D(observation.point2D_idx).xy);
+  if (!cam_point.has_value()) {
+    LOG(WARNING)
+        << "Ignoring feature because it failed to project: point3D_id="
+        << point3D_id << ", image_id=" << observation.image_id
+        << ", feature_id=" << observation.point2D_idx;
+    return;
+  }
 
-    // For calibrated and uncalibrated cameras, use different loss
-    // functions
-    // Down weight the uncalibrated cameras
-    Camera& camera = reconstruction.Camera(image.CameraId());
-    ceres::LossFunction* loss_function =
-        (camera.has_prior_focal_length)
-            ? loss_function_ptcam_calibrated_.get()
-            : loss_function_ptcam_uncalibrated_.get();
+  const Eigen::Vector3d cam_from_point3D_dir =
+      image.CamFromWorld().rotation().inverse() *
+      cam_point->homogeneous().normalized();
 
-    // If the image is not part of a camera rig, use the standard BATA error
-    if (image.IsRefInFrame()) {
+  CHECK_GE(scales_.capacity(), scales_.size())
+      << "Not enough capacity was reserved for the scales.";
+  double& scale = scales_.emplace_back(1);
+
+  if (!options_.generate_scales && random_initialization) {
+    const Eigen::Vector3d cam_from_point3D_translation =
+        point3D.xyz - frame_centers_[image.FrameId()];
+    scale = std::max(1e-5,
+                     cam_from_point3D_dir.dot(cam_from_point3D_translation) /
+                         cam_from_point3D_translation.squaredNorm());
+  }
+
+  // For calibrated and uncalibrated cameras, use different loss
+  // functions
+  // Down weight the uncalibrated cameras
+  Camera& camera = reconstruction.Camera(image.CameraId());
+  ceres::LossFunction* loss_function =
+      (camera.has_prior_focal_length)
+          ? loss_function_ptcam_calibrated_.get()
+          : loss_function_ptcam_uncalibrated_.get();
+
+  // If the image is not part of a camera rig, use the standard BATA error
+  if (image.IsRefInFrame()) {
+    ceres::CostFunction* cost_function =
+        BATAPairwiseDirectionCostFunctor::Create(cam_from_point3D_dir);
+
+    problem_->AddResidualBlock(cost_function,
+                               loss_function,
+                               frame_centers_[image.FrameId()].data(),
+                               point3D.xyz.data(),
+                               &scale);
+  } else {
+    // If the image is part of a camera rig, use the RigBATA error.
+
+    const rig_t rig_id = image.FramePtr()->RigId();
+    Rig& rig = reconstruction.Rig(rig_id);
+    Rigid3d& cam_from_rig = rig.SensorFromRig(image.CameraPtr()->SensorId());
+
+    if (!cam_from_rig.translation().hasNaN()) {
+      const Eigen::Vector3d cam_from_rig_dir =
+          image.CamFromWorld().rotation().inverse() *
+          cam_from_rig.translation();
+
       ceres::CostFunction* cost_function =
-          BATAPairwiseDirectionCostFunctor::Create(cam_from_point3D_dir);
+          RigBATAPairwiseDirectionConstantRigCostFunctor::Create(
+              cam_from_point3D_dir, cam_from_rig_dir);
 
       problem_->AddResidualBlock(cost_function,
                                  loss_function,
-                                 frame_centers_[image.FrameId()].data(),
                                  point3D.xyz.data(),
+                                 frame_centers_[image.FrameId()].data(),
                                  &scale);
     } else {
-      // If the image is part of a camera rig, use the RigBATA error.
-
-      const rig_t rig_id = image.FramePtr()->RigId();
-      Rig& rig = reconstruction.Rig(rig_id);
-      Rigid3d& cam_from_rig = rig.SensorFromRig(image.CameraPtr()->SensorId());
-
-      if (!cam_from_rig.translation().hasNaN()) {
-        const Eigen::Vector3d cam_from_rig_dir =
-            image.CamFromWorld().rotation().inverse() *
-            cam_from_rig.translation();
-
-        ceres::CostFunction* cost_function =
-            RigBATAPairwiseDirectionConstantRigCostFunctor::Create(
-                cam_from_point3D_dir, cam_from_rig_dir);
-
-        problem_->AddResidualBlock(cost_function,
-                                   loss_function,
-                                   point3D.xyz.data(),
-                                   frame_centers_[image.FrameId()].data(),
-                                   &scale);
-      } else {
-        // If the cam_from_rig contains nan values, it needs to be re-estimated.
-        // Initialize cams_in_rig_ if not already done.
-        const sensor_t sensor_id = image.CameraPtr()->SensorId();
-        if (cams_in_rig_.find(sensor_id) == cams_in_rig_.end()) {
-          // Will be initialized to random values in ParameterizeVariables().
-          cams_in_rig_[sensor_id] = Eigen::Vector3d::Zero();
-        }
-
-        ceres::CostFunction* cost_function =
-            RigBATAPairwiseDirectionCostFunctor::Create(
-                cam_from_point3D_dir,
-                image.FramePtr()->RigFromWorld().rotation());
-
-        problem_->AddResidualBlock(cost_function,
-                                   loss_function,
-                                   point3D.xyz.data(),
-                                   frame_centers_[image.FrameId()].data(),
-                                   cams_in_rig_[sensor_id].data(),
-                                   &scale);
+      // If the cam_from_rig contains nan values, it needs to be re-estimated.
+      // Initialize cams_in_rig_ if not already done.
+      const sensor_t sensor_id = image.CameraPtr()->SensorId();
+      if (cams_in_rig_.find(sensor_id) == cams_in_rig_.end()) {
+        // Will be initialized to random values in ParameterizeVariables().
+        cams_in_rig_[sensor_id] = Eigen::Vector3d::Zero();
       }
-    }
 
-    problem_->SetParameterLowerBound(&scale, 0, 1e-5);
+      ceres::CostFunction* cost_function =
+          RigBATAPairwiseDirectionCostFunctor::Create(
+              cam_from_point3D_dir,
+              image.FramePtr()->RigFromWorld().rotation());
+
+      problem_->AddResidualBlock(cost_function,
+                                 loss_function,
+                                 point3D.xyz.data(),
+                                 frame_centers_[image.FrameId()].data(),
+                                 cams_in_rig_[sensor_id].data(),
+                                 &scale);
+    }
   }
+
+  problem_->SetParameterLowerBound(&scale, 0, 1e-5);
 }
 
 void GlobalPositioner::AddCamerasAndPointsToParameterGroups(

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -379,7 +379,7 @@ void GlobalPositioner::ParameterizeVariables(Reconstruction& reconstruction) {
     }
   }
 
-  // If do not optimize the points, set the points to be constant
+  // If do not optimize the rotations, set the camera rotations to be constant
   if (!options_.optimize_points) {
     for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
       if (problem_->HasParameterBlock(point3D.xyz.data())) {

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -151,7 +151,9 @@ void GlobalPositioner::AddPointToCameraConstraints(
   // Down-weight uncalibrated cameras.
   if (options_.apply_uncalibrated_loss_downweight) {
     loss_function_ptcam_uncalibrated_ = std::make_shared<ceres::ScaledLoss>(
-        loss_function_.get(), 0.5, ceres::DO_NOT_TAKE_OWNERSHIP);
+        loss_function_.get(),
+        options_.uncalibrated_loss_downweight,
+        ceres::DO_NOT_TAKE_OWNERSHIP);
   } else {
     loss_function_ptcam_uncalibrated_ = loss_function_;
   }
@@ -189,7 +191,6 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
   for (const auto& observation : point3D.track.Elements()) {
     AddObservationToProblem(point3D_id,
                             observation,
-                            /*is_lc_observation=*/false,
                             random_initialization,
                             reconstruction);
   }
@@ -197,7 +198,6 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
     for (const auto& observation : point3D.track.lc_elements) {
       AddObservationToProblem(point3D_id,
                               observation,
-                              /*is_lc_observation=*/true,
                               random_initialization,
                               reconstruction);
     }
@@ -206,7 +206,6 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
 
 void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                                const TrackElement& observation,
-                                               bool is_lc_observation,
                                                bool random_initialization,
                                                Reconstruction& reconstruction) {
   Point3D& point3D = reconstruction.Point3D(point3D_id);

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -185,7 +185,7 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
   }
 
   // Walk regular elements then LC elements as separate passes — they
-  // share the residual layout but route to different cascade buckets.
+  // share the residual layout but use different loss function groups.
   for (const auto& observation : point3D.track.Elements()) {
     AddObservationToProblem(point3D_id,
                             observation,
@@ -368,7 +368,7 @@ void GlobalPositioner::ParameterizeVariables(Reconstruction& reconstruction) {
     }
   }
 
-  // If do not optimize the rotations, set the camera rotations to be constant
+  // If do not optimize the points, set the points to be constant
   if (!options_.optimize_points) {
     for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
       if (problem_->HasParameterBlock(point3D.xyz.data())) {

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -118,6 +118,14 @@ void GlobalPositioner::InitializeRandomPositions(
       if (!image.HasPose()) continue;
       constrained_positions.insert(image.FrameId());
     }
+    if (options_.use_lc_observations) {
+      for (const auto& observation : point3D.track.lc_elements) {
+        if (!reconstruction.ExistsImage(observation.image_id)) continue;
+        const Image& image = reconstruction.Image(observation.image_id);
+        if (!image.HasPose()) continue;
+        constrained_positions.insert(image.FrameId());
+      }
+    }
   }
 
   // Initialize frame centers in temporary storage.

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -84,10 +84,7 @@ void GlobalPositioner::SetupProblem(const PoseGraph& pose_graph,
   frame_centers_.clear();
   cams_in_rig_.clear();
 
-  // Reserve scales_ for both regular observations and lc_elements.
-  // Underestimating triggers ``vector::push_back`` reallocation mid-build,
-  // which invalidates the ``&scale`` data pointers that earlier residual
-  // blocks already stored.
+  // Reserve to avoid pointer-invalidating reallocs.
   scales_.clear();
   size_t total_observations = 0;
   for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -15,6 +15,11 @@ Eigen::Vector3d RandVector3d(double low, double high) {
                          RandomUniformReal(low, high));
 }
 
+bool IsLossConfigOverride(const LossConfig& loss_config) {
+  return loss_config.type != LossFunctionType::TRIVIAL ||
+         loss_config.scale != 1.0 || loss_config.weight != 1.0;
+}
+
 }  // namespace
 
 GlobalPositioner::GlobalPositioner(const GlobalPositionerOptions& options)
@@ -79,6 +84,10 @@ void GlobalPositioner::SetupProblem(const PoseGraph& pose_graph,
   problem_options.loss_function_ownership = ceres::DO_NOT_TAKE_OWNERSHIP;
   problem_ = std::make_unique<ceres::Problem>(problem_options);
   loss_function_ = options_.CreateLossFunction();
+  cached_loss_lc_geometry_ =
+      IsLossConfigOverride(options_.loss_lc_geometry)
+          ? options_.loss_lc_geometry.CreateLossFunction()
+          : nullptr;
 
   // Clear temporary storage from previous runs.
   frame_centers_.clear();
@@ -195,8 +204,11 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
   }
   if (options_.use_lc_observations) {
     for (const auto& observation : point3D.track.lc_elements) {
-      AddObservationToProblem(
-          point3D_id, observation, random_initialization, reconstruction);
+      AddObservationToProblem(point3D_id,
+                              observation,
+                              random_initialization,
+                              reconstruction,
+                              /*is_lc_observation=*/true);
     }
   }
 }
@@ -204,7 +216,8 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
 void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                                const TrackElement& observation,
                                                bool random_initialization,
-                                               Reconstruction& reconstruction) {
+                                               Reconstruction& reconstruction,
+                                               bool is_lc_observation) {
   Point3D& point3D = reconstruction.Point3D(point3D_id);
   if (!reconstruction.ExistsImage(observation.image_id)) return;
 
@@ -243,6 +256,9 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   ceres::LossFunction* loss_function =
       (camera.has_prior_focal_length) ? loss_function_ptcam_calibrated_.get()
                                       : loss_function_ptcam_uncalibrated_.get();
+  if (is_lc_observation && cached_loss_lc_geometry_) {
+    loss_function = cached_loss_lc_geometry_.get();
+  }
 
   // If the image is not part of a camera rig, use the standard BATA error
   if (image.IsRefInFrame()) {

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -103,9 +103,7 @@ class GlobalPositioner {
   void AddPoint3DToProblem(point3D_t point3D_id,
                            Reconstruction& reconstruction);
 
-  // Add a single observation (regular or LC) for one point3D. The
-  // ``is_lc_observation`` flag selects which loss bucket the cascade
-  // routes to.
+  // Add one observation; is_lc_observation selects the loss bucket.
   void AddObservationToProblem(point3D_t point3D_id,
                                const TrackElement& observation,
                                bool is_lc_observation,

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -64,9 +64,8 @@ struct GlobalPositionerOptions {
   // Cube half-extent for random initialization of positions and points.
   double random_init_scale = 100.0;
 
-  // Per-observation loss configs for LC routing.
+  // Per-observation geometry loss config for LC routing.
   LossConfig loss_lc_geometry;
-  LossConfig loss_lc_depth;
 
   GlobalPositionerOptions() {
     solver_options.num_threads = -1;
@@ -109,7 +108,8 @@ class GlobalPositioner {
   void AddObservationToProblem(point3D_t point3D_id,
                                const TrackElement& observation,
                                bool random_initialization,
-                               Reconstruction& reconstruction);
+                               Reconstruction& reconstruction,
+                               bool is_lc_observation = false);
 
   // Set the parameter groups
   void AddCamerasAndPointsToParameterGroups(Reconstruction& reconstruction);
@@ -129,6 +129,7 @@ class GlobalPositioner {
   std::shared_ptr<ceres::LossFunction> loss_function_;
   std::shared_ptr<ceres::LossFunction> loss_function_ptcam_uncalibrated_;
   std::shared_ptr<ceres::LossFunction> loss_function_ptcam_calibrated_;
+  std::shared_ptr<ceres::LossFunction> cached_loss_lc_geometry_;
 
   // Auxiliary scale variables.
   std::vector<double> scales_;

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -48,6 +48,9 @@ struct GlobalPositionerOptions {
   // Apply 0.5x ScaledLoss to BATA residuals from cameras without an EXIF
   // focal-length prior.
   bool apply_uncalibrated_loss_downweight = true;
+  // Scale factor applied to the loss of uncalibrated cameras when
+  // apply_uncalibrated_loss_downweight is true.
+  double uncalibrated_loss_downweight = 0.5;
 
   // The options for the solver
   ceres::Solver::Options solver_options;
@@ -103,10 +106,8 @@ class GlobalPositioner {
   void AddPoint3DToProblem(point3D_t point3D_id,
                            Reconstruction& reconstruction);
 
-  // Add one observation; is_lc_observation selects the loss bucket.
   void AddObservationToProblem(point3D_t point3D_id,
                                const TrackElement& observation,
-                               bool is_lc_observation,
                                bool random_initialization,
                                Reconstruction& reconstruction);
 

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -4,8 +4,10 @@
 #include "colmap/scene/pose_graph.h"
 #include "colmap/scene/reconstruction.h"
 
+#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 #include <ceres/ceres.h>
 
@@ -47,14 +49,21 @@ struct GlobalPositionerOptions {
   // focal-length prior.
   bool apply_uncalibrated_loss_downweight = true;
 
+  // The options for the solver
+  ceres::Solver::Options solver_options;
+
+  // Include loop-closure observations in point3D problems.
+  bool use_lc_observations = false;
+
   // Skip random initialization and reuse existing positions/points.
   bool use_init = false;
 
   // Cube half-extent for random initialization of positions and points.
   double random_init_scale = 100.0;
 
-  // The options for the solver
-  ceres::Solver::Options solver_options;
+  // Per-observation loss configs for LC routing.
+  LossConfig loss_lc_geometry;
+  LossConfig loss_lc_depth;
 
   GlobalPositionerOptions() {
     solver_options.num_threads = -1;
@@ -93,6 +102,15 @@ class GlobalPositioner {
   // Add a single point3D to the problem
   void AddPoint3DToProblem(point3D_t point3D_id,
                            Reconstruction& reconstruction);
+
+  // Add a single observation (regular or LC) for one point3D. The
+  // ``is_lc_observation`` flag selects which loss bucket the cascade
+  // routes to.
+  void AddObservationToProblem(point3D_t point3D_id,
+                               const TrackElement& observation,
+                               bool is_lc_observation,
+                               bool random_initialization,
+                               Reconstruction& reconstruction);
 
   // Set the parameter groups
   void AddCamerasAndPointsToParameterGroups(Reconstruction& reconstruction);

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -42,12 +42,14 @@ bool AllSensorsFromRigKnown(const std::unordered_map<rig_t, Rig>& rigs) {
   return all_known;
 }
 
-// Compute maximum spanning tree of the pose graph weighted by match count.
-// Returns the root image_id and populates the parents map.
+}  // namespace
+
 image_t ComputeMaximumPoseGraphSpanningTree(
     const PoseGraph& pose_graph,
     const std::unordered_set<image_t>& image_ids,
-    std::unordered_map<image_t, image_t>& parents) {
+    std::unordered_map<image_t, image_t>& parents,
+    bool prioritize_tracking,
+    const CorrespondenceGraph* correspondence_graph) {
   // Build mapping between image_id and contiguous indices.
   std::unordered_map<image_t, int> image_id_to_idx;
   std::vector<image_t> idx_to_image_id;
@@ -64,6 +66,21 @@ image_t ComputeMaximumPoseGraphSpanningTree(
   std::vector<float> weights;
   edges.reserve(pose_graph.NumEdges());
   weights.reserve(pose_graph.NumEdges());
+
+  // Edge weight = inlier count when a CorrespondenceGraph is plumbed
+  // through (post-RANSAC survivor count, matches the inlier-count semantic),
+  // falling back to ``edge.num_matches`` (raw match count) otherwise so
+  // mainline colmap callers without a CG keep their existing behavior.
+  //
+  // When ``prioritize_tracking`` is also enabled, LC-dominated edges
+  // additionally have ``kLCPenalty`` subtracted so the spanning tree
+  // picks tracking-dominated edges as parents.
+  constexpr float kLCPenalty = 1e9f;
+  const auto* cg_map_ptr =
+      (correspondence_graph != nullptr)
+          ? &correspondence_graph->ImagePairsMap()
+          : nullptr;
+
   for (const auto& [pair_id, edge] : pose_graph.ValidEdges()) {
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
     const auto it1 = image_id_to_idx.find(image_id1);
@@ -72,7 +89,29 @@ image_t ComputeMaximumPoseGraphSpanningTree(
       continue;
     }
     edges.emplace_back(it1->second, it2->second);
-    weights.push_back(static_cast<float>(edge.num_matches));
+    const CorrespondenceGraph::ImagePair* cg_pair_ptr = nullptr;
+    if (cg_map_ptr != nullptr) {
+      auto cg_pair_it = cg_map_ptr->find(pair_id);
+      if (cg_pair_it != cg_map_ptr->end()) {
+        cg_pair_ptr = &cg_pair_it->second;
+      }
+    }
+    float w = (cg_pair_ptr != nullptr)
+                  ? static_cast<float>(cg_pair_ptr->inliers.size())
+                  : static_cast<float>(edge.num_matches);
+    if (prioritize_tracking && cg_pair_ptr != nullptr &&
+        !cg_pair_ptr->inliers.empty() && !cg_pair_ptr->are_lc.empty()) {
+      size_t lc_count = 0;
+      for (const auto idx : cg_pair_ptr->inliers) {
+        if (idx < cg_pair_ptr->are_lc.size() && cg_pair_ptr->are_lc[idx]) {
+          ++lc_count;
+        }
+      }
+      if (lc_count > cg_pair_ptr->inliers.size() - lc_count) {
+        w -= kLCPenalty;
+      }
+    }
+    weights.push_back(w);
   }
 
   // Compute spanning tree using generic algorithm.
@@ -89,6 +128,8 @@ image_t ComputeMaximumPoseGraphSpanningTree(
 
   return idx_to_image_id[tree.root];
 }
+
+namespace {
 
 // Computes the largest connected component and returns image ids.
 std::unordered_set<image_t> ComputeLargestConnectedComponentImageIds(
@@ -269,7 +310,9 @@ bool RotationEstimator::EstimateRotations(
     const PoseGraph& pose_graph,
     const std::vector<PosePrior>& pose_priors,
     const std::unordered_set<image_t>& active_image_ids,
-    Reconstruction& reconstruction) {
+    Reconstruction& reconstruction,
+    std::unordered_map<image_pair_t, double>* final_weights,
+    const CorrespondenceGraph* correspondence_graph) {
   if (UseGravity(options_, pose_priors) &&
       !AllSensorsFromRigKnown(reconstruction.Rigs())) {
     return false;
@@ -284,8 +327,12 @@ bool RotationEstimator::EstimateRotations(
   }
 
   // Solve the full system.
-  if (!SolveRotationAveraging(
-          pose_graph, pose_priors, active_image_ids, reconstruction)) {
+  if (!SolveRotationAveraging(pose_graph,
+                              pose_priors,
+                              active_image_ids,
+                              reconstruction,
+                              final_weights,
+                              correspondence_graph)) {
     return false;
   }
 
@@ -395,18 +442,24 @@ bool RotationEstimator::SolveRotationAveraging(
     const PoseGraph& pose_graph,
     const std::vector<PosePrior>& pose_priors,
     const std::unordered_set<image_t>& active_image_ids,
-    Reconstruction& reconstruction) {
+    Reconstruction& reconstruction,
+    std::unordered_map<image_pair_t, double>* final_weights,
+    const CorrespondenceGraph* correspondence_graph) {
   // Initialize rotations from maximum spanning tree. Note that without
   // intialization, the gravity-aligned rotation averaging is prone to random
   // flips by 180deg.
   if (!options_.skip_initialization) {
     InitializeFromMaximumSpanningTree(
-        pose_graph, active_image_ids, reconstruction);
+        pose_graph, active_image_ids, reconstruction, correspondence_graph);
   }
 
   // Build the optimization problem.
-  RotationAveragingProblem problem(
-      pose_graph, pose_priors, options_, active_image_ids, reconstruction);
+  RotationAveragingProblem problem(pose_graph,
+                                   pose_priors,
+                                   options_,
+                                   active_image_ids,
+                                   reconstruction,
+                                   correspondence_graph);
 
   // Solve and apply results.
   RotationAveragingSolver solver(options_);
@@ -421,11 +474,16 @@ bool RotationEstimator::SolveRotationAveraging(
 void RotationEstimator::InitializeFromMaximumSpanningTree(
     const PoseGraph& pose_graph,
     const std::unordered_set<image_t>& active_image_ids,
-    Reconstruction& reconstruction) {
+    Reconstruction& reconstruction,
+    const CorrespondenceGraph* correspondence_graph) {
   // Compute maximum spanning tree over active images.
   std::unordered_map<image_t, image_t> parents;
   const image_t root = ComputeMaximumPoseGraphSpanningTree(
-      pose_graph, active_image_ids, parents);
+      pose_graph,
+      active_image_ids,
+      parents,
+      /*prioritize_tracking=*/options_.use_video_constraints,
+      correspondence_graph);
   THROW_CHECK(active_image_ids.count(root));
 
   // Iterate through the tree to initialize the rotation.
@@ -443,6 +501,11 @@ void RotationEstimator::InitializeFromMaximumSpanningTree(
   std::queue<image_t> indexes;
   indexes.push(root);
 
+  // Seed the root from its current reconstruction pose so the BFS
+  // propagates relative rotations on top of the MDRP-prior root frame
+  // instead of identity. Without this, every descendant is rotated by
+  // R_root^-1 relative to the prior gauge, which can shift IRLS
+  // weights through the ``max_rotation_error_deg`` filter.
   std::unordered_map<image_t, Rigid3d> cams_from_world;
   const auto& root_image = reconstruction.Image(root);
   cams_from_world[root] =
@@ -578,10 +641,13 @@ bool InitializeRigRotationsFromImages(
   return true;
 }
 
-bool RunRotationAveraging(const RotationEstimatorOptions& options,
-                          PoseGraph& pose_graph,
-                          Reconstruction& reconstruction,
-                          const std::vector<PosePrior>& pose_priors) {
+bool RunRotationAveraging(
+    const RotationEstimatorOptions& options,
+    PoseGraph& pose_graph,
+    Reconstruction& reconstruction,
+    const std::vector<PosePrior>& pose_priors,
+    std::unordered_map<image_pair_t, double>* final_weights,
+    const CorrespondenceGraph* correspondence_graph) {
   std::unordered_set<image_t> active_image_ids;
 
   // Step 1: Solve rotation averaging on the largest connected component.
@@ -598,8 +664,12 @@ bool RunRotationAveraging(const RotationEstimatorOptions& options,
     pose_graph.InvalidatePairsOutsideActiveImageIds(active_image_ids);
 
     RotationEstimator rotation_estimator(options);
-    if (!rotation_estimator.EstimateRotations(
-            pose_graph, pose_priors, active_image_ids, reconstruction)) {
+    if (!rotation_estimator.EstimateRotations(pose_graph,
+                                              pose_priors,
+                                              active_image_ids,
+                                              reconstruction,
+                                              final_weights,
+                                              correspondence_graph)) {
       return false;
     }
   } else {
@@ -659,8 +729,12 @@ bool RunRotationAveraging(const RotationEstimatorOptions& options,
     options_ra.skip_initialization = true;
     options_ra.use_stratified = false;
     RotationEstimator rotation_estimator(options_ra);
-    if (!rotation_estimator.EstimateRotations(
-            pose_graph, pose_priors, active_image_ids, reconstruction)) {
+    if (!rotation_estimator.EstimateRotations(pose_graph,
+                                              pose_priors,
+                                              active_image_ids,
+                                              reconstruction,
+                                              final_weights,
+                                              correspondence_graph)) {
       return false;
     }
   }

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -67,8 +67,14 @@ image_t ComputeMaximumPoseGraphSpanningTree(
   edges.reserve(pose_graph.NumEdges());
   weights.reserve(pose_graph.NumEdges());
 
-  // Weight = CG inlier count if available, else num_matches.
-  // LC-dominated edges get penalized when prioritize_tracking is set.
+  // Edge weight = inlier count when a CorrespondenceGraph is plumbed
+  // through (post-RANSAC survivor count, matches the inlier-count semantic),
+  // falling back to ``edge.num_matches`` (raw match count) otherwise so
+  // mainline colmap callers without a CG keep their existing behavior.
+  //
+  // When ``prioritize_tracking`` is also enabled, LC-dominated edges
+  // additionally have ``kLCPenalty`` subtracted so the spanning tree
+  // picks tracking-dominated edges as parents.
   constexpr float kLCPenalty = 1e9f;
   const auto* cg_map_ptr = (correspondence_graph != nullptr)
                                ? &correspondence_graph->ImagePairsMap()

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -67,14 +67,8 @@ image_t ComputeMaximumPoseGraphSpanningTree(
   edges.reserve(pose_graph.NumEdges());
   weights.reserve(pose_graph.NumEdges());
 
-  // Edge weight = inlier count when a CorrespondenceGraph is plumbed
-  // through (post-RANSAC survivor count, matches the inlier-count semantic),
-  // falling back to ``edge.num_matches`` (raw match count) otherwise so
-  // mainline colmap callers without a CG keep their existing behavior.
-  //
-  // When ``prioritize_tracking`` is also enabled, LC-dominated edges
-  // additionally have ``kLCPenalty`` subtracted so the spanning tree
-  // picks tracking-dominated edges as parents.
+  // Weight = CG inlier count if available, else num_matches.
+  // LC-dominated edges get penalized when prioritize_tracking is set.
   constexpr float kLCPenalty = 1e9f;
   const auto* cg_map_ptr =
       (correspondence_graph != nullptr)

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -501,11 +501,6 @@ void RotationEstimator::InitializeFromMaximumSpanningTree(
   std::queue<image_t> indexes;
   indexes.push(root);
 
-  // Seed the root from its current reconstruction pose so the BFS
-  // propagates relative rotations on top of the MDRP-prior root frame
-  // instead of identity. Without this, every descendant is rotated by
-  // R_root^-1 relative to the prior gauge, which can shift IRLS
-  // weights through the ``max_rotation_error_deg`` filter.
   std::unordered_map<image_t, Rigid3d> cams_from_world;
   const auto& root_image = reconstruction.Image(root);
   cams_from_world[root] =

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -94,16 +94,8 @@ image_t ComputeMaximumPoseGraphSpanningTree(
                   ? static_cast<float>(cg_pair_ptr->inliers.size())
                   : static_cast<float>(edge.num_matches);
     if (prioritize_tracking && cg_pair_ptr != nullptr &&
-        !cg_pair_ptr->inliers.empty() && !cg_pair_ptr->are_lc.empty()) {
-      size_t lc_count = 0;
-      for (const auto idx : cg_pair_ptr->inliers) {
-        if (idx < cg_pair_ptr->are_lc.size() && cg_pair_ptr->are_lc[idx]) {
-          ++lc_count;
-        }
-      }
-      if (lc_count > cg_pair_ptr->inliers.size() - lc_count) {
-        w -= kLCPenalty;
-      }
+        !IsTrackingPair(*cg_pair_ptr)) {
+      w -= kLCPenalty;
     }
     weights.push_back(w);
   }

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -305,8 +305,11 @@ bool RotationEstimator::EstimateRotations(
 
   // Handle stratified solving for mixed gravity systems.
   if (UseGravity(options_, pose_priors) && options_.use_stratified) {
-    if (!MaybeSolveGravityAlignedSubset(
-            pose_graph, pose_priors, active_image_ids, reconstruction)) {
+    if (!MaybeSolveGravityAlignedSubset(pose_graph,
+                                        pose_priors,
+                                        active_image_ids,
+                                        reconstruction,
+                                        correspondence_graph)) {
       return false;
     }
   }
@@ -335,7 +338,8 @@ bool RotationEstimator::MaybeSolveGravityAlignedSubset(
     const PoseGraph& pose_graph,
     const std::vector<PosePrior>& pose_priors,
     const std::unordered_set<image_t>& active_image_ids,
-    Reconstruction& reconstruction) {
+    Reconstruction& reconstruction,
+    const CorrespondenceGraph* correspondence_graph) {
   // Build map from image to pose prior.
   std::unordered_map<image_t, const PosePrior*> image_to_pose_prior;
   for (const auto& pose_prior : pose_priors) {
@@ -398,7 +402,9 @@ bool RotationEstimator::MaybeSolveGravityAlignedSubset(
     if (!SolveRotationAveraging(gravity_pose_graph,
                                 pose_priors,
                                 gravity_image_ids,
-                                gravity_reconstruction)) {
+                                gravity_reconstruction,
+                                nullptr,
+                                correspondence_graph)) {
       return false;
     }
 

--- a/src/colmap/estimators/rotation_averaging.cc
+++ b/src/colmap/estimators/rotation_averaging.cc
@@ -676,7 +676,9 @@ bool RunRotationAveraging(
             pose_graph,
             pose_priors,
             expanded_active_image_ids,
-            recon_expanded)) {
+            recon_expanded,
+            nullptr,
+            correspondence_graph)) {
       return false;
     }
 

--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -89,8 +89,10 @@ class RotationEstimator {
   explicit RotationEstimator(const RotationEstimatorOptions& options)
       : options_(options) {}
 
-  // Estimate global orientations for active_image_ids.
-  // Returns true on success.
+  // Estimates the global orientations of all views.
+  // Solves rotation averaging and registers frames with computed poses.
+  // active_image_ids defines which images to include.
+  // Returns true on successful estimation.
   bool EstimateRotations(
       const PoseGraph& pose_graph,
       const std::vector<PosePrior>& pose_priors,
@@ -118,7 +120,7 @@ class RotationEstimator {
       std::unordered_map<image_pair_t, double>* final_weights = nullptr,
       const class CorrespondenceGraph* correspondence_graph = nullptr);
 
-  // Initialize rotations from maximum spanning tree.
+  // Initializes rotations from maximum spanning tree.
   void InitializeFromMaximumSpanningTree(
       const PoseGraph& pose_graph,
       const std::unordered_set<image_t>& active_image_ids,
@@ -135,7 +137,10 @@ bool InitializeRigRotationsFromImages(
     const std::unordered_map<image_t, Rigid3d>& cams_from_world,
     Reconstruction& reconstruction);
 
-// High-level rotation averaging with rig expansion for unknown cam_from_rig.
+// High-level rotation averaging solver that handles rig expansion.
+// For cameras with unknown cam_from_rig, first estimates their orientations
+// independently using an expanded reconstruction, then initializes the
+// cam_from_rig and runs rotation averaging on the original reconstruction.
 bool RunRotationAveraging(
     const RotationEstimatorOptions& options,
     PoseGraph& pose_graph,

--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -143,7 +143,7 @@ bool RunRotationAveraging(
     std::unordered_map<image_pair_t, double>* final_weights = nullptr,
     const class CorrespondenceGraph* correspondence_graph = nullptr);
 
-// MST weighted by match count. When prioritize_tracking is set and a
+// MST weighted by inlier count. When prioritize_tracking is set and a
 // CorrespondenceGraph is provided, LC-dominated edges are penalized.
 image_t ComputeMaximumPoseGraphSpanningTree(
     const PoseGraph& pose_graph,

--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -67,6 +67,26 @@ struct RotationEstimatorOptions {
   // If > 0, filter image pairs with rotation error exceeding this threshold
   // after solving, then recompute active set.
   double max_rotation_error_deg = 10.0;
+
+  // Optional extensions (default OFF; disabled = baseline RA).
+
+  // If true, drop pairs whose loop-closure inlier count exceeds non-LC
+  // inliers — prevents LC-contaminated pairs from breaking RA. Consumed by
+  // BuildPairConstraints in rotation_averaging_impl.cc when a
+  // CorrespondenceGraph& is plumbed through.
+  bool skip_risky_LC_pairs = false;
+
+  // If true, switch from L1 + IRLS to a Ceres-based solver with differential
+  // loss functions (Huber for tracking pairs, Cauchy for LC pairs). Mutually
+  // exclusive with use_gravity. Also gates the MST initializer's LC-edge
+  // penalty: when true, ``ComputeMaximumPoseGraphSpanningTree`` subtracts
+  // kLCPenalty=1e9 from LC-dominated edges so the tree routes through
+  // tracking pairs first.
+  bool use_video_constraints = false;
+
+  // Loss scales for the video-aware Ceres solver.
+  double video_tracking_huber_scale = 0.1;  // ~5.7 degrees
+  double video_lc_cauchy_scale = 0.05;      // ~2.8 degrees
 };
 
 // High-level interface for rotation averaging.
@@ -81,11 +101,20 @@ class RotationEstimator {
   // Estimates the global orientations of all views.
   // Solves rotation averaging and registers frames with computed poses.
   // active_image_ids defines which images to include.
+  // ``final_weights`` (out, optional): per-pair IRLS weight from the last
+  // successful iteration. Populated only when SolveIRLS runs.
+  // ``correspondence_graph`` (in, optional): Optional CorrespondenceGraph
+  // carrying per-pair ImagePair.{inliers, are_lc} used by the LC-aware
+  // paths below. Required when ``skip_risky_LC_pairs=true``; nullptr
+  // otherwise.
   // Returns true on successful estimation.
-  bool EstimateRotations(const PoseGraph& pose_graph,
-                         const std::vector<PosePrior>& pose_priors,
-                         const std::unordered_set<image_t>& active_image_ids,
-                         Reconstruction& reconstruction);
+  bool EstimateRotations(
+      const PoseGraph& pose_graph,
+      const std::vector<PosePrior>& pose_priors,
+      const std::unordered_set<image_t>& active_image_ids,
+      Reconstruction& reconstruction,
+      std::unordered_map<image_pair_t, double>* final_weights = nullptr,
+      const class CorrespondenceGraph* correspondence_graph = nullptr);
 
  private:
   // Maybe solves 1-DOF rotation averaging on the gravity-aligned subset.
@@ -101,13 +130,19 @@ class RotationEstimator {
       const PoseGraph& pose_graph,
       const std::vector<PosePrior>& pose_priors,
       const std::unordered_set<image_t>& active_image_ids,
-      Reconstruction& reconstruction);
+      Reconstruction& reconstruction,
+      std::unordered_map<image_pair_t, double>* final_weights = nullptr,
+      const class CorrespondenceGraph* correspondence_graph = nullptr);
 
   // Initializes rotations from maximum spanning tree.
+  // ``correspondence_graph`` (in, optional): when non-null and
+  // ``options_.use_video_constraints`` is true, MST construction
+  // penalises LC-dominated edges.
   void InitializeFromMaximumSpanningTree(
       const PoseGraph& pose_graph,
       const std::unordered_set<image_t>& active_image_ids,
-      Reconstruction& reconstruction);
+      Reconstruction& reconstruction,
+      const class CorrespondenceGraph* correspondence_graph = nullptr);
 
   const RotationEstimatorOptions options_;
 };
@@ -123,9 +158,37 @@ bool InitializeRigRotationsFromImages(
 // For cameras with unknown cam_from_rig, first estimates their orientations
 // independently using an expanded reconstruction, then initializes the
 // cam_from_rig and runs rotation averaging on the original reconstruction.
-bool RunRotationAveraging(const RotationEstimatorOptions& options,
-                          PoseGraph& pose_graph,
-                          Reconstruction& reconstruction,
-                          const std::vector<PosePrior>& pose_priors);
+// ``final_weights`` (out, optional): per-pair IRLS weight from the last
+// successful iteration of the FINAL solve (if rig expansion runs, only the
+// final solve's weights are returned).
+// ``correspondence_graph`` (in, optional): Optional CorrespondenceGraph
+// carrying per-pair ImagePair.{inliers, are_lc} used by the LC-aware
+// paths below. Required when ``skip_risky_LC_pairs=true``.
+bool RunRotationAveraging(
+    const RotationEstimatorOptions& options,
+    PoseGraph& pose_graph,
+    Reconstruction& reconstruction,
+    const std::vector<PosePrior>& pose_priors,
+    std::unordered_map<image_pair_t, double>* final_weights = nullptr,
+    const class CorrespondenceGraph* correspondence_graph = nullptr);
+
+// Compute the maximum spanning tree of ``pose_graph`` over ``image_ids``,
+// weighted by ``edge.num_matches``. Returns the root image_id and populates
+// ``parents``.
+//
+// When ``prioritize_tracking=true`` and ``correspondence_graph`` is non-null,
+// LC-dominated edges (where ``are_lc`` true count > non-LC inlier count) have
+// ``kLCPenalty=1e9`` subtracted from their weight, so the MST routes around
+// them. Vanilla colmap behaviour is recovered with
+// ``prioritize_tracking=false`` (or a null correspondence_graph).
+//
+// Exposed in the public header to support unit tests of the LC-penalty
+// branch.
+image_t ComputeMaximumPoseGraphSpanningTree(
+    const PoseGraph& pose_graph,
+    const std::unordered_set<image_t>& image_ids,
+    std::unordered_map<image_t, image_t>& parents,
+    bool prioritize_tracking,
+    const class CorrespondenceGraph* correspondence_graph);
 
 }  // namespace colmap

--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -68,20 +68,11 @@ struct RotationEstimatorOptions {
   // after solving, then recompute active set.
   double max_rotation_error_deg = 10.0;
 
-  // Optional extensions (default OFF; disabled = baseline RA).
-
-  // If true, drop pairs whose loop-closure inlier count exceeds non-LC
-  // inliers — prevents LC-contaminated pairs from breaking RA. Consumed by
-  // BuildPairConstraints in rotation_averaging_impl.cc when a
-  // CorrespondenceGraph& is plumbed through.
+  // Drop pairs where LC inliers exceed tracking inliers.
   bool skip_risky_LC_pairs = false;
 
-  // If true, switch from L1 + IRLS to a Ceres-based solver with differential
-  // loss functions (Huber for tracking pairs, Cauchy for LC pairs). Mutually
-  // exclusive with use_gravity. Also gates the MST initializer's LC-edge
-  // penalty: when true, ``ComputeMaximumPoseGraphSpanningTree`` subtracts
-  // kLCPenalty=1e9 from LC-dominated edges so the tree routes through
-  // tracking pairs first.
+  // Use Ceres solver with per-pair Huber/Cauchy loss instead of L1+IRLS.
+  // Mutually exclusive with use_gravity.
   bool use_video_constraints = false;
 
   // Loss scales for the video-aware Ceres solver.
@@ -98,16 +89,8 @@ class RotationEstimator {
   explicit RotationEstimator(const RotationEstimatorOptions& options)
       : options_(options) {}
 
-  // Estimates the global orientations of all views.
-  // Solves rotation averaging and registers frames with computed poses.
-  // active_image_ids defines which images to include.
-  // ``final_weights`` (out, optional): per-pair IRLS weight from the last
-  // successful iteration. Populated only when SolveIRLS runs.
-  // ``correspondence_graph`` (in, optional): Optional CorrespondenceGraph
-  // carrying per-pair ImagePair.{inliers, are_lc} used by the LC-aware
-  // paths below. Required when ``skip_risky_LC_pairs=true``; nullptr
-  // otherwise.
-  // Returns true on successful estimation.
+  // Estimate global orientations for active_image_ids.
+  // Returns true on success.
   bool EstimateRotations(
       const PoseGraph& pose_graph,
       const std::vector<PosePrior>& pose_priors,
@@ -134,10 +117,7 @@ class RotationEstimator {
       std::unordered_map<image_pair_t, double>* final_weights = nullptr,
       const class CorrespondenceGraph* correspondence_graph = nullptr);
 
-  // Initializes rotations from maximum spanning tree.
-  // ``correspondence_graph`` (in, optional): when non-null and
-  // ``options_.use_video_constraints`` is true, MST construction
-  // penalises LC-dominated edges.
+  // Initialize rotations from maximum spanning tree.
   void InitializeFromMaximumSpanningTree(
       const PoseGraph& pose_graph,
       const std::unordered_set<image_t>& active_image_ids,
@@ -154,16 +134,7 @@ bool InitializeRigRotationsFromImages(
     const std::unordered_map<image_t, Rigid3d>& cams_from_world,
     Reconstruction& reconstruction);
 
-// High-level rotation averaging solver that handles rig expansion.
-// For cameras with unknown cam_from_rig, first estimates their orientations
-// independently using an expanded reconstruction, then initializes the
-// cam_from_rig and runs rotation averaging on the original reconstruction.
-// ``final_weights`` (out, optional): per-pair IRLS weight from the last
-// successful iteration of the FINAL solve (if rig expansion runs, only the
-// final solve's weights are returned).
-// ``correspondence_graph`` (in, optional): Optional CorrespondenceGraph
-// carrying per-pair ImagePair.{inliers, are_lc} used by the LC-aware
-// paths below. Required when ``skip_risky_LC_pairs=true``.
+// High-level rotation averaging with rig expansion for unknown cam_from_rig.
 bool RunRotationAveraging(
     const RotationEstimatorOptions& options,
     PoseGraph& pose_graph,
@@ -172,18 +143,8 @@ bool RunRotationAveraging(
     std::unordered_map<image_pair_t, double>* final_weights = nullptr,
     const class CorrespondenceGraph* correspondence_graph = nullptr);
 
-// Compute the maximum spanning tree of ``pose_graph`` over ``image_ids``,
-// weighted by ``edge.num_matches``. Returns the root image_id and populates
-// ``parents``.
-//
-// When ``prioritize_tracking=true`` and ``correspondence_graph`` is non-null,
-// LC-dominated edges (where ``are_lc`` true count > non-LC inlier count) have
-// ``kLCPenalty=1e9`` subtracted from their weight, so the MST routes around
-// them. Vanilla colmap behaviour is recovered with
-// ``prioritize_tracking=false`` (or a null correspondence_graph).
-//
-// Exposed in the public header to support unit tests of the LC-penalty
-// branch.
+// MST weighted by match count. When prioritize_tracking is set and a
+// CorrespondenceGraph is provided, LC-dominated edges are penalized.
 image_t ComputeMaximumPoseGraphSpanningTree(
     const PoseGraph& pose_graph,
     const std::unordered_set<image_t>& image_ids,

--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -69,7 +69,7 @@ struct RotationEstimatorOptions {
   double max_rotation_error_deg = 10.0;
 
   // Drop pairs where LC inliers exceed tracking inliers.
-  bool skip_risky_LC_pairs = false;
+  bool skip_risky_lc_pairs = false;
 
   // Use Ceres solver with per-pair Huber/Cauchy loss instead of L1+IRLS.
   // Mutually exclusive with use_gravity.

--- a/src/colmap/estimators/rotation_averaging.h
+++ b/src/colmap/estimators/rotation_averaging.h
@@ -106,7 +106,8 @@ class RotationEstimator {
       const PoseGraph& pose_graph,
       const std::vector<PosePrior>& pose_priors,
       const std::unordered_set<image_t>& active_image_ids,
-      Reconstruction& reconstruction);
+      Reconstruction& reconstruction,
+      const class CorrespondenceGraph* correspondence_graph = nullptr);
 
   // Core rotation averaging solver.
   bool SolveRotationAveraging(

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -14,6 +14,20 @@
 namespace colmap {
 namespace {
 
+// Returns true if the pair has more (or equal) non-LC inliers than LC
+// inliers — i.e. tracking-dominated. Used by SolveCeres to choose the
+// per-pair loss (Huber for tracking, Cauchy for LC).
+bool IsTrackingPair(const CorrespondenceGraph::ImagePair& image_pair) {
+  if (image_pair.inliers.empty()) return false;
+  size_t lc_count = 0;
+  for (const auto idx : image_pair.inliers) {
+    if (idx < image_pair.are_lc.size() && image_pair.are_lc[idx]) {
+      ++lc_count;
+    }
+  }
+  return image_pair.inliers.size() - lc_count >= lc_count;
+}
+
 // Computes the 1-DOF residual for gravity-aligned rotation constraints.
 // Returns (angle_2 - angle_1) - angle_12, wrapped to [-π, π] with jitter
 // near boundaries to avoid local minima.
@@ -82,8 +96,15 @@ RotationAveragingProblem::RotationAveragingProblem(
     const std::vector<PosePrior>& pose_priors,
     const RotationEstimatorOptions& options,
     const std::unordered_set<image_t>& active_image_ids,
-    Reconstruction& reconstruction)
-    : options_(options) {
+    Reconstruction& reconstruction,
+    const CorrespondenceGraph* correspondence_graph)
+    : options_(options),
+      correspondence_graph_(correspondence_graph) {
+  // Fail-loud guard: skip_risky_LC_pairs reads ImagePair::are_lc from the
+  // CorrespondenceGraph; with no CG the per-pair LC filter silently never
+  // triggers. Force the caller to wire CG explicitly when opting in.
+  THROW_CHECK(!options_.skip_risky_LC_pairs || correspondence_graph_ != nullptr)
+      << "skip_risky_LC_pairs=true requires correspondence_graph; got nullptr";
   // Derive active_frame_ids from active_image_ids, and cache mappings.
   for (const image_t image_id : active_image_ids) {
     const auto& image = reconstruction.Image(image_id);
@@ -232,6 +253,31 @@ void RotationAveragingProblem::BuildPairConstraints(
 
   for (const auto& [pair_id, edge] : pose_graph.ValidEdges()) {
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
+
+    // Skip pairs whose LC inliers strictly exceed non-LC inliers; LC-
+    // dominated pairs are loop-closures whose relative rotation often
+    // disagrees with track-based geometry and breaks RA convergence.
+    // Reads ImagePair.{inliers, are_lc} from the CorrespondenceGraph
+    // plumbed in via ctor; PoseGraph::Edge doesn't carry the per-pair
+    // {inliers, are_lc} fields.
+    if (options_.skip_risky_LC_pairs && correspondence_graph_ != nullptr) {
+      const auto& cg_map = correspondence_graph_->ImagePairsMap();
+      auto cg_pair_it = cg_map.find(pair_id);
+      if (cg_pair_it != cg_map.end()) {
+        const auto& cg_pair = cg_pair_it->second;
+        if (!cg_pair.inliers.empty() && !cg_pair.are_lc.empty()) {
+          size_t lc_count = 0;
+          for (const auto idx : cg_pair.inliers) {
+            if (idx < cg_pair.are_lc.size() && cg_pair.are_lc[idx]) {
+              ++lc_count;
+            }
+          }
+          if (lc_count > cg_pair.inliers.size() - lc_count) {
+            continue;
+          }
+        }
+      }
+    }
 
     const auto& image1 = reconstruction.Image(image_id1);
     const auto& image2 = reconstruction.Image(image_id2);
@@ -639,6 +685,19 @@ bool RotationAveragingSolver::Solve(RotationAveragingProblem& problem) {
     SetPRNGSeed(static_cast<unsigned>(options_.random_seed));
   }
 
+  // Video-Ceres path: mutually exclusive with use_gravity. Replaces
+  // L1+IRLS with a Ceres optimization over per-frame 3-DOF angle-axis
+  // blocks. The LC-penalty MST initialization (also gated on
+  // use_video_constraints) runs before this solve.
+  if (options_.use_video_constraints && !options_.use_gravity) {
+    VLOG(2) << "Solving video-aware Ceres rotation averaging";
+    return SolveCeres(problem);
+  }
+  if (options_.use_video_constraints && options_.use_gravity) {
+    LOG(WARNING) << "use_video_constraints + use_gravity both set; "
+                 << "use_video_constraints disabled (mutually exclusive).";
+  }
+
   if (options_.max_num_l1_iterations > 0) {
     VLOG(2) << "Solving L1 regression problem";
     if (!SolveL1Regression(problem)) {
@@ -823,5 +882,103 @@ bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
   return true;
 }
 
+// Replaces L1+IRLS with a Ceres optimization over per-frame 3-DOF
+// angle-axis blocks. Activated by use_video_constraints (and gated to
+// !use_gravity in Solve). Each pair's residual is a relative-rotation
+// error wrapped in Huber (tracking-dominated) or Cauchy (LC-dominated)
+// loss. Initialized rotations come from the LC-penalty MST (also gated
+// on use_video_constraints) or the L1+IRLS warm-start if MST init was
+// skipped.
+bool RotationAveragingSolver::SolveCeres(RotationAveragingProblem& problem) {
+  THROW_CHECK(!options_.use_gravity)
+      << "SolveCeres is gated on !use_gravity; gravity-aware video-Ceres "
+         "is not implemented (this combination is unsupported).";
+
+  const auto* cg = problem.CorrespondenceGraphPtr();
+  if (cg == nullptr) {
+    LOG(WARNING) << "use_video_constraints requires a CorrespondenceGraph "
+                 << "to classify pairs as tracking-vs-LC; falling back to "
+                 << "Huber loss for all pairs.";
+  }
+
+  ceres::Problem ceres_problem;
+  Eigen::VectorXd& estimated_rotations = problem.MutableEstimatedRotations();
+  const auto& frame_id_to_param_idx = problem.FrameIdToParamIdx();
+  const auto& image_id_to_frame_id = problem.ImageIdToFrameId();
+  const frame_t fixed_frame_id = problem.FixedFrameId();
+
+  // Add parameter blocks for all active frames (3-DOF angle-axis).
+  for (const auto& [frame_id, param_idx] : frame_id_to_param_idx) {
+    double* param = estimated_rotations.data() + param_idx;
+    ceres_problem.AddParameterBlock(param, 3);
+    if (frame_id == fixed_frame_id) {
+      ceres_problem.SetParameterBlockConstant(param);
+    }
+  }
+
+  // Add residual blocks for each pair_constraint.
+  for (const auto& [pair_id, constraint] : problem.PairConstraints()) {
+    const auto* full_3dof =
+        std::get_if<RotationAveragingProblem::Full3DOF>(&constraint.constraint);
+    if (full_3dof == nullptr) {
+      // Gravity-aligned 1-DOF should not occur in video-Ceres path
+      // (gated on !use_gravity above).
+      continue;
+    }
+    const auto frame_it1 =
+        image_id_to_frame_id.find(constraint.image_id1);
+    const auto frame_it2 =
+        image_id_to_frame_id.find(constraint.image_id2);
+    if (frame_it1 == image_id_to_frame_id.end() ||
+        frame_it2 == image_id_to_frame_id.end()) {
+      continue;
+    }
+    const auto idx_it1 = frame_id_to_param_idx.find(frame_it1->second);
+    const auto idx_it2 = frame_id_to_param_idx.find(frame_it2->second);
+    if (idx_it1 == frame_id_to_param_idx.end() ||
+        idx_it2 == frame_id_to_param_idx.end()) {
+      continue;
+    }
+
+    Eigen::Vector3d rel_aa;
+    ceres::RotationMatrixToAngleAxis(full_3dof->R_cam2_from_cam1.data(),
+                                     rel_aa.data());
+
+    bool is_tracking = true;  // Default: Huber (tracking).
+    if (cg != nullptr) {
+      auto cg_pair_it = cg->ImagePairsMap().find(pair_id);
+      if (cg_pair_it != cg->ImagePairsMap().end()) {
+        is_tracking = IsTrackingPair(cg_pair_it->second);
+      }
+    }
+    ceres::LossFunction* loss =
+        is_tracking ? static_cast<ceres::LossFunction*>(
+                          new ceres::HuberLoss(
+                              options_.video_tracking_huber_scale))
+                    : static_cast<ceres::LossFunction*>(
+                          new ceres::CauchyLoss(
+                              options_.video_lc_cauchy_scale));
+
+    ceres::CostFunction* cost = RelativeRotationError::Create(rel_aa);
+    ceres_problem.AddResidualBlock(
+        cost,
+        loss,
+        estimated_rotations.data() + idx_it1->second,
+        estimated_rotations.data() + idx_it2->second);
+  }
+
+  ceres::Solver::Options solver_options;
+  solver_options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
+  solver_options.max_num_iterations = 100;
+  solver_options.minimizer_progress_to_stdout = VLOG_IS_ON(2);
+  ceres::Solver::Summary summary;
+  ceres::Solve(solver_options, &ceres_problem, &summary);
+  if (VLOG_IS_ON(2)) {
+    LOG(INFO) << summary.FullReport();
+  } else {
+    LOG(INFO) << summary.BriefReport();
+  }
+  return summary.IsSolutionUsable();
+}
 
 }  // namespace colmap

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -668,18 +668,12 @@ void RotationAveragingProblem::ApplyResultsToReconstruction(
 }
 
 bool RotationAveragingSolver::Solve(RotationAveragingProblem& problem) {
-  // Seed the global PRNG once per solve. ComputeResiduals' boundary
-  // jitter consumer (RandomUniformReal) advances naturally across
-  // iterations from this seed; resetting per-iteration would replay
-  // the identical jitter sequence and break IRLS convergence.
+  // Seed PRNG once (not per-iteration) so jitter sequence advances naturally.
   if (options_.random_seed >= 0) {
     SetPRNGSeed(static_cast<unsigned>(options_.random_seed));
   }
 
-  // Video-Ceres path: mutually exclusive with use_gravity. Replaces
-  // L1+IRLS with a Ceres optimization over per-frame 3-DOF angle-axis
-  // blocks. The LC-penalty MST initialization (also gated on
-  // use_video_constraints) runs before this solve.
+  // Video-Ceres path (mutually exclusive with use_gravity).
   if (options_.use_video_constraints && !options_.use_gravity) {
     VLOG(2) << "Solving video-aware Ceres rotation averaging";
     return SolveCeres(problem);
@@ -850,9 +844,7 @@ bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
     // Solve the least squares problem.
     step.setZero();
     step = llt.solve(at_weight * problem.Residuals());
-    // Mirror the L1 path's NaN guard (line 755). Without this, a singular
-    // pose-graph silently corrupts cams_from_world via UpdateState and
-    // SolveIRLS returns true with garbage residuals next iteration.
+    // NaN guard: singular pose-graph corrupts cams_from_world via UpdateState.
     if (step.array().isNaN().any()) {
       LOG(ERROR) << "IRLS step is NaN at iteration " << iteration;
       return false;
@@ -873,13 +865,8 @@ bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
   return true;
 }
 
-// Replaces L1+IRLS with a Ceres optimization over per-frame 3-DOF
-// angle-axis blocks. Activated by use_video_constraints (and gated to
-// !use_gravity in Solve). Each pair's residual is a relative-rotation
-// error wrapped in Huber (tracking-dominated) or Cauchy (LC-dominated)
-// loss. Initialized rotations come from the LC-penalty MST (also gated
-// on use_video_constraints) or the L1+IRLS warm-start if MST init was
-// skipped.
+// Ceres solve over per-frame 3-DOF angle-axis: Huber for tracking pairs,
+// Cauchy for LC pairs. Requires CorrespondenceGraph for LC classification.
 bool RotationAveragingSolver::SolveCeres(RotationAveragingProblem& problem) {
   THROW_CHECK(!options_.use_gravity)
       << "SolveCeres is gated on !use_gravity; gravity-aware video-Ceres "

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -657,12 +657,18 @@ void RotationAveragingProblem::ApplyResultsToReconstruction(
 }
 
 bool RotationAveragingSolver::Solve(RotationAveragingProblem& problem) {
-  // Seed PRNG once (not per-iteration) so jitter sequence advances naturally.
+  // Seed the global PRNG once per solve. ComputeResiduals' boundary
+  // jitter consumer (RandomUniformReal) advances naturally across
+  // iterations from this seed; resetting per-iteration would replay
+  // the identical jitter sequence and break IRLS convergence.
   if (options_.random_seed >= 0) {
     SetPRNGSeed(static_cast<unsigned>(options_.random_seed));
   }
 
-  // Video-Ceres path (mutually exclusive with use_gravity).
+  // Video-Ceres path: mutually exclusive with use_gravity. Replaces
+  // L1+IRLS with a Ceres optimization over per-frame 3-DOF angle-axis
+  // blocks. The LC-penalty MST initialization (also gated on
+  // use_video_constraints) runs before this solve.
   if (options_.use_video_constraints && !options_.use_gravity) {
     VLOG(2) << "Solving video-aware Ceres rotation averaging";
     return SolveCeres(problem);
@@ -833,7 +839,9 @@ bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
     // Solve the least squares problem.
     step.setZero();
     step = llt.solve(at_weight * problem.Residuals());
-    // NaN guard: singular pose-graph corrupts cams_from_world via UpdateState.
+    // Mirror the L1 path's NaN guard (line 755). Without this, a singular
+    // pose-graph silently corrupts cams_from_world via UpdateState and
+    // SolveIRLS returns true with garbage residuals next iteration.
     if (step.array().isNaN().any()) {
       LOG(ERROR) << "IRLS step is NaN at iteration " << iteration;
       return false;
@@ -854,8 +862,13 @@ bool RotationAveragingSolver::SolveIRLS(RotationAveragingProblem& problem) {
   return true;
 }
 
-// Ceres solve over per-frame 3-DOF angle-axis: Huber for tracking pairs,
-// Cauchy for LC pairs. Requires CorrespondenceGraph for LC classification.
+// Replaces L1+IRLS with a Ceres optimization over per-frame 3-DOF
+// angle-axis blocks. Activated by use_video_constraints (and gated to
+// !use_gravity in Solve). Each pair's residual is a relative-rotation
+// error wrapped in Huber (tracking-dominated) or Cauchy (LC-dominated)
+// loss. Initialized rotations come from the LC-penalty MST (also gated
+// on use_video_constraints) or the L1+IRLS warm-start if MST init was
+// skipped.
 bool RotationAveragingSolver::SolveCeres(RotationAveragingProblem& problem) {
   THROW_CHECK(!options_.use_gravity)
       << "SolveCeres is gated on !use_gravity; gravity-aware video-Ceres "

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -12,9 +12,7 @@
 #include <ceres/rotation.h>
 
 namespace colmap {
-namespace {
 
-// True if non-LC inliers >= LC inliers.
 bool IsTrackingPair(const CorrespondenceGraph::ImagePair& image_pair) {
   if (image_pair.inliers.empty()) return false;
   size_t lc_count = 0;
@@ -25,6 +23,8 @@ bool IsTrackingPair(const CorrespondenceGraph::ImagePair& image_pair) {
   }
   return image_pair.inliers.size() - lc_count >= lc_count;
 }
+
+namespace {
 
 // Computes the 1-DOF residual for gravity-aligned rotation constraints.
 // Returns (angle_2 - angle_1) - angle_12, wrapped to [-π, π] with jitter
@@ -98,9 +98,9 @@ RotationAveragingProblem::RotationAveragingProblem(
     const CorrespondenceGraph* correspondence_graph)
     : options_(options),
       correspondence_graph_(correspondence_graph) {
-  // skip_risky_LC_pairs requires a CorrespondenceGraph.
-  THROW_CHECK(!options_.skip_risky_LC_pairs || correspondence_graph_ != nullptr)
-      << "skip_risky_LC_pairs=true requires correspondence_graph; got nullptr";
+  // skip_risky_lc_pairs requires a CorrespondenceGraph.
+  THROW_CHECK(!options_.skip_risky_lc_pairs || correspondence_graph_ != nullptr)
+      << "skip_risky_lc_pairs=true requires correspondence_graph; got nullptr";
   // Derive active_frame_ids from active_image_ids, and cache mappings.
   for (const image_t image_id : active_image_ids) {
     const auto& image = reconstruction.Image(image_id);
@@ -251,22 +251,12 @@ void RotationAveragingProblem::BuildPairConstraints(
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
 
     // Skip LC-dominated pairs.
-    if (options_.skip_risky_LC_pairs && correspondence_graph_ != nullptr) {
+    if (options_.skip_risky_lc_pairs && correspondence_graph_ != nullptr) {
       const auto& cg_map = correspondence_graph_->ImagePairsMap();
       auto cg_pair_it = cg_map.find(pair_id);
-      if (cg_pair_it != cg_map.end()) {
-        const auto& cg_pair = cg_pair_it->second;
-        if (!cg_pair.inliers.empty() && !cg_pair.are_lc.empty()) {
-          size_t lc_count = 0;
-          for (const auto idx : cg_pair.inliers) {
-            if (idx < cg_pair.are_lc.size() && cg_pair.are_lc[idx]) {
-              ++lc_count;
-            }
-          }
-          if (lc_count > cg_pair.inliers.size() - lc_count) {
-            continue;
-          }
-        }
+      if (cg_pair_it != cg_map.end() &&
+          !IsTrackingPair(cg_pair_it->second)) {
+        continue;
       }
     }
 
@@ -746,7 +736,7 @@ bool RotationAveragingSolver::SolveL1Regression(
             options_.l1_step_convergence_threshold ||
         std::abs(prev_norm - curr_norm) < kEps) {
       if (std::abs(prev_norm - curr_norm) < kEps)
-        LOG(INFO) << "std::abs(prev_norm - curr_norm) < " << kEps;
+        VLOG(2) << "std::abs(prev_norm - curr_norm) < " << kEps;
       iteration++;
       break;
     }

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -14,9 +14,7 @@
 namespace colmap {
 namespace {
 
-// Returns true if the pair has more (or equal) non-LC inliers than LC
-// inliers — i.e. tracking-dominated. Used by SolveCeres to choose the
-// per-pair loss (Huber for tracking, Cauchy for LC).
+// True if non-LC inliers >= LC inliers.
 bool IsTrackingPair(const CorrespondenceGraph::ImagePair& image_pair) {
   if (image_pair.inliers.empty()) return false;
   size_t lc_count = 0;
@@ -100,9 +98,7 @@ RotationAveragingProblem::RotationAveragingProblem(
     const CorrespondenceGraph* correspondence_graph)
     : options_(options),
       correspondence_graph_(correspondence_graph) {
-  // Fail-loud guard: skip_risky_LC_pairs reads ImagePair::are_lc from the
-  // CorrespondenceGraph; with no CG the per-pair LC filter silently never
-  // triggers. Force the caller to wire CG explicitly when opting in.
+  // skip_risky_LC_pairs requires a CorrespondenceGraph.
   THROW_CHECK(!options_.skip_risky_LC_pairs || correspondence_graph_ != nullptr)
       << "skip_risky_LC_pairs=true requires correspondence_graph; got nullptr";
   // Derive active_frame_ids from active_image_ids, and cache mappings.
@@ -254,12 +250,7 @@ void RotationAveragingProblem::BuildPairConstraints(
   for (const auto& [pair_id, edge] : pose_graph.ValidEdges()) {
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
 
-    // Skip pairs whose LC inliers strictly exceed non-LC inliers; LC-
-    // dominated pairs are loop-closures whose relative rotation often
-    // disagrees with track-based geometry and breaks RA convergence.
-    // Reads ImagePair.{inliers, are_lc} from the CorrespondenceGraph
-    // plumbed in via ctor; PoseGraph::Edge doesn't carry the per-pair
-    // {inliers, are_lc} fields.
+    // Skip LC-dominated pairs.
     if (options_.skip_risky_LC_pairs && correspondence_graph_ != nullptr) {
       const auto& cg_map = correspondence_graph_->ImagePairsMap();
       auto cg_pair_it = cg_map.find(pair_id);

--- a/src/colmap/estimators/rotation_averaging_impl.cc
+++ b/src/colmap/estimators/rotation_averaging_impl.cc
@@ -17,7 +17,8 @@ bool IsTrackingPair(const CorrespondenceGraph::ImagePair& image_pair) {
   if (image_pair.inliers.empty()) return false;
   size_t lc_count = 0;
   for (const auto idx : image_pair.inliers) {
-    if (idx < image_pair.are_lc.size() && image_pair.are_lc[idx]) {
+    if (idx >= 0 && static_cast<size_t>(idx) < image_pair.are_lc.size() &&
+        image_pair.are_lc[idx]) {
       ++lc_count;
     }
   }

--- a/src/colmap/estimators/rotation_averaging_impl.h
+++ b/src/colmap/estimators/rotation_averaging_impl.h
@@ -100,14 +100,6 @@ class RotationAveragingProblem {
     return pair_constraints_;
   }
 
-  // After a successful IRLS solve, ``RotationAveragingSolver::SolveIRLS``
-  // calls ``SetFinalWeightsFromIRLS(weights_irls)`` to capture the
-  // per-pair IRLS weight from the last successful iteration. Caller reads
-  // this for the consecutive-pair-weight degeneracy diagnostic.
-  void SetFinalWeightsFromIRLS(const Eigen::VectorXd& weights_irls);
-  const std::unordered_map<image_pair_t, double>& FinalWeights() const {
-    return final_weights_;
-  }
 
   // Accessors for the video-Ceres path (gated on !use_gravity).
   Eigen::VectorXd& MutableEstimatedRotations() { return estimated_rotations_; }
@@ -170,10 +162,6 @@ class RotationAveragingProblem {
   // Active frames for the current solve.
   std::unordered_set<frame_t> active_frame_ids_;
 
-  // Per-pair IRLS weight from the last successful iteration. Populated by
-  // SetFinalWeightsFromIRLS. Empty if SolveIRLS didn't run (e.g. L1-only
-  // path, or video-Ceres path).
-  std::unordered_map<image_pair_t, double> final_weights_;
 
   // For per-pair LC fields (inliers, are_lc) not carried by PoseGraph::Edge.
   const CorrespondenceGraph* correspondence_graph_ = nullptr;

--- a/src/colmap/estimators/rotation_averaging_impl.h
+++ b/src/colmap/estimators/rotation_averaging_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "colmap/estimators/rotation_averaging.h"
+#include "colmap/scene/correspondence_graph.h"
 
 #include <optional>
 #include <variant>
@@ -10,6 +11,34 @@
 #include <ceres/rotation.h>
 
 namespace colmap {
+
+// AutoDiff relative rotation error for the video-Ceres path.
+// Residual = AngleAxis(R2^T * R_rel * R1), all 3-DOF angle-axis.
+struct RelativeRotationError {
+  explicit RelativeRotationError(const Eigen::Vector3d& rel_rot_aa)
+      : rel_rot_aa_(rel_rot_aa) {}
+
+  template <typename T>
+  bool operator()(const T* const r1_aa,
+                  const T* const r2_aa,
+                  T* residuals) const {
+    Eigen::Matrix<T, 3, 3> R1, R2, R_rel;
+    ceres::AngleAxisToRotationMatrix(r1_aa, R1.data());
+    ceres::AngleAxisToRotationMatrix(r2_aa, R2.data());
+    Eigen::Matrix<T, 3, 1> rel_aa_t = rel_rot_aa_.cast<T>();
+    ceres::AngleAxisToRotationMatrix(rel_aa_t.data(), R_rel.data());
+    Eigen::Matrix<T, 3, 3> R_err = R2.transpose() * R_rel * R1;
+    ceres::RotationMatrixToAngleAxis(R_err.data(), residuals);
+    return true;
+  }
+
+  static ceres::CostFunction* Create(const Eigen::Vector3d& rel_rot_aa) {
+    return new ceres::AutoDiffCostFunction<RelativeRotationError, 3, 3, 3>(
+        new RelativeRotationError(rel_rot_aa));
+  }
+
+  const Eigen::Vector3d rel_rot_aa_;
+};
 
 // Rotation averaging problem formulated as linear system A*x = b where:
 //   x = [rig_from_world rotations, unknown cam_from_rig rotations]
@@ -44,7 +73,8 @@ class RotationAveragingProblem {
                            const std::vector<PosePrior>& pose_priors,
                            const RotationEstimatorOptions& options,
                            const std::unordered_set<image_t>& active_image_ids,
-                           Reconstruction& reconstruction);
+                           Reconstruction& reconstruction,
+                           const CorrespondenceGraph* correspondence_graph = nullptr);
 
   // Computes residual vector b from current rotation estimates.
   void ComputeResiduals();
@@ -68,6 +98,28 @@ class RotationAveragingProblem {
   const std::unordered_map<image_pair_t, PairConstraint>& PairConstraints()
       const {
     return pair_constraints_;
+  }
+
+  // After a successful IRLS solve, ``RotationAveragingSolver::SolveIRLS``
+  // calls ``SetFinalWeightsFromIRLS(weights_irls)`` to capture the
+  // per-pair IRLS weight from the last successful iteration. Caller reads
+  // this for the consecutive-pair-weight degeneracy diagnostic.
+  void SetFinalWeightsFromIRLS(const Eigen::VectorXd& weights_irls);
+  const std::unordered_map<image_pair_t, double>& FinalWeights() const {
+    return final_weights_;
+  }
+
+  // Accessors for the video-Ceres path (gated on !use_gravity).
+  Eigen::VectorXd& MutableEstimatedRotations() { return estimated_rotations_; }
+  const std::unordered_map<frame_t, int>& FrameIdToParamIdx() const {
+    return frame_id_to_param_idx_;
+  }
+  const std::unordered_map<image_t, frame_t>& ImageIdToFrameId() const {
+    return image_id_to_frame_id_;
+  }
+  frame_t FixedFrameId() const { return fixed_frame_id_; }
+  const CorrespondenceGraph* CorrespondenceGraphPtr() const {
+    return correspondence_graph_;
   }
 
  private:
@@ -117,6 +169,14 @@ class RotationAveragingProblem {
 
   // Active frames for the current solve.
   std::unordered_set<frame_t> active_frame_ids_;
+
+  // Per-pair IRLS weight from the last successful iteration. Populated by
+  // SetFinalWeightsFromIRLS. Empty if SolveIRLS didn't run (e.g. L1-only
+  // path, or video-Ceres path).
+  std::unordered_map<image_pair_t, double> final_weights_;
+
+  // For per-pair LC fields (inliers, are_lc) not carried by PoseGraph::Edge.
+  const CorrespondenceGraph* correspondence_graph_ = nullptr;
 };
 
 // Solves the rotation averaging problem using L1 regression followed by IRLS.
@@ -134,6 +194,10 @@ class RotationAveragingSolver {
 
   // Iteratively reweighted least squares phase.
   bool SolveIRLS(RotationAveragingProblem& problem);
+
+  // Ceres solve over per-frame 3-DOF angle-axis: Huber for tracking
+  // pairs, Cauchy for LC pairs. Requires CorrespondenceGraph.
+  bool SolveCeres(RotationAveragingProblem& problem);
 
   // Computes IRLS weights for all constraints.
   // Returns nullopt if any weight is NaN.

--- a/src/colmap/estimators/rotation_averaging_impl.h
+++ b/src/colmap/estimators/rotation_averaging_impl.h
@@ -12,6 +12,9 @@
 
 namespace colmap {
 
+// True if non-LC inliers >= LC inliers (i.e. the pair is tracking-dominated).
+bool IsTrackingPair(const CorrespondenceGraph::ImagePair& image_pair);
+
 // AutoDiff relative rotation error for the video-Ceres path.
 // Residual = AngleAxis(R2^T * R_rel * R1), all 3-DOF angle-axis.
 struct RelativeRotationError {
@@ -100,8 +103,7 @@ class RotationAveragingProblem {
     return pair_constraints_;
   }
 
-
-  // Accessors for the video-Ceres path (gated on !use_gravity).
+  // Accessors for the Ceres solver path (gated on !use_gravity).
   Eigen::VectorXd& MutableEstimatedRotations() { return estimated_rotations_; }
   const std::unordered_map<frame_t, int>& FrameIdToParamIdx() const {
     return frame_id_to_param_idx_;
@@ -161,7 +163,6 @@ class RotationAveragingProblem {
 
   // Active frames for the current solve.
   std::unordered_set<frame_t> active_frame_ids_;
-
 
   // For per-pair LC fields (inliers, are_lc) not carried by PoseGraph::Edge.
   const CorrespondenceGraph* correspondence_graph_ = nullptr;

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -372,6 +372,35 @@ TEST(RotationAveraging, SkipRiskyLcPairsWithUnknownRigUsesCorrespondenceGraph) {
                            data.database_cache.CorrespondenceGraph().get()));
 }
 
+TEST(RotationAveraging,
+     SkipRiskyLcPairsWithStratifiedGravityUsesCorrespondenceGraph) {
+  SetPRNGSeed(1);
+
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 5;
+  synthetic_dataset_options.num_points3D = 50;
+  synthetic_dataset_options.prior_gravity = true;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  auto data = CreateTestData(synthetic_dataset_options);
+
+  // Remove one gravity prior so the stratified subset path is used.
+  data.pose_priors.pop_back();
+
+  RotationEstimatorOptions options = CreateRATestOptions(/*use_gravity=*/true);
+  options.skip_risky_lc_pairs = true;
+  options.use_stratified = true;
+
+  EXPECT_TRUE(
+      RunRotationAveraging(options,
+                           data.pose_graph,
+                           data.reconstruction,
+                           data.pose_priors,
+                           nullptr,
+                           data.database_cache.CorrespondenceGraph().get()));
+}
+
 // LC-penalty branch inside ComputeMaximumPoseGraphSpanningTree.
 //
 // With ``prioritize_tracking=false`` the MST runs vanilla maximum-weight

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -343,7 +343,7 @@ TEST(RotationAveraging, GravityWithUnknownRigSensorsReturnsFalse) {
                                            data.reconstruction));
 }
 
-// ---- LC-penalty branch inside ComputeMaximumPoseGraphSpanningTree.
+// LC-penalty branch inside ComputeMaximumPoseGraphSpanningTree.
 //
 // With ``prioritize_tracking=false`` the MST runs vanilla maximum-weight
 // Kruskal. With ``prioritize_tracking=true`` it subtracts
@@ -555,9 +555,7 @@ TEST(RotationAveraging, InitializeSensorFromRigUsingCamsFromWorld) {
   }
 }
 
-// =============================================================================
 // RelativeRotationError functor tests (video-aware Ceres path).
-// =============================================================================
 
 namespace {
 

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -29,6 +29,7 @@
 
 #include "colmap/estimators/rotation_averaging.h"
 
+#include "colmap/estimators/rotation_averaging_impl.h"
 #include "colmap/math/math.h"
 #include "colmap/math/random.h"
 #include "colmap/scene/database_cache.h"
@@ -36,6 +37,13 @@
 #include "colmap/scene/pose_graph.h"
 #include "colmap/scene/synthetic.h"
 
+#include <algorithm>
+#include <array>
+#include <numeric>
+#include <set>
+
+#include <Eigen/Geometry>
+#include <ceres/rotation.h>
 #include <gtest/gtest.h>
 
 namespace colmap {
@@ -335,6 +343,179 @@ TEST(RotationAveraging, GravityWithUnknownRigSensorsReturnsFalse) {
                                            data.reconstruction));
 }
 
+// ---- LC-penalty branch inside ComputeMaximumPoseGraphSpanningTree.
+//
+// With ``prioritize_tracking=false`` the MST runs vanilla maximum-weight
+// Kruskal. With ``prioritize_tracking=true`` it subtracts
+// ``kLCPenalty=1e9`` from edges whose ``are_lc`` true count exceeds non-LC
+// inliers, routing the tree away from LC-dominated pairs.
+//
+// We construct a minimal three-image graph where the highest-weight edge is
+// LC-dominated and verify the parent map flips between the two modes.
+
+namespace {
+
+// Build a minimal PoseGraph with three valid edges:
+//   1-2: weight 100 (LC-dominated when correspondence_graph is annotated)
+//   1-3: weight 10
+//   2-3: weight 10
+// With prioritize_tracking=false the MST picks 1-2 plus one of {1-3, 2-3}.
+// With prioritize_tracking=true and the LC annotation below, the 1-2 edge
+// has its weight reduced by kLCPenalty=1e9 so the MST picks 1-3 and 2-3.
+struct LcMstFixture {
+  PoseGraph pose_graph;
+  CorrespondenceGraph correspondence_graph;
+  std::unordered_set<image_t> image_ids;
+};
+
+LcMstFixture BuildLcMstFixture() {
+  LcMstFixture data;
+  for (image_t image_id : {static_cast<image_t>(1),
+                           static_cast<image_t>(2),
+                           static_cast<image_t>(3)}) {
+    data.image_ids.insert(image_id);
+    // The CG ``AddImage`` only requires per-image num_points2D; pose-graph
+    // edges below carry the actual weights.
+    data.correspondence_graph.AddImage(image_id, /*num_points=*/0);
+  }
+
+  auto AddEdge = [&](image_t a, image_t b, int num_matches) {
+    PoseGraph::Edge edge;
+    edge.cam2_from_cam1 = Rigid3d();
+    edge.num_matches = num_matches;
+    edge.valid = true;
+    data.pose_graph.AddEdge(a, b, std::move(edge));
+  };
+
+  AddEdge(1, 2, /*num_matches=*/100);
+  AddEdge(1, 3, /*num_matches=*/10);
+  AddEdge(2, 3, /*num_matches=*/10);
+
+  // Mark the 1-2 pair as LC-dominated: more than half of its inliers carry
+  // are_lc=true. The MST helper inspects ImagePairsMap() entries indexed by
+  // pair_id, and (when a CG is plumbed through) reads the edge weight from
+  // ``inliers.size()`` rather than ``edge.num_matches``. Size each inliers
+  // vector to match the corresponding pose-graph edge so the two weight
+  // sources agree.
+  const image_pair_t pair_12 = ImagePairToPairId(1, 2);
+  auto& cg_pair = data.correspondence_graph.MutableImagePairs()[pair_12];
+  cg_pair.image_id1 = 1;
+  cg_pair.image_id2 = 2;
+  cg_pair.pair_id = pair_12;
+  cg_pair.inliers.resize(100);
+  std::iota(cg_pair.inliers.begin(), cg_pair.inliers.end(), 0);
+  // 80 of 100 inliers are LC -> dominated.
+  cg_pair.are_lc.assign(100, true);
+  std::fill(cg_pair.are_lc.begin() + 80, cg_pair.are_lc.end(), false);
+
+  // The other two pairs are tracking-dominated, weight 10 each.
+  const std::array<std::pair<image_t, image_t>, 2> tracking_pairs = {
+      {{1, 3}, {2, 3}}};
+  for (const auto& pair : tracking_pairs) {
+    const image_t a = pair.first;
+    const image_t b = pair.second;
+    const image_pair_t pair_id = ImagePairToPairId(a, b);
+    auto& other = data.correspondence_graph.MutableImagePairs()[pair_id];
+    other.image_id1 = a;
+    other.image_id2 = b;
+    other.pair_id = pair_id;
+    other.inliers.resize(10);
+    std::iota(other.inliers.begin(), other.inliers.end(), 0);
+    other.are_lc.assign(10, false);
+  }
+  return data;
+}
+
+}  // namespace
+
+// Returns the set of (child, parent) edges in the spanning tree, excluding
+// the root self-loop (``parents[root] == root``).
+std::set<std::pair<image_t, image_t>> CollectTreeEdges(
+    const std::unordered_map<image_t, image_t>& parents, image_t root) {
+  std::set<std::pair<image_t, image_t>> edges;
+  for (const auto& [child, parent] : parents) {
+    if (child == root) continue;  // root's self-loop is not a tree edge
+    // Canonicalise (a, b) so we can compare regardless of orientation.
+    edges.emplace(std::min(child, parent), std::max(child, parent));
+  }
+  return edges;
+}
+
+TEST(RotationAveraging, Gate_LcPenaltyMst_Off_KeepsLcDominantEdge) {
+  LcMstFixture data = BuildLcMstFixture();
+
+  std::unordered_map<image_t, image_t> parents;
+  const image_t root = ComputeMaximumPoseGraphSpanningTree(
+      data.pose_graph,
+      data.image_ids,
+      parents,
+      /*prioritize_tracking=*/false,
+      &data.correspondence_graph);
+
+  // 3 nodes -> 3 entries in the parent map (one is the root self-loop).
+  EXPECT_EQ(parents.size(), 3u);
+
+  // The 1-2 edge (weight 100) is the heaviest, so it must appear in the
+  // tree regardless of LC status when the gate is OFF.
+  const auto tree_edges = CollectTreeEdges(parents, root);
+  EXPECT_EQ(tree_edges.size(), 2u);
+  EXPECT_GT(tree_edges.count({1, 2}), 0u)
+      << "Expected the 1-2 edge in the MST when prioritize_tracking=false";
+
+  EXPECT_TRUE(root == 1 || root == 2 || root == 3);
+}
+
+TEST(RotationAveraging, Gate_LcPenaltyMst_On_RoutesAroundLcEdge) {
+  LcMstFixture data = BuildLcMstFixture();
+
+  std::unordered_map<image_t, image_t> parents;
+  const image_t root = ComputeMaximumPoseGraphSpanningTree(
+      data.pose_graph,
+      data.image_ids,
+      parents,
+      /*prioritize_tracking=*/true,
+      &data.correspondence_graph);
+
+  // With the LC penalty active, the 1-2 edge's effective weight is
+  // 100 - kLCPenalty (=1e9), so the MST must pick the 1-3 + 2-3 path.
+  EXPECT_EQ(parents.size(), 3u);
+  const auto tree_edges = CollectTreeEdges(parents, root);
+  EXPECT_EQ(tree_edges.size(), 2u);
+  EXPECT_EQ(tree_edges.count({1, 2}), 0u)
+      << "Expected the 1-2 edge to be skipped when prioritize_tracking=true";
+  EXPECT_GT(tree_edges.count({1, 3}), 0u)
+      << "Expected the 1-3 edge in the LC-penalty MST";
+  EXPECT_GT(tree_edges.count({2, 3}), 0u)
+      << "Expected the 2-3 edge in the LC-penalty MST";
+
+  EXPECT_TRUE(root == 1 || root == 2 || root == 3);
+}
+
+TEST(RotationAveraging,
+     Gate_LcPenaltyMst_OnWithoutCgFallsBackToVanilla) {
+  // With the gate ON but no correspondence graph, the helper should ignore
+  // the LC penalty entirely (the second guard in the ``cg_map_ptr`` ternary).
+  // Verifies that the gate alone — without a CG — does not silently change
+  // behaviour relative to the OFF branch.
+  LcMstFixture data = BuildLcMstFixture();
+
+  std::unordered_map<image_t, image_t> parents_on;
+  ComputeMaximumPoseGraphSpanningTree(data.pose_graph,
+                                      data.image_ids,
+                                      parents_on,
+                                      /*prioritize_tracking=*/true,
+                                      /*correspondence_graph=*/nullptr);
+
+  std::unordered_map<image_t, image_t> parents_off;
+  ComputeMaximumPoseGraphSpanningTree(data.pose_graph,
+                                      data.image_ids,
+                                      parents_off,
+                                      /*prioritize_tracking=*/false,
+                                      /*correspondence_graph=*/nullptr);
+
+  EXPECT_EQ(parents_on, parents_off);
+}
+
 // Covers: InitializeRigRotationsFromImages standalone (lines 465-564) with
 // multi-camera rig to exercise cam_from_rig estimation and rig_from_world
 // averaging.
@@ -371,6 +552,111 @@ TEST(RotationAveraging, InitializeSensorFromRigUsingCamsFromWorld) {
                         .rotation()),
                 1e-6);
     }
+  }
+}
+
+// =============================================================================
+// RelativeRotationError functor tests (video-aware Ceres path).
+// =============================================================================
+
+namespace {
+
+// Convert a rotation matrix to a 3-DOF angle-axis vector.
+Eigen::Vector3d RotationMatrixToAngleAxisVec(const Eigen::Matrix3d& R) {
+  Eigen::Vector3d aa;
+  ceres::RotationMatrixToAngleAxis(R.data(), aa.data());
+  return aa;
+}
+
+// Convert a quaternion to a 3-DOF angle-axis vector.
+Eigen::Vector3d QuaternionToAngleAxisVec(const Eigen::Quaterniond& q) {
+  return RotationMatrixToAngleAxisVec(q.toRotationMatrix());
+}
+
+}  // namespace
+
+TEST(RelativeRotationError, ZeroResidualWhenRotationsConsistent) {
+  // Construct a consistent triple (R1, R2, R_rel) such that
+  // R2 = R_rel * R1. The residual should vanish.
+  for (int trial = 0; trial < 16; ++trial) {
+    const Eigen::Quaterniond q1 = Eigen::Quaterniond::UnitRandom();
+    const Eigen::Quaterniond q_rel = Eigen::Quaterniond::UnitRandom();
+    const Eigen::Matrix3d R1 = q1.toRotationMatrix();
+    const Eigen::Matrix3d R_rel = q_rel.toRotationMatrix();
+    const Eigen::Matrix3d R2 = R_rel * R1;
+
+    const Eigen::Vector3d aa1 = RotationMatrixToAngleAxisVec(R1);
+    const Eigen::Vector3d aa2 = RotationMatrixToAngleAxisVec(R2);
+    const Eigen::Vector3d rel_aa = RotationMatrixToAngleAxisVec(R_rel);
+
+    RelativeRotationError functor(rel_aa);
+    Eigen::Vector3d residual;
+    ASSERT_TRUE(functor(aa1.data(), aa2.data(), residual.data()));
+    EXPECT_LT(residual.norm(), 1e-9) << "trial=" << trial;
+  }
+}
+
+TEST(RelativeRotationError, NonZeroResidualWhenInconsistent) {
+  // Inject a known angular discrepancy R_err on top of an otherwise
+  // consistent triple, so the functor's residual norm should match
+  // the discrepancy angle.
+  for (int trial = 0; trial < 16; ++trial) {
+    const Eigen::Quaterniond q1 = Eigen::Quaterniond::UnitRandom();
+    const Eigen::Quaterniond q_rel = Eigen::Quaterniond::UnitRandom();
+
+    // Build a known small-angle perturbation about a random axis.
+    const double err_angle = 0.05 + 0.1 * trial / 16.0;  // 0.05..0.15 rad
+    Eigen::Vector3d axis = Eigen::Vector3d::Random().normalized();
+    const Eigen::AngleAxisd q_err(err_angle, axis);
+
+    const Eigen::Matrix3d R1 = q1.toRotationMatrix();
+    const Eigen::Matrix3d R_rel = q_rel.toRotationMatrix();
+    // R2 deliberately rotated *off* the consistent value by R_err. The
+    // residual ends up being the inverse-transformed perturbation:
+    //   R_residual = R2^T * R_rel * R1
+    //              = (R_err * R_rel * R1)^T * R_rel * R1
+    //              = R1^T * R_rel^T * R_err^T * R_rel * R1.
+    // That is a similarity transform of R_err^T, so its rotation angle
+    // equals err_angle exactly.
+    const Eigen::Matrix3d R2 = q_err.toRotationMatrix() * R_rel * R1;
+
+    const Eigen::Vector3d aa1 = RotationMatrixToAngleAxisVec(R1);
+    const Eigen::Vector3d aa2 = RotationMatrixToAngleAxisVec(R2);
+    const Eigen::Vector3d rel_aa = RotationMatrixToAngleAxisVec(R_rel);
+
+    RelativeRotationError functor(rel_aa);
+    Eigen::Vector3d residual;
+    ASSERT_TRUE(functor(aa1.data(), aa2.data(), residual.data()));
+    EXPECT_NEAR(residual.norm(), err_angle, 1e-9) << "trial=" << trial;
+  }
+}
+
+TEST(RelativeRotationError, SymmetryUnderSwapAndInvert) {
+  // Swapping (R1, R2) and inverting R_rel must give a residual of equal
+  // magnitude (sign flips because angle-axis of inverse is negated).
+  for (int trial = 0; trial < 16; ++trial) {
+    const Eigen::Quaterniond q1 = Eigen::Quaterniond::UnitRandom();
+    const Eigen::Quaterniond q2 = Eigen::Quaterniond::UnitRandom();
+    const Eigen::Quaterniond q_rel = Eigen::Quaterniond::UnitRandom();
+
+    const Eigen::Vector3d aa1 = QuaternionToAngleAxisVec(q1);
+    const Eigen::Vector3d aa2 = QuaternionToAngleAxisVec(q2);
+    const Eigen::Vector3d rel_aa = QuaternionToAngleAxisVec(q_rel);
+    const Eigen::Vector3d rel_aa_inv = QuaternionToAngleAxisVec(q_rel.conjugate());
+
+    RelativeRotationError functor_orig(rel_aa);
+    RelativeRotationError functor_swap(rel_aa_inv);
+    Eigen::Vector3d residual_orig, residual_swap;
+    ASSERT_TRUE(functor_orig(aa1.data(), aa2.data(), residual_orig.data()));
+    ASSERT_TRUE(functor_swap(aa2.data(), aa1.data(), residual_swap.data()));
+
+    // Norms must agree to high precision.
+    EXPECT_NEAR(residual_orig.norm(), residual_swap.norm(), 1e-9)
+        << "trial=" << trial;
+    // The two residuals are angle-axis vectors of mutually inverse
+    // rotations, hence sum to zero.
+    EXPECT_LT((residual_orig + residual_swap).norm(), 1e-9)
+        << "trial=" << trial;
   }
 }
 

--- a/src/colmap/estimators/rotation_averaging_test.cc
+++ b/src/colmap/estimators/rotation_averaging_test.cc
@@ -51,16 +51,17 @@ namespace {
 
 void LoadReconstructionAndPoseGraph(const Database& database,
                                     Reconstruction* reconstruction,
-                                    PoseGraph* pose_graph) {
-  DatabaseCache database_cache;
+                                    PoseGraph* pose_graph,
+                                    DatabaseCache* database_cache) {
   DatabaseCache::Options options;
-  database_cache.Load(database, options);
-  reconstruction->Load(database_cache);
-  pose_graph->Load(*database_cache.CorrespondenceGraph());
+  database_cache->Load(database, options);
+  reconstruction->Load(*database_cache);
+  pose_graph->Load(*database_cache->CorrespondenceGraph());
 }
 
 struct TestData {
   std::shared_ptr<Database> database;
+  DatabaseCache database_cache;
   Reconstruction gt_reconstruction;
   Reconstruction reconstruction;
   PoseGraph pose_graph;
@@ -77,8 +78,10 @@ TestData CreateTestData(const SyntheticDatasetOptions& dataset_options,
     SynthesizeNoise(
         *noise_options, &data.gt_reconstruction, data.database.get());
   }
-  LoadReconstructionAndPoseGraph(
-      *data.database, &data.reconstruction, &data.pose_graph);
+  LoadReconstructionAndPoseGraph(*data.database,
+                                 &data.reconstruction,
+                                 &data.pose_graph,
+                                 &data.database_cache);
   data.pose_priors = data.database->ReadAllPosePriors();
   return data;
 }
@@ -341,6 +344,32 @@ TEST(RotationAveraging, GravityWithUnknownRigSensorsReturnsFalse) {
                                            data.pose_priors,
                                            active_image_ids,
                                            data.reconstruction));
+}
+
+TEST(RotationAveraging, SkipRiskyLcPairsWithUnknownRigUsesCorrespondenceGraph) {
+  SetPRNGSeed(1);
+
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 2;
+  synthetic_dataset_options.num_frames_per_rig = 4;
+  synthetic_dataset_options.num_points3D = 50;
+  synthetic_dataset_options.sensor_from_rig_rotation_stddev = 20.;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  auto data = CreateTestData(synthetic_dataset_options);
+
+  ResetSensorsFromRig(data.reconstruction);
+
+  RotationEstimatorOptions options = CreateRATestOptions();
+  options.skip_risky_lc_pairs = true;
+
+  EXPECT_TRUE(
+      RunRotationAveraging(options,
+                           data.pose_graph,
+                           data.reconstruction,
+                           data.pose_priors,
+                           nullptr,
+                           data.database_cache.CorrespondenceGraph().get()));
 }
 
 // LC-penalty branch inside ComputeMaximumPoseGraphSpanningTree.

--- a/src/colmap/estimators/view_graph_calibration.h
+++ b/src/colmap/estimators/view_graph_calibration.h
@@ -118,9 +118,8 @@ struct FocalLengthCalibResult {
 
 // Run only the Ceres focal-length optimization and return the focals + per-pair
 // calibration errors, without touching a database, F/E recomputation, or pair
-// state. Exposed so external callers can drive the optimization with their own
-// scene state (e.g. an unordered_map<image_t, Image> not yet promoted to a
-// Reconstruction).
+// state. Exposed so external callers can drive the optimization with their
+// own scene state.
 FocalLengthCalibResult CalibrateFocalLengths(
     const ViewGraphCalibrationOptions& options,
     const std::vector<FocalLengthCalibInput>& inputs,

--- a/src/colmap/estimators/view_graph_calibration.h
+++ b/src/colmap/estimators/view_graph_calibration.h
@@ -115,8 +115,9 @@ struct FocalLengthCalibResult {
 
 // Run only the Ceres focal-length optimization and return the focals + per-pair
 // calibration errors, without touching a database, F/E recomputation, or pair
-// state. Exposed so external callers can drive the optimization with their
-// own scene state.
+// state. Exposed so external callers can drive the optimization with their own
+// scene state (e.g. an unordered_map<image_t, Image> not yet promoted to a
+// Reconstruction).
 FocalLengthCalibResult CalibrateFocalLengths(
     const ViewGraphCalibrationOptions& options,
     const std::vector<FocalLengthCalibInput>& inputs,

--- a/src/colmap/scene/correspondence_graph.cc
+++ b/src/colmap/scene/correspondence_graph.cc
@@ -124,7 +124,11 @@ void CorrespondenceGraph::AddTwoViewGeometry(
   THROW_CHECK(inserted)
       << "Two view geometry for image pair was already added: image_id1="
       << image_id1 << ", image_id2=" << image_id2;
-  image_pair_it->second.num_matches =
+  auto& image_pair = image_pair_it->second;
+  image_pair.image_id1 = image_id1;
+  image_pair.image_id2 = image_id2;
+  image_pair.pair_id = pair_id;
+  image_pair.num_matches =
       static_cast<point2D_t>(two_view_geometry.inlier_matches.size());
 
   // Store all matches in correspondence graph data structure. This data-
@@ -132,6 +136,8 @@ void CorrespondenceGraph::AddTwoViewGeometry(
   // significantly more efficient when updating the correspondences in case an
   // observation is triangulated.
 
+  FeatureMatches stored_inlier_matches;
+  stored_inlier_matches.reserve(two_view_geometry.inlier_matches.size());
   for (const auto& match : two_view_geometry.inlier_matches) {
     const bool valid_idx1 = match.point2D_idx1 < image1.corrs.size();
     const bool valid_idx2 = match.point2D_idx2 < image2.corrs.size();
@@ -153,7 +159,7 @@ void CorrespondenceGraph::AddTwoViewGeometry(
       if (duplicate) {
         image1.num_correspondences -= 1;
         image2.num_correspondences -= 1;
-        image_pair_it->second.num_matches -= 1;
+        image_pair.num_matches -= 1;
         LOG(WARNING) << StringPrintf(
             "Duplicate correspondence between "
             "point2D_idx=%d in image_id=%d and point2D_idx=%d in "
@@ -172,11 +178,12 @@ void CorrespondenceGraph::AddTwoViewGeometry(
         if (corrs2.size() == 1) {
           image2.num_observations += 1;
         }
+        stored_inlier_matches.push_back(match);
       }
     } else {
       image1.num_correspondences -= 1;
       image2.num_correspondences -= 1;
-      image_pair_it->second.num_matches -= 1;
+      image_pair.num_matches -= 1;
       if (!valid_idx1) {
         LOG(WARNING) << StringPrintf(
             "point2D_idx=%d in image_id=%d does not exist",
@@ -191,6 +198,16 @@ void CorrespondenceGraph::AddTwoViewGeometry(
       }
     }
   }
+  image_pair.matches.resize(static_cast<int>(stored_inlier_matches.size()), 2);
+  image_pair.inliers.resize(stored_inlier_matches.size());
+  image_pair.are_lc.assign(stored_inlier_matches.size(), false);
+  for (size_t i = 0; i < stored_inlier_matches.size(); ++i) {
+    image_pair.matches(static_cast<int>(i), 0) =
+        stored_inlier_matches[i].point2D_idx1;
+    image_pair.matches(static_cast<int>(i), 1) =
+        stored_inlier_matches[i].point2D_idx2;
+    image_pair.inliers[i] = static_cast<int>(i);
+  }
 
   // Clear and deallocate matches.
   FeatureMatches().swap(two_view_geometry.inlier_matches);
@@ -199,7 +216,7 @@ void CorrespondenceGraph::AddTwoViewGeometry(
     two_view_geometry.Invert();
   }
 
-  image_pair_it->second.two_view_geometry = std::move(two_view_geometry);
+  image_pair.two_view_geometry = std::move(two_view_geometry);
 }
 
 CorrespondenceGraph::CorrespondenceRange

--- a/src/colmap/scene/correspondence_graph.h
+++ b/src/colmap/scene/correspondence_graph.h
@@ -66,6 +66,8 @@ class CorrespondenceGraph {
   };
 
   // Two-view image pair with geometry, matches, and metadata.
+  // Extends colmap core with glomap additions: image IDs, validity flags,
+  // loop closure markers, covariance, and full match data.
   struct ImagePair {
     // Default constructor.
     ImagePair() = default;
@@ -76,7 +78,7 @@ class CorrespondenceGraph {
           image_id2(img_id2),
           pair_id(ImagePairToPairId(img_id1, img_id2)) {}
 
-    // Image identifiers.
+    // Image identifiers (colmap upstream + glomap additions).
     image_t image_id1 = kInvalidImageId;
     image_t image_id2 = kInvalidImageId;
 
@@ -86,11 +88,13 @@ class CorrespondenceGraph {
     // Indicator whether the image pair is valid.
     bool is_valid = true;
 
-    // The number of inlier matches between pairs of images.
+    // The number of inlier matches between pairs of images (colmap upstream).
     point2D_t num_matches = 0;
 
-    // The two-view geometry of the image pair without matches.
+    // The two-view geometry of the image pair without matches (colmap upstream).
     struct TwoViewGeometry two_view_geometry;
+
+    // --- glomap additions below ---
 
     // Weight is the initial inlier rate.
     double weight = 0.0;
@@ -99,12 +103,18 @@ class CorrespondenceGraph {
     // Initialized to zero matrix to indicate it hasn't been computed yet.
     Eigen::Matrix3d cov_t = Eigen::Matrix3d::Zero();
 
+    // Indicator whether this is a loop closure.
+    bool is_LC = false;
+
     // All matches between the two images (not just inliers).
     // First column is feature index in image1, second column in image2.
     Eigen::MatrixXi matches;
 
     // Row indices of inliers in the matches matrix.
     std::vector<int> inliers;
+
+    // Whether each match is a loop closure match (same size as matches.rows()).
+    std::vector<bool> are_lc;
   };
 
   CorrespondenceGraph() = default;
@@ -198,7 +208,9 @@ class CorrespondenceGraph {
   inline std::unordered_map<image_pair_t, ImagePair>& MutableImagePairs() {
     return image_pairs_;
   }
-  // Const accessor for the internal image_pairs map.
+  // Const accessor for the internal image_pairs map. RA's
+  // skip_risky_LC_pairs path uses this to read ImagePair.{inliers, are_lc}
+  // without taking mutable access.
   inline const std::unordered_map<image_pair_t, ImagePair>& ImagePairsMap()
       const {
     return image_pairs_;

--- a/src/colmap/scene/correspondence_graph.h
+++ b/src/colmap/scene/correspondence_graph.h
@@ -66,7 +66,7 @@ class CorrespondenceGraph {
   };
 
   // Two-view image pair with geometry, matches, and metadata.
-  // Extends colmap core with glomap additions: image IDs, validity flags,
+  // Extends colmap core with image IDs, validity flags,
   // loop closure markers, covariance, and full match data.
   struct ImagePair {
     // Default constructor.
@@ -78,7 +78,7 @@ class CorrespondenceGraph {
           image_id2(img_id2),
           pair_id(ImagePairToPairId(img_id1, img_id2)) {}
 
-    // Image identifiers (colmap upstream + glomap additions).
+    // Image identifiers.
     image_t image_id1 = kInvalidImageId;
     image_t image_id2 = kInvalidImageId;
 
@@ -88,13 +88,11 @@ class CorrespondenceGraph {
     // Indicator whether the image pair is valid.
     bool is_valid = true;
 
-    // The number of inlier matches between pairs of images (colmap upstream).
+    // The number of inlier matches between pairs of images.
     point2D_t num_matches = 0;
 
-    // The two-view geometry of the image pair without matches (colmap upstream).
+    // The two-view geometry of the image pair without matches.
     struct TwoViewGeometry two_view_geometry;
-
-    // --- glomap additions below ---
 
     // Weight is the initial inlier rate.
     double weight = 0.0;
@@ -206,7 +204,7 @@ class CorrespondenceGraph {
     return image_pairs_;
   }
   // Const accessor for the internal image_pairs map. RA's
-  // skip_risky_LC_pairs path uses this to read ImagePair.{inliers, are_lc}
+  // skip_risky_lc_pairs path uses this to read ImagePair.{inliers, are_lc}
   // without taking mutable access.
   inline const std::unordered_map<image_pair_t, ImagePair>& ImagePairsMap()
       const {

--- a/src/colmap/scene/correspondence_graph.h
+++ b/src/colmap/scene/correspondence_graph.h
@@ -103,9 +103,6 @@ class CorrespondenceGraph {
     // Initialized to zero matrix to indicate it hasn't been computed yet.
     Eigen::Matrix3d cov_t = Eigen::Matrix3d::Zero();
 
-    // Indicator whether this is a loop closure.
-    bool is_LC = false;
-
     // All matches between the two images (not just inliers).
     // First column is feature index in image1, second column in image2.
     Eigen::MatrixXi matches;

--- a/src/colmap/scene/correspondence_graph_test.cc
+++ b/src/colmap/scene/correspondence_graph_test.cc
@@ -103,6 +103,13 @@ TEST_P(CorrespondenceGraphFinalizeTest, TwoView) {
   EXPECT_EQ(correspondence_graph.NumMatchesBetweenAllImages().at(pair_id), 4);
   EXPECT_THAT(correspondence_graph.ImagePairs(),
               testing::UnorderedElementsAre(pair_id));
+  const auto& image_pair = correspondence_graph.ImagePairsMap().at(pair_id);
+  EXPECT_EQ(image_pair.image_id1, 0);
+  EXPECT_EQ(image_pair.image_id2, 1);
+  EXPECT_EQ(image_pair.matches.rows(), 4);
+  EXPECT_EQ(image_pair.matches.cols(), 2);
+  EXPECT_EQ(image_pair.inliers, std::vector<int>({0, 1, 2, 3}));
+  EXPECT_EQ(image_pair.are_lc, std::vector<bool>({false, false, false, false}));
   const TwoViewGeometry two_view_geometry01_stored =
       correspondence_graph.ExtractTwoViewGeometry(
           0, 1, /*extract_inlier_matches=*/true);

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -41,11 +41,12 @@ Image::Image()
       num_points3D_(0) {}
 
 Image::Image(const Image& other)
-    : features(other.features),
-      features_undist(other.features_undist),
-      angular_stddevs(other.angular_stddevs),
-      is_inlier(other.is_inlier),
+    : is_inlier(other.is_inlier),
       is_track_anchor(other.is_track_anchor),
+      angular_stddevs(other.angular_stddevs),
+      is_registered(other.is_registered),
+      features(other.features),
+      features_undist(other.features_undist),
       name_(other.Name()),
       camera_ptr_(other.HasCameraPtr() ? other.CameraPtr() : nullptr),
       frame_ptr_(other.HasFramePtr() ? other.FramePtr() : nullptr),
@@ -75,12 +76,12 @@ Image& Image::operator=(const Image& other) {
     num_points3D_ = other.NumPoints3D();
     points2D_ = other.Points2D();
     pixel_cholesky_xy_ = other.PixelCholeskyXY();
-    // Public data members.
-    features = other.features;
-    features_undist = other.features_undist;
-    angular_stddevs = other.angular_stddevs;
     is_inlier = other.is_inlier;
     is_track_anchor = other.is_track_anchor;
+    angular_stddevs = other.angular_stddevs;
+    is_registered = other.is_registered;
+    features = other.features;
+    features_undist = other.features_undist;
   }
   return *this;
 }

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -75,11 +75,12 @@ Image& Image::operator=(const Image& other) {
     num_points3D_ = other.NumPoints3D();
     points2D_ = other.Points2D();
     pixel_cholesky_xy_ = other.PixelCholeskyXY();
-    is_inlier = other.is_inlier;
-    is_track_anchor = other.is_track_anchor;
-    angular_stddevs = other.angular_stddevs;
+    // Public data members.
     features = other.features;
     features_undist = other.features_undist;
+    angular_stddevs = other.angular_stddevs;
+    is_inlier = other.is_inlier;
+    is_track_anchor = other.is_track_anchor;
   }
   return *this;
 }

--- a/src/colmap/scene/image.cc
+++ b/src/colmap/scene/image.cc
@@ -44,7 +44,6 @@ Image::Image(const Image& other)
     : is_inlier(other.is_inlier),
       is_track_anchor(other.is_track_anchor),
       angular_stddevs(other.angular_stddevs),
-      is_registered(other.is_registered),
       features(other.features),
       features_undist(other.features_undist),
       name_(other.Name()),
@@ -79,7 +78,6 @@ Image& Image::operator=(const Image& other) {
     is_inlier = other.is_inlier;
     is_track_anchor = other.is_track_anchor;
     angular_stddevs = other.angular_stddevs;
-    is_registered = other.is_registered;
     features = other.features;
     features_undist = other.features_undist;
   }

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -164,9 +164,6 @@ class Image {
   // Whether this image is currently registered.
   bool is_registered = false;
 
-  // FORK-REMOVAL TODO: features / features_undist are fork-only.
-  // See .claude/notes/glomap_audit/fork_removal_todo.md.
-
   // Raw 2D keypoints (xy), separate from points2D_.
   std::vector<Eigen::Vector2d> features;
   // Undistorted 3D rays per feature.

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -161,6 +161,9 @@ class Image {
   // Per-feature angular standard deviations (sigma_x, sigma_y) in radians.
   std::vector<Eigen::Vector2d> angular_stddevs;
 
+  // FORK-REMOVAL TODO: features / features_undist are fork-only.
+  // See .claude/notes/glomap_audit/fork_removal_todo.md.
+
   // Raw 2D keypoints (xy), separate from points2D_.
   std::vector<Eigen::Vector2d> features;
   // Undistorted 3D rays per feature.
@@ -316,11 +319,6 @@ const std::vector<struct Point2D>& Image::Points2D() const { return points2D_; }
 std::vector<struct Point2D>& Image::Points2D() { return points2D_; }
 
 bool Image::operator==(const Image& other) const {
-  // Identity-equality (NOT bit-equality across pipeline state). Mutable
-  // per-pipeline-phase fields (is_inlier, features_undist, ...) are
-  // intentionally NOT compared — two Images at different pipeline stages
-  // with the same identity should compare equal. pixel_cholesky_xy_ is
-  // included because it's a per-feature immutable property.
   const bool result = image_id_ == other.image_id_ &&          //
                       camera_id_ == other.camera_id_ &&        //
                       frame_id_ == other.frame_id_ &&          //

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -161,6 +161,9 @@ class Image {
   // Per-feature angular standard deviations (sigma_x, sigma_y) in radians.
   std::vector<Eigen::Vector2d> angular_stddevs;
 
+  // Whether this image is currently registered.
+  bool is_registered = false;
+
   // FORK-REMOVAL TODO: features / features_undist are fork-only.
   // See .claude/notes/glomap_audit/fork_removal_todo.md.
 
@@ -319,13 +322,19 @@ const std::vector<struct Point2D>& Image::Points2D() const { return points2D_; }
 std::vector<struct Point2D>& Image::Points2D() { return points2D_; }
 
 bool Image::operator==(const Image& other) const {
+  // Identity-equality (NOT bit-equality across pipeline state). Mutable
+  // per-pipeline-phase fields (is_inlier, features_undist, ...) are
+  // intentionally NOT compared — two Images at different pipeline stages
+  // with the same identity should compare equal. pixel_cholesky_xy_ is
+  // included because it's a per-feature immutable property.
   const bool result = image_id_ == other.image_id_ &&          //
                       camera_id_ == other.camera_id_ &&        //
                       frame_id_ == other.frame_id_ &&          //
                       name_ == other.name_ &&                  //
                       num_points3D_ == other.num_points3D_ &&  //
                       HasPose() == other.HasPose() &&          //
-                      points2D_ == other.points2D_;
+                      points2D_ == other.points2D_ &&          //
+                      pixel_cholesky_xy_ == other.pixel_cholesky_xy_;
   if (!HasPose()) {
     return result;
   } else {

--- a/src/colmap/scene/image.h
+++ b/src/colmap/scene/image.h
@@ -161,9 +161,6 @@ class Image {
   // Per-feature angular standard deviations (sigma_x, sigma_y) in radians.
   std::vector<Eigen::Vector2d> angular_stddevs;
 
-  // Whether this image is currently registered.
-  bool is_registered = false;
-
   // Raw 2D keypoints (xy), separate from points2D_.
   std::vector<Eigen::Vector2d> features;
   // Undistorted 3D rays per feature.

--- a/src/colmap/scene/track.h
+++ b/src/colmap/scene/track.h
@@ -85,6 +85,10 @@ class Track {
   inline bool operator==(const Track& other) const;
   inline bool operator!=(const Track& other) const;
 
+  // Elements contributed by loop closures (parallel to the standard
+  // elements_ list; same (image_id, point2D_idx) value type as TrackElement).
+  std::vector<TrackElement> lc_elements;
+
  private:
   std::vector<TrackElement> elements_;
 };

--- a/src/colmap/sfm/CMakeLists.txt
+++ b/src/colmap/sfm/CMakeLists.txt
@@ -45,12 +45,10 @@ COLMAP_ADD_LIBRARY(
     PUBLIC_LINK_LIBS
         colmap_scene
         colmap_estimators
-        colmap_estimators_solvers
         colmap_util
     PRIVATE_LINK_LIBS
         colmap_geometry
         colmap_image
-        PoseLib
 )
 
 if(MSVC)

--- a/src/colmap/sfm/CMakeLists.txt
+++ b/src/colmap/sfm/CMakeLists.txt
@@ -40,8 +40,8 @@ COLMAP_ADD_LIBRARY(
         image_pair_inliers.h image_pair_inliers.cc
         observation_manager.h observation_manager.cc
         track_establishment.h track_establishment.cc
-        view_graph_manipulation.h view_graph_manipulation.cc
         track_filter.h track_filter.cc
+        view_graph_manipulation.h view_graph_manipulation.cc
     PUBLIC_LINK_LIBS
         colmap_scene
         colmap_estimators

--- a/src/colmap/sfm/CMakeLists.txt
+++ b/src/colmap/sfm/CMakeLists.txt
@@ -40,15 +40,17 @@ COLMAP_ADD_LIBRARY(
         image_pair_inliers.h image_pair_inliers.cc
         observation_manager.h observation_manager.cc
         track_establishment.h track_establishment.cc
-        track_filter.h track_filter.cc
         view_graph_manipulation.h view_graph_manipulation.cc
+        track_filter.h track_filter.cc
     PUBLIC_LINK_LIBS
         colmap_scene
         colmap_estimators
+        colmap_estimators_solvers
         colmap_util
     PRIVATE_LINK_LIBS
         colmap_geometry
         colmap_image
+        PoseLib
 )
 
 if(MSVC)
@@ -73,6 +75,11 @@ COLMAP_ADD_TEST(
 COLMAP_ADD_TEST(
     NAME incremental_mapper_test
     SRCS incremental_mapper_test.cc
+    LINK_LIBS colmap_sfm
+)
+COLMAP_ADD_TEST(
+    NAME track_establishment_test
+    SRCS track_establishment_test.cc
     LINK_LIBS colmap_sfm
 )
 COLMAP_ADD_TEST(

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -177,8 +177,8 @@ void GlobalMapper::SubsampleTracksForProblem(
   opts.two_view_depth_gate = options.track_two_view_depth_gate;
 
   // Extract registered image set from the reconstruction.
-  // Depth-prior maps are empty on this branch (populated by the depth
-  // extension); pass empty containers to SubsampleTracks.
+  // Depth-prior maps are empty here (populated by optional depth extension);
+  // pass empty containers to SubsampleTracks.
   std::unordered_set<image_t> registered_image_ids;
   std::unordered_map<image_t, std::vector<double>> depth_priors;
   std::unordered_map<image_t, std::vector<bool>> depth_prior_validity;

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -129,12 +129,11 @@ void GlobalMapper::EstablishTracks(const GlobalMapperOptions& options) {
   to.intra_image_consistency_threshold =
       options.track_intra_image_consistency_threshold;
   to.min_num_views_per_track = options.track_min_num_views_per_track;
-  // When the LC second pass is enabled, the helper-side greedy
-  // subsample is bypassed so SubsampleTracksForProblem can run with the
-  // full candidate set including LC observations.
-  to.required_tracks_per_view =
-      options.track_lc_second_pass ? std::numeric_limits<int>::max()
-                                   : options.track_required_tracks_per_view;
+  // LC second pass appends observations after the union-find pass, so it needs
+  // the full candidate set. Without LC, preserve native per-view limiting.
+  to.required_tracks_per_view = options.track_lc_second_pass
+                                    ? std::numeric_limits<int>::max()
+                                    : options.track_required_tracks_per_view;
 
   std::vector<image_pair_t> valid_pair_ids;
   valid_pair_ids.reserve(pose_graph_->NumEdges());
@@ -147,60 +146,21 @@ void GlobalMapper::EstablishTracks(const GlobalMapperOptions& options) {
     ignore_match = MakeLoopClosureMatchPredicate(
         valid_pair_ids, *database_cache_->CorrespondenceGraph());
   }
-
-  auto selected = EstablishTracksFromCorrGraph(
-      valid_pair_ids,
-      *database_cache_->CorrespondenceGraph(),
-      image_id_to_keypoints,
-      to,
-      ignore_match);
+  auto selected =
+      EstablishTracksFromCorrGraph(valid_pair_ids,
+                                   *database_cache_->CorrespondenceGraph(),
+                                   image_id_to_keypoints,
+                                   to,
+                                   ignore_match);
   if (options.track_lc_second_pass) {
     AppendLoopClosureObservations(
-        valid_pair_ids,
-        *database_cache_->CorrespondenceGraph(),
-        selected);
+        valid_pair_ids, *database_cache_->CorrespondenceGraph(), selected);
   }
   for (auto& [point3D_id, point3D] : selected) {
     reconstruction_->AddPoint3D(point3D_id, std::move(point3D));
   }
   LOG(INFO) << "Track establishment: " << reconstruction_->NumPoints3D()
             << " tracks added to reconstruction";
-}
-
-void GlobalMapper::SubsampleTracksForProblem(
-    const GlobalMapperOptions& options) {
-  TrackSubsampleOptions opts;
-  opts.min_num_views_per_track = options.track_min_num_views_per_track;
-  opts.max_num_views_per_track = options.track_max_num_views_per_track;
-  opts.required_tracks_per_view = options.track_required_tracks_per_view;
-  opts.max_num_tracks = options.track_max_num_tracks;
-
-  // Extract registered image set from the reconstruction.
-  std::unordered_set<image_t> registered_image_ids;
-  for (const image_t image_id : reconstruction_->RegImageIds()) {
-    registered_image_ids.insert(image_id);
-  }
-
-  auto selected = SubsampleTracks(opts,
-                                   registered_image_ids,
-                                   reconstruction_->Points3D());
-
-  // Sync back: drop everything not in the selected dict, replace tracks
-  // present in selected so post-restriction Track elements are written.
-  std::vector<point3D_t> to_delete;
-  for (const auto& [pid, _] : reconstruction_->Points3D()) {
-    if (selected.count(pid) == 0) {
-      to_delete.push_back(pid);
-    }
-  }
-  for (const point3D_t pid : to_delete) {
-    reconstruction_->DeletePoint3D(pid);
-  }
-  for (auto& [pid, p3d] : selected) {
-    if (reconstruction_->ExistsPoint3D(pid)) {
-      reconstruction_->Point3D(pid).track = std::move(p3d.track);
-    }
-  }
 }
 
 bool GlobalMapper::GlobalPositioning(const GlobalPositionerOptions& options,

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -129,7 +129,12 @@ void GlobalMapper::EstablishTracks(const GlobalMapperOptions& options) {
   to.intra_image_consistency_threshold =
       options.track_intra_image_consistency_threshold;
   to.min_num_views_per_track = options.track_min_num_views_per_track;
-  to.required_tracks_per_view = options.track_required_tracks_per_view;
+  // When the LC second pass is enabled, the helper-side greedy
+  // subsample is bypassed so SubsampleTracksForProblem can run with the
+  // full candidate set including LC observations.
+  to.required_tracks_per_view =
+      options.track_lc_second_pass ? std::numeric_limits<int>::max()
+                                   : options.track_required_tracks_per_view;
 
   std::vector<image_pair_t> valid_pair_ids;
   valid_pair_ids.reserve(pose_graph_->NumEdges());
@@ -137,16 +142,72 @@ void GlobalMapper::EstablishTracks(const GlobalMapperOptions& options) {
     valid_pair_ids.push_back(pair_id);
   }
 
+  MatchPredicate ignore_match;
+  if (options.track_lc_second_pass) {
+    ignore_match = MakeLoopClosureMatchPredicate(
+        valid_pair_ids, *database_cache_->CorrespondenceGraph());
+  }
+
   auto selected = EstablishTracksFromCorrGraph(
       valid_pair_ids,
       *database_cache_->CorrespondenceGraph(),
       image_id_to_keypoints,
-      to);
+      to,
+      ignore_match);
+  if (options.track_lc_second_pass) {
+    AppendLoopClosureObservations(
+        valid_pair_ids,
+        *database_cache_->CorrespondenceGraph(),
+        selected);
+  }
   for (auto& [point3D_id, point3D] : selected) {
     reconstruction_->AddPoint3D(point3D_id, std::move(point3D));
   }
   LOG(INFO) << "Track establishment: " << reconstruction_->NumPoints3D()
             << " tracks added to reconstruction";
+}
+
+void GlobalMapper::SubsampleTracksForProblem(
+    const GlobalMapperOptions& options) {
+  TrackSubsampleOptions opts;
+  opts.min_num_views_per_track = options.track_min_num_views_per_track;
+  opts.max_num_views_per_track = options.track_max_num_views_per_track;
+  opts.required_tracks_per_view = options.track_required_tracks_per_view;
+  opts.max_num_tracks = options.track_max_num_tracks;
+  opts.two_view_depth_gate = options.track_two_view_depth_gate;
+
+  // Extract registered image set from the reconstruction.
+  // Depth-prior maps are empty on this branch (populated by the depth
+  // extension); pass empty containers to SubsampleTracks.
+  std::unordered_set<image_t> registered_image_ids;
+  std::unordered_map<image_t, std::vector<double>> depth_priors;
+  std::unordered_map<image_t, std::vector<bool>> depth_prior_validity;
+  for (const image_t image_id : reconstruction_->RegImageIds()) {
+    registered_image_ids.insert(image_id);
+  }
+
+  auto selected = SubsampleTracks(opts,
+                                   registered_image_ids,
+                                   depth_priors,
+                                   depth_prior_validity,
+                                   reconstruction_->Points3D());
+
+  // Sync back: drop everything not in the selected dict, replace tracks
+  // present in selected so post-restriction Track elements are written.
+  std::vector<point3D_t> to_delete;
+  for (const auto& [pid, _] : reconstruction_->Points3D()) {
+    if (selected.count(pid) == 0) {
+      to_delete.push_back(pid);
+    }
+  }
+  for (const point3D_t pid : to_delete) {
+    reconstruction_->DeletePoint3D(pid);
+  }
+  for (auto& [pid, p3d] : selected) {
+    if (reconstruction_->ExistsPoint3D(pid)) {
+      reconstruction_->Point3D(pid).track = std::move(p3d.track);
+    }
+  }
 }
 
 bool GlobalMapper::GlobalPositioning(const GlobalPositionerOptions& options,

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -89,16 +89,24 @@ bool GlobalMapper::RotationAveraging(const RotationEstimatorOptions& options) {
   // connected component.
   RotationEstimatorOptions custom_options = options;
   custom_options.filter_unregistered = false;
-  if (!RunRotationAveraging(
-          custom_options, *pose_graph_, *reconstruction_, pose_priors)) {
+  if (!RunRotationAveraging(custom_options,
+                            *pose_graph_,
+                            *reconstruction_,
+                            pose_priors,
+                            nullptr,
+                            database_cache_->CorrespondenceGraph().get())) {
     return false;
   }
 
   // Second pass: re-solve on registered frames only to refine rotations
   // after outlier removal.
   custom_options.filter_unregistered = true;
-  if (!RunRotationAveraging(
-          custom_options, *pose_graph_, *reconstruction_, pose_priors)) {
+  if (!RunRotationAveraging(custom_options,
+                            *pose_graph_,
+                            *reconstruction_,
+                            pose_priors,
+                            nullptr,
+                            database_cache_->CorrespondenceGraph().get())) {
     return false;
   }
 

--- a/src/colmap/sfm/global_mapper.cc
+++ b/src/colmap/sfm/global_mapper.cc
@@ -174,22 +174,15 @@ void GlobalMapper::SubsampleTracksForProblem(
   opts.max_num_views_per_track = options.track_max_num_views_per_track;
   opts.required_tracks_per_view = options.track_required_tracks_per_view;
   opts.max_num_tracks = options.track_max_num_tracks;
-  opts.two_view_depth_gate = options.track_two_view_depth_gate;
 
   // Extract registered image set from the reconstruction.
-  // Depth-prior maps are empty here (populated by optional depth extension);
-  // pass empty containers to SubsampleTracks.
   std::unordered_set<image_t> registered_image_ids;
-  std::unordered_map<image_t, std::vector<double>> depth_priors;
-  std::unordered_map<image_t, std::vector<bool>> depth_prior_validity;
   for (const image_t image_id : reconstruction_->RegImageIds()) {
     registered_image_ids.insert(image_id);
   }
 
   auto selected = SubsampleTracks(opts,
                                    registered_image_ids,
-                                   depth_priors,
-                                   depth_prior_validity,
                                    reconstruction_->Points3D());
 
   // Sync back: drop everything not in the selected dict, replace tracks

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -66,14 +66,7 @@ struct GlobalMapperOptions {
   int track_required_tracks_per_view = std::numeric_limits<int>::max();
   // Minimum number of views per track.
   int track_min_num_views_per_track = 3;
-  // Upper bound on track length (regular Track::Length() only; LC
-  // observations not counted). Tracks above this are dropped during
-  // SubsampleTracksForProblem.
-  int track_max_num_views_per_track = std::numeric_limits<int>::max();
-  // Hard cap on the number of tracks kept after subsampling.
-  int track_max_num_tracks = std::numeric_limits<int>::max();
-  // Append LC observations to tracks after establishment. Bypasses
-  // helper-side subsample; call SubsampleTracksForProblem after.
+  // Append LC observations to tracks after establishment.
   bool track_lc_second_pass = false;
 
   // Thresholds for each component.
@@ -121,9 +114,6 @@ class GlobalMapper {
 
   // Establish tracks from feature matches.
   void EstablishTracks(const GlobalMapperOptions& options);
-
-  // Greedy length-sorted subsample with optional 2-view depth gate.
-  void SubsampleTracksForProblem(const GlobalMapperOptions& options);
 
   // Estimate global camera positions.
   bool GlobalPositioning(const GlobalPositionerOptions& options,

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -66,6 +66,24 @@ struct GlobalMapperOptions {
   int track_required_tracks_per_view = std::numeric_limits<int>::max();
   // Minimum number of views per track.
   int track_min_num_views_per_track = 3;
+  // Upper bound on track length (regular Track::Length() only; LC
+  // observations not counted). Tracks above this are dropped during
+  // SubsampleTracksForProblem.
+  int track_max_num_views_per_track = std::numeric_limits<int>::max();
+  // Hard cap on the number of tracks kept after subsampling.
+  int track_max_num_tracks = std::numeric_limits<int>::max();
+  // If true, AppendLoopClosureObservations runs after EstablishTracks to
+  // populate Track::lc_elements from inliers flagged as LC observations
+  // (CorrespondenceGraph::ImagePair::are_lc). When enabled the helper-
+  // side greedy subsample is bypassed (track_required_tracks_per_view is
+  // forced to INT_MAX); call SubsampleTracksForProblem afterwards if a
+  // post-LC subsample is desired. Default off (vanilla colmap behavior).
+  bool track_lc_second_pass = false;
+  // If true, SubsampleTracksForProblem drops 2-view tracks unless both
+  // observations satisfy
+  // ``image.depth_prior_validity[idx] && image.depth_priors[idx] > 1e-6``.
+  // Tracks with three or more views bypass the gate.
+  bool track_two_view_depth_gate = false;
 
   // Thresholds for each component.
   double max_angular_reproj_error_deg = 1.;   // for global positioning
@@ -112,6 +130,14 @@ class GlobalMapper {
 
   // Establish tracks from feature matches.
   void EstablishTracks(const GlobalMapperOptions& options);
+
+  // Greedy length-sorted subsample of the current reconstruction's
+  // tracks, with optional 2-view depth-validity gate. Only meaningful
+  // after ``EstablishTracks`` has populated ``reconstruction_->Points3D()``.
+  // Reads the ``track_max_num_views_per_track``, ``track_max_num_tracks``,
+  // ``track_required_tracks_per_view``, ``track_min_num_views_per_track``,
+  // and ``track_two_view_depth_gate`` fields of ``options``.
+  void SubsampleTracksForProblem(const GlobalMapperOptions& options);
 
   // Estimate global camera positions.
   bool GlobalPositioning(const GlobalPositionerOptions& options,

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -72,17 +72,10 @@ struct GlobalMapperOptions {
   int track_max_num_views_per_track = std::numeric_limits<int>::max();
   // Hard cap on the number of tracks kept after subsampling.
   int track_max_num_tracks = std::numeric_limits<int>::max();
-  // If true, AppendLoopClosureObservations runs after EstablishTracks to
-  // populate Track::lc_elements from inliers flagged as LC observations
-  // (CorrespondenceGraph::ImagePair::are_lc). When enabled the helper-
-  // side greedy subsample is bypassed (track_required_tracks_per_view is
-  // forced to INT_MAX); call SubsampleTracksForProblem afterwards if a
-  // post-LC subsample is desired. Default off (vanilla colmap behavior).
+  // Append LC observations to tracks after establishment. Bypasses
+  // helper-side subsample; call SubsampleTracksForProblem after.
   bool track_lc_second_pass = false;
-  // If true, SubsampleTracksForProblem drops 2-view tracks unless both
-  // observations satisfy
-  // ``image.depth_prior_validity[idx] && image.depth_priors[idx] > 1e-6``.
-  // Tracks with three or more views bypass the gate.
+  // Drop 2-view tracks without valid depth priors on both observations.
   bool track_two_view_depth_gate = false;
 
   // Thresholds for each component.
@@ -131,12 +124,7 @@ class GlobalMapper {
   // Establish tracks from feature matches.
   void EstablishTracks(const GlobalMapperOptions& options);
 
-  // Greedy length-sorted subsample of the current reconstruction's
-  // tracks, with optional 2-view depth-validity gate. Only meaningful
-  // after ``EstablishTracks`` has populated ``reconstruction_->Points3D()``.
-  // Reads the ``track_max_num_views_per_track``, ``track_max_num_tracks``,
-  // ``track_required_tracks_per_view``, ``track_min_num_views_per_track``,
-  // and ``track_two_view_depth_gate`` fields of ``options``.
+  // Greedy length-sorted subsample with optional 2-view depth gate.
   void SubsampleTracksForProblem(const GlobalMapperOptions& options);
 
   // Estimate global camera positions.

--- a/src/colmap/sfm/global_mapper.h
+++ b/src/colmap/sfm/global_mapper.h
@@ -75,8 +75,6 @@ struct GlobalMapperOptions {
   // Append LC observations to tracks after establishment. Bypasses
   // helper-side subsample; call SubsampleTracksForProblem after.
   bool track_lc_second_pass = false;
-  // Drop 2-view tracks without valid depth priors on both observations.
-  bool track_two_view_depth_gate = false;
 
   // Thresholds for each component.
   double max_angular_reproj_error_deg = 1.;   // for global positioning

--- a/src/colmap/sfm/global_mapper_test.cc
+++ b/src/colmap/sfm/global_mapper_test.cc
@@ -45,6 +45,32 @@ TEST(GlobalMapper, WithoutNoise) {
                                  /*max_proj_center_error=*/1e-4));
 }
 
+TEST(GlobalMapper, RotationAveragingForwardsCorrespondenceGraph) {
+  SetPRNGSeed(1);
+  const auto database_path = CreateTestDir() / "database.db";
+
+  auto database = Database::Open(database_path);
+  Reconstruction gt_reconstruction;
+  SyntheticDatasetOptions synthetic_dataset_options;
+  synthetic_dataset_options.num_rigs = 1;
+  synthetic_dataset_options.num_cameras_per_rig = 1;
+  synthetic_dataset_options.num_frames_per_rig = 5;
+  synthetic_dataset_options.num_points3D = 50;
+  synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
+  SynthesizeDataset(
+      synthetic_dataset_options, &gt_reconstruction, database.get());
+
+  auto reconstruction = std::make_shared<Reconstruction>();
+
+  GlobalMapper global_mapper(CreateDatabaseCache(*database));
+  global_mapper.BeginReconstruction(reconstruction);
+
+  RotationEstimatorOptions options;
+  options.skip_risky_lc_pairs = true;
+
+  EXPECT_TRUE(global_mapper.RotationAveraging(options));
+}
+
 TEST(GlobalMapper, WithoutNoiseWithNonTrivialKnownRig) {
   SetPRNGSeed(1);
   const auto database_path = CreateTestDir() / "database.db";

--- a/src/colmap/sfm/track_establishment.cc
+++ b/src/colmap/sfm/track_establishment.cc
@@ -21,16 +21,14 @@ inline uint64_t EncodeObservationKey(image_t image_id, point2D_t feature_id) {
 }
 
 void ValidateLoopClosureImagePairMetadata(
-    image_pair_t pair_id,
-    const CorrespondenceGraph::ImagePair& image_pair) {
+    image_pair_t pair_id, const CorrespondenceGraph::ImagePair& image_pair) {
   const int num_matches = image_pair.matches.rows();
   THROW_CHECK_EQ(image_pair.are_lc.size(), static_cast<size_t>(num_matches))
       << "Malformed LC metadata for image pair " << pair_id
       << ": are_lc.size() must match matches.rows()";
   for (const int idx : image_pair.inliers) {
-    THROW_CHECK_GE(idx, 0)
-        << "Malformed LC metadata for image pair " << pair_id
-        << ": negative inlier index";
+    THROW_CHECK_GE(idx, 0) << "Malformed LC metadata for image pair " << pair_id
+                           << ": negative inlier index";
     THROW_CHECK_LT(idx, num_matches)
         << "Malformed LC metadata for image pair " << pair_id
         << ": inlier index outside matches.rows()";
@@ -113,8 +111,8 @@ std::unordered_map<point3D_t, Point3D> EstablishTracksFromCorrGraph(
     };
     if (matches.rows() > 0 || !image_pair.inliers.empty()) {
       for (const int idx : image_pair.inliers) {
-        THROW_CHECK_GE(idx, 0) << "Negative inlier index for image pair "
-                               << pair_id;
+        THROW_CHECK_GE(idx, 0)
+            << "Negative inlier index for image pair " << pair_id;
         THROW_CHECK_LT(idx, matches.rows())
             << "Inlier index outside matches.rows() for image pair " << pair_id;
         union_match(static_cast<point2D_t>(matches(idx, 0)),
@@ -226,7 +224,6 @@ std::unordered_map<point3D_t, Point3D> EstablishTracksFromCorrGraph(
   return selected;
 }
 
-
 void AppendLoopClosureObservations(
     const std::vector<image_pair_t>& valid_pair_ids,
     const CorrespondenceGraph& corr_graph,
@@ -320,18 +317,18 @@ void AppendLoopClosureObservations(
   }
 }
 
-std::unordered_map<point3D_t, Point3D> SubsampleTracks(
-    const TrackSubsampleOptions& options,
+std::unordered_map<point3D_t, Point3D> FilterTracksForProblem(
+    const TrackProblemFilterOptions& options,
     const std::unordered_set<image_t>& registered_image_ids,
     const std::unordered_map<point3D_t, Point3D>& tracks_full) {
-  // Length filter: lower bound counts regular + LC observations; upper
-  // bound counts regular only. The asymmetry is intentional.
+  // Track admission is based on regular observations only. LC observations may
+  // augment an admitted track, but they must not make a one-view regular track
+  // eligible for global positioning.
   std::vector<std::pair<size_t, point3D_t>> track_lengths;
   size_t dropped_by_length = 0;
   for (const auto& [track_id, point3D] : tracks_full) {
-    const size_t total =
-        point3D.track.Length() + point3D.track.lc_elements.size();
-    if (total < static_cast<size_t>(options.min_num_views_per_track) ||
+    if (point3D.track.Length() <
+            static_cast<size_t>(options.min_num_views_per_track) ||
         point3D.track.Length() >
             static_cast<size_t>(options.max_num_views_per_track)) {
       ++dropped_by_length;
@@ -342,13 +339,12 @@ std::unordered_map<point3D_t, Point3D> SubsampleTracks(
   std::sort(track_lengths.begin(), track_lengths.end(), std::greater<>());
 
   // Selection domain = registered images.
-  std::unordered_map<image_t, int> tracks_per_camera;
+  std::unordered_set<image_t> registered_image_id_set;
   for (const image_t image_id : registered_image_ids) {
-    tracks_per_camera[image_id] = 0;
+    registered_image_id_set.insert(image_id);
   }
 
   std::unordered_map<point3D_t, Point3D> selected;
-  int cameras_left = static_cast<int>(tracks_per_camera.size());
   for (const auto& [track_length, track_id] : track_lengths) {
     const Point3D& src = tracks_full.at(track_id);
 
@@ -356,11 +352,11 @@ std::unordered_map<point3D_t, Point3D> SubsampleTracks(
     // selection domain.
     Point3D candidate;
     for (const auto& el : src.track.Elements()) {
-      if (tracks_per_camera.count(el.image_id) == 0) continue;
+      if (registered_image_id_set.count(el.image_id) == 0) continue;
       candidate.track.AddElement(el);
     }
     for (const auto& lc_el : src.track.lc_elements) {
-      if (tracks_per_camera.count(lc_el.image_id) == 0) continue;
+      if (registered_image_id_set.count(lc_el.image_id) == 0) continue;
       candidate.track.lc_elements.emplace_back(lc_el);
     }
     if (candidate.track.Length() <
@@ -368,24 +364,9 @@ std::unordered_map<point3D_t, Point3D> SubsampleTracks(
       continue;
     }
 
-    // Greedy quota: a track is added if any element's PRE-increment
-    // count is within the target. Counters increment for every kept
-    // element regardless of whether the track was added.
-    bool added = false;
-    for (const auto& el : candidate.track.Elements()) {
-      auto& count = tracks_per_camera[el.image_id];
-      if (count > options.required_tracks_per_view) continue;
-      ++count;
-      if (count > options.required_tracks_per_view) --cameras_left;
-      if (!added) {
-        selected.emplace(track_id, candidate);
-        added = true;
-      }
-    }
-    if (cameras_left == 0) break;
-    if (static_cast<int>(selected.size()) > options.max_num_tracks) break;
+    selected.emplace(track_id, candidate);
   }
-  LOG(INFO) << "Subsampled to " << selected.size() << " tracks (dropped "
+  LOG(INFO) << "Filtered to " << selected.size() << " tracks (dropped "
             << (tracks_full.size() - selected.size()) << ", "
             << dropped_by_length << " by length)";
   return selected;

--- a/src/colmap/sfm/track_establishment.cc
+++ b/src/colmap/sfm/track_establishment.cc
@@ -5,6 +5,7 @@
 #include "colmap/util/logging.h"
 
 #include <algorithm>
+#include <memory>
 #include <utility>
 
 namespace colmap {
@@ -20,12 +21,47 @@ inline uint64_t EncodeObservationKey(image_t image_id, point2D_t feature_id) {
 
 }  // namespace
 
+MatchPredicate MakeLoopClosureMatchPredicate(
+    const std::vector<image_pair_t>& valid_pair_ids,
+    const CorrespondenceGraph& corr_graph) {
+  // Build a set of (image_id, point2D_idx) keys that appear as inliers on
+  // LC-flagged matches. Any match touching one of these observations is
+  // suppressed in the first union-find pass so that LC observations only
+  // enter tracks via AppendLoopClosureObservations.
+  auto lc_obs = std::make_shared<std::unordered_set<uint64_t>>();
+  for (const image_pair_t pair_id : valid_pair_ids) {
+    const auto it = corr_graph.ImagePairsMap().find(pair_id);
+    if (it == corr_graph.ImagePairsMap().end()) continue;
+    const auto& image_pair = it->second;
+    const Eigen::MatrixXi& matches = image_pair.matches;
+    const std::vector<int>& inliers = image_pair.inliers;
+    const std::vector<bool>& are_lc = image_pair.are_lc;
+    for (const int idx : inliers) {
+      if (static_cast<size_t>(idx) < are_lc.size() && are_lc[idx]) {
+        lc_obs->insert(EncodeObservationKey(
+            image_pair.image_id1,
+            static_cast<point2D_t>(matches(idx, 0))));
+        lc_obs->insert(EncodeObservationKey(
+            image_pair.image_id2,
+            static_cast<point2D_t>(matches(idx, 1))));
+      }
+    }
+  }
+  return [lc_obs = std::move(lc_obs)](
+             image_t image_id1, point2D_t p1,
+             image_t image_id2, point2D_t p2) -> bool {
+    return lc_obs->count(EncodeObservationKey(image_id1, p1)) ||
+           lc_obs->count(EncodeObservationKey(image_id2, p2));
+  };
+}
+
 std::unordered_map<point3D_t, Point3D> EstablishTracksFromCorrGraph(
     const std::vector<image_pair_t>& valid_pair_ids,
     const CorrespondenceGraph& corr_graph,
     const std::unordered_map<image_t, std::vector<Eigen::Vector2d>>&
         image_id_to_keypoints,
-    const TrackEstablishmentOptions& options) {
+    const TrackEstablishmentOptions& options,
+    const MatchPredicate& ignore_match) {
   using Observation = std::pair<image_t, point2D_t>;
 
   // Union all matching observations.
@@ -39,6 +75,10 @@ std::unordered_map<point3D_t, Point3D> EstablishTracksFromCorrGraph(
         << "Missing keypoints for image " << image_id2;
     corr_graph.ExtractMatchesBetweenImages(image_id1, image_id2, matches);
     for (const auto& match : matches) {
+      if (ignore_match && ignore_match(image_id1, match.point2D_idx1,
+                                      image_id2, match.point2D_idx2)) {
+        continue;
+      }
       const Observation obs1(image_id1, match.point2D_idx1);
       const Observation obs2(image_id2, match.point2D_idx2);
       if (obs2 < obs1) {
@@ -243,8 +283,6 @@ void AppendLoopClosureObservations(
 std::unordered_map<point3D_t, Point3D> SubsampleTracks(
     const TrackSubsampleOptions& options,
     const std::unordered_set<image_t>& registered_image_ids,
-    const std::unordered_map<image_t, std::vector<double>>& depth_priors,
-    const std::unordered_map<image_t, std::vector<bool>>& depth_prior_validity,
     const std::unordered_map<point3D_t, Point3D>& tracks_full) {
   // Length filter: lower bound counts regular + LC observations; upper
   // bound counts regular only. The asymmetry is intentional.
@@ -276,12 +314,10 @@ std::unordered_map<point3D_t, Point3D> SubsampleTracks(
 
     // Restrict to selection domain + lc-elements that fall in the
     // selection domain.
-    std::unordered_set<image_t> distinct_image_ids;
     Point3D candidate;
     for (const auto& el : src.track.Elements()) {
       if (tracks_per_camera.count(el.image_id) == 0) continue;
       candidate.track.AddElement(el);
-      distinct_image_ids.insert(el.image_id);
     }
     for (const auto& lc_el : src.track.lc_elements) {
       if (tracks_per_camera.count(lc_el.image_id) == 0) continue;
@@ -290,23 +326,6 @@ std::unordered_map<point3D_t, Point3D> SubsampleTracks(
     if (candidate.track.Length() <
         static_cast<size_t>(options.min_num_views_per_track)) {
       continue;
-    }
-    if (options.two_view_depth_gate && distinct_image_ids.size() == 2) {
-      bool depth_ok = true;
-      for (const auto& el : candidate.track.Elements()) {
-        const auto valid_it = depth_prior_validity.find(el.image_id);
-        const auto prior_it = depth_priors.find(el.image_id);
-        if (valid_it == depth_prior_validity.end() ||
-            prior_it == depth_priors.end() ||
-            el.point2D_idx >= valid_it->second.size() ||
-            !valid_it->second[el.point2D_idx] ||
-            el.point2D_idx >= prior_it->second.size() ||
-            prior_it->second[el.point2D_idx] <= 1e-6) {
-          depth_ok = false;
-          break;
-        }
-      }
-      if (!depth_ok) continue;
     }
 
     // Greedy quota: a track is added if any element's PRE-increment

--- a/src/colmap/sfm/track_establishment.cc
+++ b/src/colmap/sfm/track_establishment.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <set>
 #include <utility>
 
 namespace colmap {
@@ -19,39 +20,59 @@ inline uint64_t EncodeObservationKey(image_t image_id, point2D_t feature_id) {
          static_cast<uint64_t>(feature_id);
 }
 
+void ValidateLoopClosureImagePairMetadata(
+    image_pair_t pair_id,
+    const CorrespondenceGraph::ImagePair& image_pair) {
+  const int num_matches = image_pair.matches.rows();
+  THROW_CHECK_EQ(image_pair.are_lc.size(), static_cast<size_t>(num_matches))
+      << "Malformed LC metadata for image pair " << pair_id
+      << ": are_lc.size() must match matches.rows()";
+  for (const int idx : image_pair.inliers) {
+    THROW_CHECK_GE(idx, 0)
+        << "Malformed LC metadata for image pair " << pair_id
+        << ": negative inlier index";
+    THROW_CHECK_LT(idx, num_matches)
+        << "Malformed LC metadata for image pair " << pair_id
+        << ": inlier index outside matches.rows()";
+  }
+}
+
 }  // namespace
 
 MatchPredicate MakeLoopClosureMatchPredicate(
     const std::vector<image_pair_t>& valid_pair_ids,
     const CorrespondenceGraph& corr_graph) {
-  // Build a set of (image_id, point2D_idx) keys that appear as inliers on
-  // LC-flagged matches. Any match touching one of these observations is
-  // suppressed in the first union-find pass so that LC observations only
-  // enter tracks via AppendLoopClosureObservations.
-  auto lc_obs = std::make_shared<std::unordered_set<uint64_t>>();
+  // Build a set of exact LC-flagged match pairs. Only those pairwise
+  // constraints are suppressed from the first union-find pass; the same
+  // endpoint may still participate in regular tracks through non-LC matches.
+  using LCKey = std::pair<uint64_t, uint64_t>;
+  auto lc_matches = std::make_shared<std::set<LCKey>>();
   for (const image_pair_t pair_id : valid_pair_ids) {
     const auto it = corr_graph.ImagePairsMap().find(pair_id);
     if (it == corr_graph.ImagePairsMap().end()) continue;
+    const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
     const auto& image_pair = it->second;
+    ValidateLoopClosureImagePairMetadata(pair_id, image_pair);
     const Eigen::MatrixXi& matches = image_pair.matches;
     const std::vector<int>& inliers = image_pair.inliers;
     const std::vector<bool>& are_lc = image_pair.are_lc;
     for (const int idx : inliers) {
-      if (static_cast<size_t>(idx) < are_lc.size() && are_lc[idx]) {
-        lc_obs->insert(EncodeObservationKey(
-            image_pair.image_id1,
-            static_cast<point2D_t>(matches(idx, 0))));
-        lc_obs->insert(EncodeObservationKey(
-            image_pair.image_id2,
-            static_cast<point2D_t>(matches(idx, 1))));
+      if (are_lc[idx]) {
+        const uint64_t key1 = EncodeObservationKey(
+            image_id1, static_cast<point2D_t>(matches(idx, 0)));
+        const uint64_t key2 = EncodeObservationKey(
+            image_id2, static_cast<point2D_t>(matches(idx, 1)));
+        lc_matches->insert({key1, key2});
+        lc_matches->insert({key2, key1});
       }
     }
   }
-  return [lc_obs = std::move(lc_obs)](
-             image_t image_id1, point2D_t p1,
-             image_t image_id2, point2D_t p2) -> bool {
-    return lc_obs->count(EncodeObservationKey(image_id1, p1)) ||
-           lc_obs->count(EncodeObservationKey(image_id2, p2));
+  return [lc_matches = std::move(lc_matches)](image_t image_id1,
+                                              point2D_t p1,
+                                              image_t image_id2,
+                                              point2D_t p2) -> bool {
+    return lc_matches->count({EncodeObservationKey(image_id1, p1),
+                              EncodeObservationKey(image_id2, p2)}) > 0;
   };
 }
 
@@ -64,27 +85,46 @@ std::unordered_map<point3D_t, Point3D> EstablishTracksFromCorrGraph(
     const MatchPredicate& ignore_match) {
   using Observation = std::pair<image_t, point2D_t>;
 
-  // Union all matching observations.
+  // Union all matching observations. Iterate ImagePair metadata directly:
+  // VideoSfM populates matches/inliers on ImagePair without always using the
+  // flat correspondence graph storage behind ExtractMatchesBetweenImages.
+  // Fall back to the native correspondence storage for vanilla COLMAP pairs.
   UnionFind<Observation> uf;
-  FeatureMatches matches;
+  FeatureMatches extracted_matches;
   for (const image_pair_t pair_id : valid_pair_ids) {
     const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
     THROW_CHECK(image_id_to_keypoints.count(image_id1))
         << "Missing keypoints for image " << image_id1;
     THROW_CHECK(image_id_to_keypoints.count(image_id2))
         << "Missing keypoints for image " << image_id2;
-    corr_graph.ExtractMatchesBetweenImages(image_id1, image_id2, matches);
-    for (const auto& match : matches) {
-      if (ignore_match && ignore_match(image_id1, match.point2D_idx1,
-                                      image_id2, match.point2D_idx2)) {
-        continue;
+    const auto& image_pair = corr_graph.ImagePairsMap().at(pair_id);
+    const Eigen::MatrixXi& matches = image_pair.matches;
+    const auto union_match = [&](const point2D_t p2d1, const point2D_t p2d2) {
+      if (ignore_match && ignore_match(image_id1, p2d1, image_id2, p2d2)) {
+        return;
       }
-      const Observation obs1(image_id1, match.point2D_idx1);
-      const Observation obs2(image_id2, match.point2D_idx2);
+      const Observation obs1(image_id1, p2d1);
+      const Observation obs2(image_id2, p2d2);
       if (obs2 < obs1) {
         uf.Union(obs1, obs2);
       } else {
         uf.Union(obs2, obs1);
+      }
+    };
+    if (matches.rows() > 0 || !image_pair.inliers.empty()) {
+      for (const int idx : image_pair.inliers) {
+        THROW_CHECK_GE(idx, 0) << "Negative inlier index for image pair "
+                               << pair_id;
+        THROW_CHECK_LT(idx, matches.rows())
+            << "Inlier index outside matches.rows() for image pair " << pair_id;
+        union_match(static_cast<point2D_t>(matches(idx, 0)),
+                    static_cast<point2D_t>(matches(idx, 1)));
+      }
+    } else {
+      corr_graph.ExtractMatchesBetweenImages(
+          image_id1, image_id2, extracted_matches);
+      for (const auto& match : extracted_matches) {
+        union_match(match.point2D_idx1, match.point2D_idx2);
       }
     }
   }
@@ -207,6 +247,7 @@ void AppendLoopClosureObservations(
 
   for (const image_pair_t pair_id : valid_pair_ids) {
     const auto& image_pair = corr_graph.ImagePairsMap().at(pair_id);
+    ValidateLoopClosureImagePairMetadata(pair_id, image_pair);
     const Eigen::MatrixXi& matches = image_pair.matches;
     const std::vector<int>& inliers = image_pair.inliers;
     const std::vector<bool>& are_lc = image_pair.are_lc;
@@ -214,18 +255,17 @@ void AppendLoopClosureObservations(
     // Skip pairs without any LC inliers (cheap pre-check).
     bool has_lc = false;
     for (const int idx : inliers) {
-      if (static_cast<size_t>(idx) < are_lc.size() && are_lc[idx]) {
+      if (are_lc[idx]) {
         has_lc = true;
         break;
       }
     }
     if (!has_lc) continue;
 
-    const image_t image_id1 = image_pair.image_id1;
-    const image_t image_id2 = image_pair.image_id2;
+    const auto [image_id1, image_id2] = PairIdToImagePair(pair_id);
 
     for (const int idx : inliers) {
-      if (static_cast<size_t>(idx) >= are_lc.size() || !are_lc[idx]) {
+      if (!are_lc[idx]) {
         continue;
       }
       const point2D_t p1 = static_cast<point2D_t>(matches(idx, 0));

--- a/src/colmap/sfm/track_establishment.cc
+++ b/src/colmap/sfm/track_establishment.cc
@@ -9,6 +9,17 @@
 
 namespace colmap {
 
+namespace {
+
+// Encodes (image_id, point2D_idx) into a single 64-bit key for fast LC-pass
+// lookups.
+inline uint64_t EncodeObservationKey(image_t image_id, point2D_t feature_id) {
+  return (static_cast<uint64_t>(image_id) << 32) |
+         static_cast<uint64_t>(feature_id);
+}
+
+}  // namespace
+
 std::unordered_map<point3D_t, Point3D> EstablishTracksFromCorrGraph(
     const std::vector<image_pair_t>& valid_pair_ids,
     const CorrespondenceGraph& corr_graph,
@@ -132,6 +143,192 @@ std::unordered_map<point3D_t, Point3D> EstablishTracksFromCorrGraph(
 
   LOG(INFO) << "Before greedy subsample: " << candidate_points3D.size()
             << ", after: " << selected.size();
+  return selected;
+}
+
+
+void AppendLoopClosureObservations(
+    const std::vector<image_pair_t>& valid_pair_ids,
+    const CorrespondenceGraph& corr_graph,
+    std::unordered_map<point3D_t, Point3D>& tracks) {
+  // Build the lookup from observation -> track_id, and find the next
+  // free track id (max + 1) so newly-minted LC-only tracks never
+  // collide with the dense [0, N) ids written by
+  // EstablishTracksFromCorrGraph.
+  std::unordered_map<uint64_t, point3D_t> obs_to_track;
+  point3D_t next_id = 0;
+  for (const auto& [track_id, point3D] : tracks) {
+    next_id = std::max(next_id, static_cast<point3D_t>(track_id + 1));
+    for (const auto& el : point3D.track.Elements()) {
+      obs_to_track.emplace(EncodeObservationKey(el.image_id, el.point2D_idx),
+                           track_id);
+    }
+  }
+
+  for (const image_pair_t pair_id : valid_pair_ids) {
+    const auto& image_pair = corr_graph.ImagePairsMap().at(pair_id);
+    const Eigen::MatrixXi& matches = image_pair.matches;
+    const std::vector<int>& inliers = image_pair.inliers;
+    const std::vector<bool>& are_lc = image_pair.are_lc;
+
+    // Skip pairs without any LC inliers (cheap pre-check).
+    bool has_lc = false;
+    for (const int idx : inliers) {
+      if (static_cast<size_t>(idx) < are_lc.size() && are_lc[idx]) {
+        has_lc = true;
+        break;
+      }
+    }
+    if (!has_lc) continue;
+
+    const image_t image_id1 = image_pair.image_id1;
+    const image_t image_id2 = image_pair.image_id2;
+
+    for (const int idx : inliers) {
+      if (static_cast<size_t>(idx) >= are_lc.size() || !are_lc[idx]) {
+        continue;
+      }
+      const point2D_t p1 = static_cast<point2D_t>(matches(idx, 0));
+      const point2D_t p2 = static_cast<point2D_t>(matches(idx, 1));
+      const uint64_t key1 = EncodeObservationKey(image_id1, p1);
+      const uint64_t key2 = EncodeObservationKey(image_id2, p2);
+
+      auto it1 = obs_to_track.find(key1);
+      auto it2 = obs_to_track.find(key2);
+      const bool has_track1 = (it1 != obs_to_track.end());
+      const bool has_track2 = (it2 != obs_to_track.end());
+
+      if (!has_track1 && !has_track2) {
+        // Mint two reciprocal LC-only tracks. Each gets the regular
+        // observation as a Track::Element and the other side as
+        // lc_elements.
+        const point3D_t tid_a = next_id++;
+        const point3D_t tid_b = next_id++;
+        Point3D track_a;
+        track_a.track.AddElement(image_id1, p1);
+        track_a.track.lc_elements.emplace_back(image_id2, p2);
+        Point3D track_b;
+        track_b.track.AddElement(image_id2, p2);
+        track_b.track.lc_elements.emplace_back(image_id1, p1);
+        const auto inserted_a = tracks.emplace(tid_a, std::move(track_a));
+        THROW_CHECK(inserted_a.second)
+            << "Track id collision on " << tid_a
+            << " — sequential id minting violated unexpectedly";
+        const auto inserted_b = tracks.emplace(tid_b, std::move(track_b));
+        THROW_CHECK(inserted_b.second)
+            << "Track id collision on " << tid_b
+            << " — sequential id minting violated unexpectedly";
+        obs_to_track[key1] = tid_a;
+        obs_to_track[key2] = tid_b;
+        continue;
+      }
+      if (has_track1 && has_track2) {
+        const point3D_t t1 = it1->second;
+        const point3D_t t2 = it2->second;
+        if (t1 != t2) {
+          tracks.at(t1).track.lc_elements.emplace_back(image_id2, p2);
+          tracks.at(t2).track.lc_elements.emplace_back(image_id1, p1);
+        }
+        continue;
+      }
+      if (has_track1) {
+        tracks.at(it1->second).track.lc_elements.emplace_back(image_id2, p2);
+      } else {
+        tracks.at(it2->second).track.lc_elements.emplace_back(image_id1, p1);
+      }
+    }
+  }
+}
+
+std::unordered_map<point3D_t, Point3D> SubsampleTracks(
+    const TrackSubsampleOptions& options,
+    const std::unordered_set<image_t>& registered_image_ids,
+    const std::unordered_map<image_t, std::vector<double>>& depth_priors,
+    const std::unordered_map<image_t, std::vector<bool>>& depth_prior_validity,
+    const std::unordered_map<point3D_t, Point3D>& tracks_full) {
+  // Length filter: lower bound counts regular + LC observations; upper
+  // bound counts regular only. The asymmetry is intentional.
+  std::vector<std::pair<size_t, point3D_t>> track_lengths;
+  size_t dropped_by_length = 0;
+  for (const auto& [track_id, point3D] : tracks_full) {
+    const size_t total =
+        point3D.track.Length() + point3D.track.lc_elements.size();
+    if (total < static_cast<size_t>(options.min_num_views_per_track) ||
+        point3D.track.Length() >
+            static_cast<size_t>(options.max_num_views_per_track)) {
+      ++dropped_by_length;
+      continue;
+    }
+    track_lengths.emplace_back(point3D.track.Length(), track_id);
+  }
+  std::sort(track_lengths.begin(), track_lengths.end(), std::greater<>());
+
+  // Selection domain = registered images.
+  std::unordered_map<image_t, int> tracks_per_camera;
+  for (const image_t image_id : registered_image_ids) {
+    tracks_per_camera[image_id] = 0;
+  }
+
+  std::unordered_map<point3D_t, Point3D> selected;
+  int cameras_left = static_cast<int>(tracks_per_camera.size());
+  for (const auto& [track_length, track_id] : track_lengths) {
+    const Point3D& src = tracks_full.at(track_id);
+
+    // Restrict to selection domain + lc-elements that fall in the
+    // selection domain.
+    std::unordered_set<image_t> distinct_image_ids;
+    Point3D candidate;
+    for (const auto& el : src.track.Elements()) {
+      if (tracks_per_camera.count(el.image_id) == 0) continue;
+      candidate.track.AddElement(el);
+      distinct_image_ids.insert(el.image_id);
+    }
+    for (const auto& lc_el : src.track.lc_elements) {
+      if (tracks_per_camera.count(lc_el.image_id) == 0) continue;
+      candidate.track.lc_elements.emplace_back(lc_el);
+    }
+    if (candidate.track.Length() <
+        static_cast<size_t>(options.min_num_views_per_track)) {
+      continue;
+    }
+    if (options.two_view_depth_gate && distinct_image_ids.size() == 2) {
+      bool depth_ok = true;
+      for (const auto& el : candidate.track.Elements()) {
+        const auto valid_it = depth_prior_validity.find(el.image_id);
+        const auto prior_it = depth_priors.find(el.image_id);
+        if (valid_it == depth_prior_validity.end() ||
+            prior_it == depth_priors.end() ||
+            el.point2D_idx >= valid_it->second.size() ||
+            !valid_it->second[el.point2D_idx] ||
+            el.point2D_idx >= prior_it->second.size() ||
+            prior_it->second[el.point2D_idx] <= 1e-6) {
+          depth_ok = false;
+          break;
+        }
+      }
+      if (!depth_ok) continue;
+    }
+
+    // Greedy quota: a track is added if any element's PRE-increment
+    // count is within the target. Counters increment for every kept
+    // element regardless of whether the track was added.
+    bool added = false;
+    for (const auto& el : candidate.track.Elements()) {
+      auto& count = tracks_per_camera[el.image_id];
+      if (count > options.required_tracks_per_view) continue;
+      ++count;
+      if (count > options.required_tracks_per_view) --cameras_left;
+      if (!added) {
+        selected.emplace(track_id, candidate);
+        added = true;
+      }
+    }
+    if (cameras_left == 0) break;
+    if (static_cast<int>(selected.size()) > options.max_num_tracks) break;
+  }
+  LOG(INFO) << "Subsampled to " << selected.size() << " tracks (dropped "
+            << (tracks_full.size() - selected.size()) << ", "
+            << dropped_by_length << " by length)";
   return selected;
 }
 

--- a/src/colmap/sfm/track_establishment.h
+++ b/src/colmap/sfm/track_establishment.h
@@ -31,7 +31,8 @@ struct TrackEstablishmentOptions {
 
 // Predicate called for each match (image_id1, point2D_idx1, image_id2,
 // point2D_idx2). Returns true to skip (ignore) the match.
-using MatchPredicate = std::function<bool(image_t, point2D_t, image_t, point2D_t)>;
+using MatchPredicate =
+    std::function<bool(image_t, point2D_t, image_t, point2D_t)>;
 
 // Returns a MatchPredicate that ignores exact LC-flagged inlier matches
 // (are_lc==true) in the correspondence graph. This excludes LC pairwise
@@ -61,16 +62,15 @@ void AppendLoopClosureObservations(
     const CorrespondenceGraph& corr_graph,
     std::unordered_map<point3D_t, Point3D>& tracks);
 
-struct TrackSubsampleOptions {
+struct TrackProblemFilterOptions {
   int min_num_views_per_track = 3;
   int max_num_views_per_track = std::numeric_limits<int>::max();
-  int required_tracks_per_view = std::numeric_limits<int>::max();
-  int max_num_tracks = std::numeric_limits<int>::max();
 };
 
-// Greedy length-sorted subsample with per-image quota. Returns selected tracks.
-std::unordered_map<point3D_t, Point3D> SubsampleTracks(
-    const TrackSubsampleOptions& options,
+// Filter tracks for the optimization problem. LC observations may augment an
+// admitted regular track, but do not satisfy the regular-view admission gate.
+std::unordered_map<point3D_t, Point3D> FilterTracksForProblem(
+    const TrackProblemFilterOptions& options,
     const std::unordered_set<image_t>& registered_image_ids,
     const std::unordered_map<point3D_t, Point3D>& tracks_full);
 

--- a/src/colmap/sfm/track_establishment.h
+++ b/src/colmap/sfm/track_establishment.h
@@ -33,9 +33,10 @@ struct TrackEstablishmentOptions {
 // point2D_idx2). Returns true to skip (ignore) the match.
 using MatchPredicate = std::function<bool(image_t, point2D_t, image_t, point2D_t)>;
 
-// Returns a MatchPredicate that ignores matches flagged as LC (are_lc==true)
-// in the correspondence graph, so they are excluded from the first-pass
-// union-find and only incorporated via AppendLoopClosureObservations.
+// Returns a MatchPredicate that ignores exact LC-flagged inlier matches
+// (are_lc==true) in the correspondence graph. This excludes LC pairwise
+// constraints from the first-pass union-find while still allowing the same
+// endpoints to participate in regular tracks through non-LC matches.
 MatchPredicate MakeLoopClosureMatchPredicate(
     const std::vector<image_pair_t>& valid_pair_ids,
     const CorrespondenceGraph& corr_graph);

--- a/src/colmap/sfm/track_establishment.h
+++ b/src/colmap/sfm/track_establishment.h
@@ -6,6 +6,7 @@
 
 #include <limits>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <Eigen/Core>
@@ -27,14 +28,41 @@ struct TrackEstablishmentOptions {
   int required_tracks_per_view = std::numeric_limits<int>::max();
 };
 
-// Build tracks via union-find over inlier matches with consistency check,
-// length filter, and optional greedy subsample. Returns {point3D_id: Point3D}
-// with Track populated; xyz/color left for triangulation.
+// Build tracks via union-find over matches extracted from the correspondence
+// graph with consistency check, length filter, and optional greedy subsample.
+// Returns {point3D_id: Point3D} with Track populated; xyz/color left for
+// triangulation.
 std::unordered_map<point3D_t, Point3D> EstablishTracksFromCorrGraph(
     const std::vector<image_pair_t>& valid_pair_ids,
     const CorrespondenceGraph& corr_graph,
     const std::unordered_map<image_t, std::vector<Eigen::Vector2d>>&
         image_id_to_keypoints,
     const TrackEstablishmentOptions& options);
+
+// Append LC observations to existing tracks as Track::lc_elements.
+// 4 cases: neither/both-distinct/both-same/one-side has a track.
+// New track ids minted from max(track_id)+1.
+void AppendLoopClosureObservations(
+    const std::vector<image_pair_t>& valid_pair_ids,
+    const CorrespondenceGraph& corr_graph,
+    std::unordered_map<point3D_t, Point3D>& tracks);
+
+struct TrackSubsampleOptions {
+  int min_num_views_per_track = 3;
+  int max_num_views_per_track = std::numeric_limits<int>::max();
+  int required_tracks_per_view = std::numeric_limits<int>::max();
+  int max_num_tracks = std::numeric_limits<int>::max();
+  // Drop 2-view tracks without valid depth priors on both observations.
+  bool two_view_depth_gate = false;
+};
+
+// Greedy length-sorted subsample with per-image quota and optional
+// 2-view depth gate. Returns selected tracks.
+std::unordered_map<point3D_t, Point3D> SubsampleTracks(
+    const TrackSubsampleOptions& options,
+    const std::unordered_set<image_t>& registered_image_ids,
+    const std::unordered_map<image_t, std::vector<double>>& depth_priors,
+    const std::unordered_map<image_t, std::vector<bool>>& depth_prior_validity,
+    const std::unordered_map<point3D_t, Point3D>& tracks_full);
 
 }  // namespace colmap

--- a/src/colmap/sfm/track_establishment.h
+++ b/src/colmap/sfm/track_establishment.h
@@ -4,6 +4,7 @@
 #include "colmap/scene/point3d.h"
 #include "colmap/util/types.h"
 
+#include <functional>
 #include <limits>
 #include <unordered_map>
 #include <unordered_set>
@@ -28,6 +29,17 @@ struct TrackEstablishmentOptions {
   int required_tracks_per_view = std::numeric_limits<int>::max();
 };
 
+// Predicate called for each match (image_id1, point2D_idx1, image_id2,
+// point2D_idx2). Returns true to skip (ignore) the match.
+using MatchPredicate = std::function<bool(image_t, point2D_t, image_t, point2D_t)>;
+
+// Returns a MatchPredicate that ignores matches flagged as LC (are_lc==true)
+// in the correspondence graph, so they are excluded from the first-pass
+// union-find and only incorporated via AppendLoopClosureObservations.
+MatchPredicate MakeLoopClosureMatchPredicate(
+    const std::vector<image_pair_t>& valid_pair_ids,
+    const CorrespondenceGraph& corr_graph);
+
 // Build tracks via union-find over matches extracted from the correspondence
 // graph with consistency check, length filter, and optional greedy subsample.
 // Returns {point3D_id: Point3D} with Track populated; xyz/color left for
@@ -37,7 +49,8 @@ std::unordered_map<point3D_t, Point3D> EstablishTracksFromCorrGraph(
     const CorrespondenceGraph& corr_graph,
     const std::unordered_map<image_t, std::vector<Eigen::Vector2d>>&
         image_id_to_keypoints,
-    const TrackEstablishmentOptions& options);
+    const TrackEstablishmentOptions& options,
+    const MatchPredicate& ignore_match = {});
 
 // Append LC observations to existing tracks as Track::lc_elements.
 // 4 cases: neither/both-distinct/both-same/one-side has a track.
@@ -52,17 +65,12 @@ struct TrackSubsampleOptions {
   int max_num_views_per_track = std::numeric_limits<int>::max();
   int required_tracks_per_view = std::numeric_limits<int>::max();
   int max_num_tracks = std::numeric_limits<int>::max();
-  // Drop 2-view tracks without valid depth priors on both observations.
-  bool two_view_depth_gate = false;
 };
 
-// Greedy length-sorted subsample with per-image quota and optional
-// 2-view depth gate. Returns selected tracks.
+// Greedy length-sorted subsample with per-image quota. Returns selected tracks.
 std::unordered_map<point3D_t, Point3D> SubsampleTracks(
     const TrackSubsampleOptions& options,
     const std::unordered_set<image_t>& registered_image_ids,
-    const std::unordered_map<image_t, std::vector<double>>& depth_priors,
-    const std::unordered_map<image_t, std::vector<bool>>& depth_prior_validity,
     const std::unordered_map<point3D_t, Point3D>& tracks_full);
 
 }  // namespace colmap

--- a/src/colmap/sfm/track_establishment_test.cc
+++ b/src/colmap/sfm/track_establishment_test.cc
@@ -1,0 +1,768 @@
+// Copyright (c), ETH Zurich and UNC Chapel Hill.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "colmap/sfm/track_establishment.h"
+
+#include "colmap/scene/correspondence_graph.h"
+#include "colmap/scene/image.h"
+#include "colmap/scene/point3d.h"
+#include "colmap/util/types.h"
+
+#include <algorithm>
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
+namespace colmap {
+namespace {
+
+// Build an ImagePair entry directly into the corr_graph's image_pairs map
+// with the ``matches`` and ``inliers`` fields populated.
+// ``EstablishTracksFromCorrGraph`` only reads those two fields plus the pair
+// keys, so we bypass ``AddTwoViewGeometry`` and the colmap flat_corrs path.
+void AddImagePair(CorrespondenceGraph& corr_graph,
+                  image_t image_id1,
+                  image_t image_id2,
+                  const std::vector<std::pair<int, int>>& matches,
+                  const std::vector<int>& inliers) {
+  const image_pair_t pair_id = ImagePairToPairId(image_id1, image_id2);
+  CorrespondenceGraph::ImagePair image_pair(image_id1, image_id2);
+  Eigen::MatrixXi matches_mat(static_cast<int>(matches.size()), 2);
+  for (size_t i = 0; i < matches.size(); ++i) {
+    matches_mat(static_cast<int>(i), 0) = matches[i].first;
+    matches_mat(static_cast<int>(i), 1) = matches[i].second;
+  }
+  image_pair.matches = std::move(matches_mat);
+  image_pair.inliers = inliers;
+  image_pair.num_matches = static_cast<point2D_t>(inliers.size());
+  corr_graph.MutableImagePairs().emplace(pair_id, std::move(image_pair));
+}
+
+// Build a map ``image_id -> [Vector2d(0,0), Vector2d(1,1), ...]`` so all
+// keypoints on a given image are well-separated (intra-image consistency
+// trivially holds when all features are at distinct integer pixels).
+std::unordered_map<image_t, std::vector<Eigen::Vector2d>>
+MakeWellSeparatedKeypoints(const std::vector<image_t>& image_ids,
+                           int num_points_per_image) {
+  std::unordered_map<image_t, std::vector<Eigen::Vector2d>> result;
+  for (const image_t image_id : image_ids) {
+    auto& kps = result[image_id];
+    kps.reserve(num_points_per_image);
+    for (int i = 0; i < num_points_per_image; ++i) {
+      // Spread keypoints 100px apart on both axes so every intra-image
+      // pair is far above the default 10px threshold.
+      kps.emplace_back(100.0 * i, 100.0 * i);
+    }
+  }
+  return result;
+}
+
+// Helper: collect keys of corr_graph.image_pairs into a vector.
+std::vector<image_pair_t> CollectPairIds(const CorrespondenceGraph& g) {
+  std::vector<image_pair_t> ids;
+  ids.reserve(g.ImagePairsMap().size());
+  for (const auto& [pair_id, _] : g.ImagePairsMap()) ids.push_back(pair_id);
+  return ids;
+}
+
+// 3 images, 3 valid pairs (1-2, 1-3, 2-3), 5 inlier matches per pair, all
+// pointing to the same 5 underlying 3D points (feature index i corresponds
+// to point i on every image). Expect 5 tracks of length 3.
+TEST(TrackEstablishment, Basic3PairTriangle) {
+  CorrespondenceGraph corr_graph;
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(2, 5);
+  corr_graph.AddImage(3, 5);
+
+  std::vector<std::pair<int, int>> matches;
+  std::vector<int> inliers;
+  for (int i = 0; i < 5; ++i) {
+    matches.emplace_back(i, i);
+    inliers.push_back(i);
+  }
+  AddImagePair(corr_graph, 1, 2, matches, inliers);
+  AddImagePair(corr_graph, 1, 3, matches, inliers);
+  AddImagePair(corr_graph, 2, 3, matches, inliers);
+
+  const auto keypoints = MakeWellSeparatedKeypoints({1, 2, 3}, 5);
+  const TrackEstablishmentOptions options;  // defaults: min_views=3
+  const auto tracks = EstablishTracksFromCorrGraph(
+      CollectPairIds(corr_graph), corr_graph, keypoints, options);
+
+  EXPECT_EQ(tracks.size(), 5);
+  for (const auto& [pid, point3D] : tracks) {
+    EXPECT_EQ(point3D.track.Length(), 3);
+  }
+}
+
+// Same geometry but ``min_num_views_per_track = 4`` rejects every length-3
+// track.
+TEST(TrackEstablishment, LengthFilterDropsShortTracks) {
+  CorrespondenceGraph corr_graph;
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(2, 5);
+  corr_graph.AddImage(3, 5);
+
+  std::vector<std::pair<int, int>> matches;
+  std::vector<int> inliers;
+  for (int i = 0; i < 5; ++i) {
+    matches.emplace_back(i, i);
+    inliers.push_back(i);
+  }
+  AddImagePair(corr_graph, 1, 2, matches, inliers);
+  AddImagePair(corr_graph, 1, 3, matches, inliers);
+  AddImagePair(corr_graph, 2, 3, matches, inliers);
+
+  const auto keypoints = MakeWellSeparatedKeypoints({1, 2, 3}, 5);
+  TrackEstablishmentOptions options;
+  options.min_num_views_per_track = 4;
+  const auto tracks = EstablishTracksFromCorrGraph(
+      CollectPairIds(corr_graph), corr_graph, keypoints, options);
+
+  EXPECT_TRUE(tracks.empty());
+}
+
+// Drive two distinct features on image 1 (idx 0 and idx 1) into the same
+// union-find root via image 2's feature 0:
+//   pair (1,2): match (img1:0 <-> img2:0)
+//   pair (2,3): match (img2:0 <-> img3:0) -- chain via image 3
+//   pair (1,3): match (img1:1 <-> img3:0) -- this fuses img1:0 ~ img1:1
+// keypoints for img1:0 = (0,0) and img1:1 = (1000,1000) -> intra-image
+// consistency violated (>10px), track dropped.
+// 4 images so the surviving tracks (built from idx 1..4) still have length 3.
+TEST(TrackEstablishment, IntraImageConsistencyDropsInconsistentTrack) {
+  CorrespondenceGraph corr_graph;
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(2, 5);
+  corr_graph.AddImage(3, 5);
+
+  // Inconsistent fusion path for feature 0 chain.
+  AddImagePair(corr_graph, 1, 2, {{0, 0}}, {0});
+  AddImagePair(corr_graph, 2, 3, {{0, 0}}, {0});
+  AddImagePair(corr_graph, 1, 3, {{1, 0}}, {0});
+
+  // Keypoints: image 1 has feature 0 and feature 1 placed FAR apart so the
+  // intra-image consistency check rejects the merged track.
+  std::unordered_map<image_t, std::vector<Eigen::Vector2d>> keypoints;
+  keypoints[1] = {Eigen::Vector2d(0, 0), Eigen::Vector2d(1000, 1000),
+                  Eigen::Vector2d(200, 200), Eigen::Vector2d(300, 300),
+                  Eigen::Vector2d(400, 400)};
+  keypoints[2] = {Eigen::Vector2d(0, 0), Eigen::Vector2d(100, 100),
+                  Eigen::Vector2d(200, 200), Eigen::Vector2d(300, 300),
+                  Eigen::Vector2d(400, 400)};
+  keypoints[3] = {Eigen::Vector2d(0, 0), Eigen::Vector2d(100, 100),
+                  Eigen::Vector2d(200, 200), Eigen::Vector2d(300, 300),
+                  Eigen::Vector2d(400, 400)};
+
+  TrackEstablishmentOptions options;
+  options.min_num_views_per_track = 2;  // accept length-2 if any survived
+  options.intra_image_consistency_threshold = 10.0;
+  const auto tracks = EstablishTracksFromCorrGraph(
+      CollectPairIds(corr_graph), corr_graph, keypoints, options);
+
+  // The single track we constructed is inconsistent; nothing else exists.
+  EXPECT_TRUE(tracks.empty());
+}
+
+// ``ignore_match`` returning true for any match touching image 1 strips
+// image 1's contribution from union-find. The remaining 5 tracks then have
+// length 2 (only images 2 and 3) so default min_views=3 drops them all;
+// loosening to min_views=2 surfaces them and asserts none of the kept tracks
+// reference image 1.
+TEST(TrackEstablishment, IgnoreMatchPredicateDropsImage) {
+  CorrespondenceGraph corr_graph;
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(2, 5);
+  corr_graph.AddImage(3, 5);
+
+  std::vector<std::pair<int, int>> matches;
+  std::vector<int> inliers;
+  for (int i = 0; i < 5; ++i) {
+    matches.emplace_back(i, i);
+    inliers.push_back(i);
+  }
+  AddImagePair(corr_graph, 1, 2, matches, inliers);
+  AddImagePair(corr_graph, 1, 3, matches, inliers);
+  AddImagePair(corr_graph, 2, 3, matches, inliers);
+
+  const auto keypoints = MakeWellSeparatedKeypoints({1, 2, 3}, 5);
+  const auto pair_ids = CollectPairIds(corr_graph);
+
+  const MatchPredicate ignore_image1 =
+      [](image_t i1, point2D_t /*p1*/, image_t i2, point2D_t /*p2*/) {
+        return i1 == 1 || i2 == 1;
+      };
+
+  // With min_views=3, dropping image 1 leaves only length-2 tracks across
+  // images 2-3, all filtered out.
+  {
+    TrackEstablishmentOptions options;  // default min_views=3
+    const auto tracks = EstablishTracksFromCorrGraph(
+        pair_ids, corr_graph, keypoints, options, ignore_image1);
+    EXPECT_TRUE(tracks.empty());
+  }
+
+  // With min_views=2 the surviving tracks become visible; verify image 1 is
+  // entirely absent.
+  {
+    TrackEstablishmentOptions options;
+    options.min_num_views_per_track = 2;
+    const auto tracks = EstablishTracksFromCorrGraph(
+        pair_ids, corr_graph, keypoints, options, ignore_image1);
+    EXPECT_EQ(tracks.size(), 5);
+    for (const auto& [pid, point3D] : tracks) {
+      EXPECT_EQ(point3D.track.Length(), 2);
+      for (const auto& el : point3D.track.Elements()) {
+        EXPECT_NE(el.image_id, 1u);
+      }
+    }
+  }
+}
+
+// Empty ``valid_pair_ids`` yields no tracks and no crash.
+TEST(TrackEstablishment, EmptyInputReturnsEmpty) {
+  CorrespondenceGraph corr_graph;
+  std::unordered_map<image_t, std::vector<Eigen::Vector2d>> keypoints;
+  TrackEstablishmentOptions options;
+  const auto tracks =
+      EstablishTracksFromCorrGraph({}, corr_graph, keypoints, options);
+  EXPECT_TRUE(tracks.empty());
+}
+
+// ============================================================================
+// FindTracksForProblem (greedy subsample + 2-view depth gate)
+// ============================================================================
+
+// Build a registered Image with N features.
+Image MakeRegisteredImage(image_t image_id, int num_features) {
+  Image image;
+  image.SetImageId(image_id);
+  image.is_registered = true;
+  image.features.assign(num_features, Eigen::Vector2d::Zero());
+  return image;
+}
+
+// Build a Point3D with regular elements (image_id, feature_idx) pairs; no
+// LC elements.
+Point3D MakePoint3DFromElements(
+    const std::vector<std::pair<image_t, point2D_t>>& elements) {
+  Point3D p;
+  for (const auto& [image_id, point2D_idx] : elements) {
+    p.track.AddElement(image_id, point2D_idx);
+  }
+  return p;
+}
+
+// Collect registered image ids from a test fixture.
+std::unordered_set<image_t> MakeRegisteredImageIds(
+    const std::unordered_map<image_t, Image>& images) {
+  std::unordered_set<image_t> ids;
+  for (const auto& [image_id, image] : images) {
+    if (image.is_registered) ids.insert(image_id);
+  }
+  return ids;
+}
+
+// LengthFilter: with ``min_num_views_per_track=10`` every track here is too
+// short, so SubsampleTracks returns empty. Loosening to 2 surfaces every input
+// track (assuming the per-view greedy quota is satisfied).
+//
+// Drives SubsampleTracks.
+TEST(FindTracksForProblem, LengthFilter) {
+  std::unordered_map<image_t, Image> images;
+  images.emplace(1, MakeRegisteredImage(1, 5));
+  images.emplace(2, MakeRegisteredImage(2, 5));
+  images.emplace(3, MakeRegisteredImage(3, 5));
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  for (point2D_t f = 0; f < 5; ++f) {
+    tracks_full.emplace(f,
+                        MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
+  }
+
+  const auto reg_ids = MakeRegisteredImageIds(images);
+  const std::unordered_map<image_t, std::vector<double>> empty_depths;
+  const std::unordered_map<image_t, std::vector<bool>> empty_validity;
+
+  // High-min variant: tracks have length 3, demand 10.
+  {
+    TrackSubsampleOptions options;
+    options.min_num_views_per_track = 10;
+    options.required_tracks_per_view = 1000;  // never saturate
+    const auto selected = SubsampleTracks(
+        options, reg_ids, empty_depths, empty_validity, tracks_full);
+    EXPECT_EQ(selected.size(), 0u);
+    EXPECT_TRUE(selected.empty());
+  }
+
+  // Low-min variant: every length-3 track survives.
+  {
+    TrackSubsampleOptions options;
+    options.min_num_views_per_track = 2;
+    options.required_tracks_per_view = 1000;
+    const auto selected = SubsampleTracks(
+        options, reg_ids, empty_depths, empty_validity, tracks_full);
+    EXPECT_EQ(selected.size(), 5u);
+  }
+}
+
+// MaxLengthFilter: tracks of length 5 dropped when max=4.
+//
+// Drives SubsampleTracks.
+TEST(FindTracksForProblem, MaxLengthFilter) {
+  std::unordered_map<image_t, Image> images;
+  for (image_t i = 1; i <= 5; ++i) {
+    images.emplace(i, MakeRegisteredImage(i, 3));
+  }
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  for (point2D_t f = 0; f < 3; ++f) {
+    tracks_full.emplace(
+        f, MakePoint3DFromElements(
+               {{1, f}, {2, f}, {3, f}, {4, f}, {5, f}}));
+  }
+
+  const auto reg_ids = MakeRegisteredImageIds(images);
+  const std::unordered_map<image_t, std::vector<double>> empty_depths;
+  const std::unordered_map<image_t, std::vector<bool>> empty_validity;
+
+  TrackSubsampleOptions options;
+  options.min_num_views_per_track = 2;
+  options.max_num_views_per_track = 4;
+  options.required_tracks_per_view = 1000;
+  const auto selected = SubsampleTracks(
+      options, reg_ids, empty_depths, empty_validity, tracks_full);
+  EXPECT_EQ(selected.size(), 0u);
+  EXPECT_TRUE(selected.empty());
+}
+
+// GreedyQuota: 5 length-3 tracks across 3 images, ``required_tracks_per_view=2``
+// per-view quota. Greedy keeps as soon as every image is satisfied -> 2
+// tracks suffice (each contributes to all 3 images at once).
+//
+// Drives SubsampleTracks.
+TEST(FindTracksForProblem, GreedyQuota) {
+  std::unordered_map<image_t, Image> images;
+  for (image_t i = 1; i <= 3; ++i) {
+    images.emplace(i, MakeRegisteredImage(i, 5));
+  }
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  for (point2D_t f = 0; f < 5; ++f) {
+    tracks_full.emplace(f,
+                        MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
+  }
+
+  const auto reg_ids = MakeRegisteredImageIds(images);
+  const std::unordered_map<image_t, std::vector<double>> empty_depths;
+  const std::unordered_map<image_t, std::vector<bool>> empty_validity;
+
+  TrackSubsampleOptions options;
+  options.min_num_views_per_track = 2;
+  options.required_tracks_per_view = 2;
+  const auto selected = SubsampleTracks(
+      options, reg_ids, empty_depths, empty_validity, tracks_full);
+  const size_t n_selected = selected.size();
+
+  // Each track touches all 3 images so 2 tracks fully satisfy the per-view
+  // quota of 2. Bound: at most all 5 input tracks; at least 2 (the quota).
+  EXPECT_GE(n_selected, 2u);
+  EXPECT_LE(n_selected, 5u);
+}
+
+// MinTracksPerViewBugDocumentation: enshrines the actual behaviour of the
+// default ``required_tracks_per_view = INT_MAX``.
+TEST(FindTracksForProblem, MinTracksPerViewBugDocumentation) {
+  std::unordered_map<image_t, Image> images;
+  for (image_t i = 1; i <= 3; ++i) {
+    images.emplace(i, MakeRegisteredImage(i, 3));
+  }
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  for (point2D_t f = 0; f < 3; ++f) {
+    tracks_full.emplace(f,
+                        MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
+  }
+
+  const auto reg_ids = MakeRegisteredImageIds(images);
+  const std::unordered_map<image_t, std::vector<double>> empty_depths;
+  const std::unordered_map<image_t, std::vector<bool>> empty_validity;
+
+  TrackSubsampleOptions options;
+  options.min_num_views_per_track = 2;
+  // options.required_tracks_per_view stays at default = INT_MAX.
+  const auto selected = SubsampleTracks(
+      options, reg_ids, empty_depths, empty_validity, tracks_full);
+  // All 3 tracks are kept — the quota gate is disabled by INT_MAX bar.
+  EXPECT_EQ(selected.size(), 3u);
+}
+
+// ============================================================================
+// ProcessLoopClosurePairs (second pass over LC-marked inlier matches)
+// ============================================================================
+//
+// These tests now drive the two-step ``EstablishTracksFromCorrGraph`` (with
+// ``MakeLoopClosureMatchPredicate`` filtering LC matches out of the union-
+// find pass) followed by ``AppendLoopClosureObservations`` (which adds LC
+// observations as parallel ``Track::lc_elements``). Setup:
+//   * Regular matches (``are_lc[idx]=false``) drive native track construction.
+//   * LC matches (``are_lc[idx]=true``) are skipped by
+//     ``MakeLoopClosureMatchPredicate`` and consumed by
+//     ``AppendLoopClosureObservations``.
+// The post-condition tracks dict is what we assert on.
+
+// Variant of ``AddImagePair`` that also populates ``are_lc``. Each
+// ``lc_match_indices`` entry is a row index into ``matches`` (NOT an index
+// into ``inliers``); matching the indexing convention used inside
+// ``AppendLoopClosureObservations``.
+void AddImagePairWithLC(CorrespondenceGraph& corr_graph,
+                        image_t image_id1,
+                        image_t image_id2,
+                        const std::vector<std::pair<int, int>>& matches,
+                        const std::vector<int>& inliers,
+                        const std::vector<size_t>& lc_match_indices) {
+  const image_pair_t pair_id = ImagePairToPairId(image_id1, image_id2);
+  CorrespondenceGraph::ImagePair image_pair(image_id1, image_id2);
+  Eigen::MatrixXi matches_mat(static_cast<int>(matches.size()), 2);
+  for (size_t i = 0; i < matches.size(); ++i) {
+    matches_mat(static_cast<int>(i), 0) = matches[i].first;
+    matches_mat(static_cast<int>(i), 1) = matches[i].second;
+  }
+  image_pair.matches = std::move(matches_mat);
+  image_pair.inliers = inliers;
+  image_pair.num_matches = static_cast<point2D_t>(inliers.size());
+  std::vector<bool> are_lc(matches.size(), false);
+  for (const size_t row : lc_match_indices) are_lc[row] = true;
+  image_pair.are_lc = std::move(are_lc);
+  corr_graph.MutableImagePairs().emplace(pair_id, std::move(image_pair));
+}
+
+// Helper: track contains (image_id, p2d_idx) as a regular element.
+bool TrackHasElement(const Track& track,
+                     image_t image_id,
+                     point2D_t p2d_idx) {
+  for (const auto& el : track.Elements()) {
+    if (el.image_id == image_id && el.point2D_idx == p2d_idx) return true;
+  }
+  return false;
+}
+
+// Helper: track contains (image_id, p2d_idx) as an LC element.
+bool TrackHasLCElement(const Track& track,
+                       image_t image_id,
+                       point2D_t p2d_idx) {
+  for (const auto& el : track.lc_elements) {
+    if (el.image_id == image_id && el.point2D_idx == p2d_idx) return true;
+  }
+  return false;
+}
+
+// Run the native + LC two-step end-to-end and return the populated tracks
+// dict.
+std::unordered_map<point3D_t, Point3D> EstablishFullTracks(
+    const CorrespondenceGraph& corr_graph,
+    const std::unordered_map<image_t, std::vector<Eigen::Vector2d>>& keypoints,
+    const TrackEstablishmentOptions& options) {
+  const auto pair_ids = CollectPairIds(corr_graph);
+  const auto ignore_lc =
+      MakeLoopClosureMatchPredicate(pair_ids, corr_graph);
+  auto tracks = EstablishTracksFromCorrGraph(
+      pair_ids, corr_graph, keypoints, options, ignore_lc);
+  AppendLoopClosureObservations(pair_ids, corr_graph, tracks);
+  return tracks;
+}
+
+// Both endpoints of the LC match already lie on existing native tracks, but
+// on DIFFERENT tracks. Expect reciprocal lc_elements added to both; tracks
+// stay separate (no merge).
+//
+// Setup: regular triangle (1,2,3) with feature i <-> feature i, plus a
+// regular pair (3,4) extending each feature-i track to image 4 -> 5 native
+// tracks of length 4. LC pair (1,4) with one match (img1:feat=0 <->
+// img4:feat=1): feat-0 chain holds img1:0; feat-1 chain holds img4:1.
+//
+// Drives EstablishTracksFromCorrGraph + AppendLoopClosureObservations.
+TEST(ProcessLoopClosurePairs, BothExistingTracks) {
+  CorrespondenceGraph corr_graph;
+  for (image_t i = 1; i <= 4; ++i) corr_graph.AddImage(i, 5);
+
+  std::vector<std::pair<int, int>> reg_matches;
+  std::vector<int> reg_inliers;
+  for (int i = 0; i < 5; ++i) {
+    reg_matches.emplace_back(i, i);
+    reg_inliers.push_back(i);
+  }
+  AddImagePairWithLC(corr_graph, 1, 2, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 1, 3, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 2, 3, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 3, 4, reg_matches, reg_inliers, {});
+
+  // LC-only pair (1,4) with the cross-track match.
+  AddImagePairWithLC(corr_graph, 1, 4, {{0, 1}}, {0}, {0});
+
+  const auto kps = MakeWellSeparatedKeypoints({1, 2, 3, 4}, 5);
+
+  TrackEstablishmentOptions opts;
+  opts.min_num_views_per_track = 3;
+  opts.intra_image_consistency_threshold = 10.0;
+  const auto tracks = EstablishFullTracks(corr_graph, kps, opts);
+
+  // Native pass yields 5 tracks; LC pass adds reciprocal lc_elements
+  // without minting any new track.
+  EXPECT_EQ(tracks.size(), 5u);
+
+  // Locate the two native tracks the LC match's endpoints fall on.
+  const auto kInvalid = std::numeric_limits<point3D_t>::max();
+  point3D_t tid_a = kInvalid;
+  point3D_t tid_b = kInvalid;
+  for (const auto& [tid, p3d] : tracks) {
+    if (TrackHasElement(p3d.track, 1, 0)) tid_a = tid;
+    if (TrackHasElement(p3d.track, 4, 1)) tid_b = tid;
+  }
+  ASSERT_NE(tid_a, kInvalid);
+  ASSERT_NE(tid_b, kInvalid);
+  EXPECT_NE(tid_a, tid_b) << "Tracks must remain separate (no merge).";
+
+  // Reciprocal lc_elements present.
+  EXPECT_TRUE(TrackHasLCElement(tracks.at(tid_a).track, 4, 1));
+  EXPECT_TRUE(TrackHasLCElement(tracks.at(tid_b).track, 1, 0));
+
+  // Sanity: the LC observation is NOT a regular element of either track.
+  EXPECT_FALSE(TrackHasElement(tracks.at(tid_a).track, 4, 1));
+  EXPECT_FALSE(TrackHasElement(tracks.at(tid_b).track, 1, 0));
+}
+
+// Exactly one LC endpoint lies on an existing native track; the other side
+// is orphan. Expect lc_element added to the existing track; no new track is
+// minted.
+//
+// Drives EstablishTracksFromCorrGraph + AppendLoopClosureObservations.
+TEST(ProcessLoopClosurePairs, OneExistingTrack) {
+  CorrespondenceGraph corr_graph;
+  for (image_t i = 1; i <= 3; ++i) corr_graph.AddImage(i, 5);
+  corr_graph.AddImage(4, 5);  // image 4 has no regular pair -> orphan.
+
+  std::vector<std::pair<int, int>> reg_matches;
+  std::vector<int> reg_inliers;
+  for (int i = 0; i < 5; ++i) {
+    reg_matches.emplace_back(i, i);
+    reg_inliers.push_back(i);
+  }
+  AddImagePairWithLC(corr_graph, 1, 2, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 1, 3, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 2, 3, reg_matches, reg_inliers, {});
+
+  // LC-only pair (1, 4): img1:feat=0 (on native track) <-> img4:feat=0
+  // (orphan).
+  AddImagePairWithLC(corr_graph, 1, 4, {{0, 0}}, {0}, {0});
+
+  const auto kps = MakeWellSeparatedKeypoints({1, 2, 3, 4}, 5);
+
+  TrackEstablishmentOptions opts;
+  opts.min_num_views_per_track = 3;
+  opts.intra_image_consistency_threshold = 10.0;
+  const auto tracks = EstablishFullTracks(corr_graph, kps, opts);
+
+  // 5 native tracks; no new track minted (one side already on a track).
+  EXPECT_EQ(tracks.size(), 5u);
+
+  bool found_track_a = false;
+  for (const auto& [tid, p3d] : tracks) {
+    if (TrackHasElement(p3d.track, 1, 0)) {
+      EXPECT_TRUE(TrackHasLCElement(p3d.track, 4, 0));
+      found_track_a = true;
+    }
+    // (img4, feat=0) should never be a regular element.
+    EXPECT_FALSE(TrackHasElement(p3d.track, 4, 0));
+  }
+  EXPECT_TRUE(found_track_a);
+}
+
+// Both LC endpoints are orphan (neither lives on a native track). Expect 2
+// new tracks minted, each with 1 regular element + the other side as
+// lc_element. Ids land at sequential positions past the native max.
+//
+// Drives EstablishTracksFromCorrGraph + AppendLoopClosureObservations.
+TEST(ProcessLoopClosurePairs, NeitherExistingTrack) {
+  CorrespondenceGraph corr_graph;
+  for (image_t i = 1; i <= 3; ++i) corr_graph.AddImage(i, 5);
+  // Images 4, 5 are orphan.
+  corr_graph.AddImage(4, 5);
+  corr_graph.AddImage(5, 5);
+
+  std::vector<std::pair<int, int>> reg_matches;
+  std::vector<int> reg_inliers;
+  for (int i = 0; i < 5; ++i) {
+    reg_matches.emplace_back(i, i);
+    reg_inliers.push_back(i);
+  }
+  AddImagePairWithLC(corr_graph, 1, 2, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 1, 3, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 2, 3, reg_matches, reg_inliers, {});
+
+  // LC-only pair (4, 5) carrying one match img4:feat=2 <-> img5:feat=3.
+  AddImagePairWithLC(corr_graph, 4, 5, {{2, 3}}, {0}, {0});
+
+  const auto kps = MakeWellSeparatedKeypoints({1, 2, 3, 4, 5}, 5);
+
+  TrackEstablishmentOptions opts;
+  opts.min_num_views_per_track = 3;
+  opts.intra_image_consistency_threshold = 10.0;
+  const auto tracks = EstablishFullTracks(corr_graph, kps, opts);
+
+  // 5 native tracks + 2 minted = 7.
+  EXPECT_EQ(tracks.size(), 7u);
+
+  const auto kInvalid = std::numeric_limits<point3D_t>::max();
+  point3D_t tid_for_4_2 = kInvalid;
+  point3D_t tid_for_5_3 = kInvalid;
+  for (const auto& [tid, p3d] : tracks) {
+    if (TrackHasElement(p3d.track, 4, 2)) tid_for_4_2 = tid;
+    if (TrackHasElement(p3d.track, 5, 3)) tid_for_5_3 = tid;
+  }
+  ASSERT_NE(tid_for_4_2, kInvalid);
+  ASSERT_NE(tid_for_5_3, kInvalid);
+  // Native ids are dense [0, 5); minted ids must be >= 5.
+  EXPECT_GE(tid_for_4_2, 5u);
+  EXPECT_GE(tid_for_5_3, 5u);
+  // Sequential — they differ by exactly 1.
+  const point3D_t lo = std::min(tid_for_4_2, tid_for_5_3);
+  const point3D_t hi = std::max(tid_for_4_2, tid_for_5_3);
+  EXPECT_EQ(hi, lo + 1);
+
+  // Each minted track has exactly 1 regular element + 1 lc_element.
+  const auto& track_a = tracks.at(tid_for_4_2).track;
+  EXPECT_EQ(track_a.Length(), 1u);
+  EXPECT_EQ(track_a.lc_elements.size(), 1u);
+  EXPECT_TRUE(TrackHasLCElement(track_a, 5, 3));
+
+  const auto& track_b = tracks.at(tid_for_5_3).track;
+  EXPECT_EQ(track_b.Length(), 1u);
+  EXPECT_EQ(track_b.lc_elements.size(), 1u);
+  EXPECT_TRUE(TrackHasLCElement(track_b, 4, 2));
+}
+
+// Multiple LC matches across multiple pairs. The internal obs_to_track
+// lookup must be updated as each new track is minted so subsequent LC pairs
+// find them — otherwise we'd double-mint and end up with 4 minted tracks
+// instead of 2.
+//
+// Setup: regular triangle on (1,2,3) -> 5 native tracks. Then LC pairs
+// (4,5) and (5,6), each with one LC match. The two pairs share the
+// observation (img5:feat=0). Whichever pair runs first mints a track for
+// (img5:feat=0); the second pair must hit "OneExistingTrack" via that
+// observation rather than re-mint.
+//
+// Drives EstablishTracksFromCorrGraph + AppendLoopClosureObservations.
+TEST(ProcessLoopClosurePairs, MultipleLCMatchesAcrossPairs) {
+  CorrespondenceGraph corr_graph;
+  for (image_t i = 1; i <= 6; ++i) corr_graph.AddImage(i, 5);
+
+  std::vector<std::pair<int, int>> reg_matches;
+  std::vector<int> reg_inliers;
+  for (int i = 0; i < 5; ++i) {
+    reg_matches.emplace_back(i, i);
+    reg_inliers.push_back(i);
+  }
+  AddImagePairWithLC(corr_graph, 1, 2, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 1, 3, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 2, 3, reg_matches, reg_inliers, {});
+
+  AddImagePairWithLC(corr_graph, 4, 5, {{0, 0}}, {0}, {0});
+  AddImagePairWithLC(corr_graph, 5, 6, {{0, 0}}, {0}, {0});
+
+  const auto kps = MakeWellSeparatedKeypoints({1, 2, 3, 4, 5, 6}, 5);
+
+  TrackEstablishmentOptions opts;
+  opts.min_num_views_per_track = 3;
+  opts.intra_image_consistency_threshold = 10.0;
+  const auto tracks = EstablishFullTracks(corr_graph, kps, opts);
+
+  // 5 native + (2 minted from first LC pair processed) + (0 minted from
+  // second LC pair, "OneExistingTrack" branch on img5:feat=0) = 7.
+  // Without the obs_to_track update, the second pair would mint two more
+  // tracks (or one, depending on order) and we'd see 8 or 9.
+  EXPECT_EQ(tracks.size(), 7u);
+
+  // (img5, feat=0) appears as a regular element exactly once across the
+  // minted tracks.
+  int count_5_0_regular = 0;
+  for (const auto& [tid, p3d] : tracks) {
+    if (TrackHasElement(p3d.track, 5, 0)) ++count_5_0_regular;
+  }
+  EXPECT_EQ(count_5_0_regular, 1);
+}
+
+// Smoke test: native produces 10 dense tracks (ids in [0, 10)); minted ids
+// must start >= 10 and never collide with a native id.
+//
+// Drives EstablishTracksFromCorrGraph + AppendLoopClosureObservations.
+TEST(ProcessLoopClosurePairs, SequentialIdsNoCollision) {
+  CorrespondenceGraph corr_graph;
+  for (image_t i = 1; i <= 3; ++i) corr_graph.AddImage(i, 10);
+  corr_graph.AddImage(4, 10);
+  corr_graph.AddImage(5, 10);
+
+  std::vector<std::pair<int, int>> reg_matches;
+  std::vector<int> reg_inliers;
+  for (int i = 0; i < 10; ++i) {
+    reg_matches.emplace_back(i, i);
+    reg_inliers.push_back(i);
+  }
+  AddImagePairWithLC(corr_graph, 1, 2, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 1, 3, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 2, 3, reg_matches, reg_inliers, {});
+  AddImagePairWithLC(corr_graph, 4, 5, {{0, 0}}, {0}, {0});
+
+  const auto kps = MakeWellSeparatedKeypoints({1, 2, 3, 4, 5}, 10);
+
+  TrackEstablishmentOptions opts;
+  opts.min_num_views_per_track = 3;
+  opts.intra_image_consistency_threshold = 10.0;
+  const auto tracks = EstablishFullTracks(corr_graph, kps, opts);
+
+  EXPECT_EQ(tracks.size(), 12u);  // 10 native + 2 minted
+
+  // Native ids: dense [0, 10). Verify no collision: every track that holds
+  // (img4, feat=0) or (img5, feat=0) as a regular element has id >= 10.
+  for (const auto& [tid, p3d] : tracks) {
+    const bool minted_endpoint = TrackHasElement(p3d.track, 4, 0) ||
+                                 TrackHasElement(p3d.track, 5, 0);
+    if (minted_endpoint) {
+      EXPECT_GE(tid, 10u) << "minted id " << tid << " collided with native";
+    }
+  }
+}
+
+}  // namespace
+}  // namespace colmap

--- a/src/colmap/sfm/track_establishment_test.cc
+++ b/src/colmap/sfm/track_establishment_test.cc
@@ -351,8 +351,13 @@ void AddImagePairWithLC(CorrespondenceGraph& corr_graph,
                         const std::vector<std::pair<int, int>>& matches,
                         const std::vector<int>& inliers,
                         const std::vector<size_t>& lc_match_indices) {
+  // Register via AddTwoViewGeometry so ExtractMatchesBetweenImages works.
+  AddImagePair(corr_graph, image_id1, image_id2, matches, inliers);
+
+  // Populate extended fields on the ImagePair that AddTwoViewGeometry
+  // created.
   const image_pair_t pair_id = ImagePairToPairId(image_id1, image_id2);
-  CorrespondenceGraph::ImagePair image_pair(image_id1, image_id2);
+  auto& image_pair = corr_graph.MutableImagePairs().at(pair_id);
   Eigen::MatrixXi matches_mat(static_cast<int>(matches.size()), 2);
   for (size_t i = 0; i < matches.size(); ++i) {
     matches_mat(static_cast<int>(i), 0) = matches[i].first;
@@ -360,11 +365,9 @@ void AddImagePairWithLC(CorrespondenceGraph& corr_graph,
   }
   image_pair.matches = std::move(matches_mat);
   image_pair.inliers = inliers;
-  image_pair.num_matches = static_cast<point2D_t>(inliers.size());
   std::vector<bool> are_lc(matches.size(), false);
   for (const size_t row : lc_match_indices) are_lc[row] = true;
   image_pair.are_lc = std::move(are_lc);
-  corr_graph.MutableImagePairs().emplace(pair_id, std::move(image_pair));
 }
 
 // Helper: track contains (image_id, p2d_idx) as a regular element.
@@ -387,158 +390,141 @@ bool TrackHasLCElement(const Track& track,
   return false;
 }
 
-// Run the native + LC two-step end-to-end and return the populated tracks
-// dict.
+// Populate an LC-only ImagePair directly (no AddTwoViewGeometry). Use for
+// tests that call AppendLoopClosureObservations in isolation.
+void AddLCOnlyPair(CorrespondenceGraph& corr_graph,
+                   image_t image_id1,
+                   image_t image_id2,
+                   const std::vector<std::pair<int, int>>& matches,
+                   const std::vector<int>& inliers) {
+  const image_pair_t pair_id = ImagePairToPairId(image_id1, image_id2);
+  CorrespondenceGraph::ImagePair image_pair(image_id1, image_id2);
+  Eigen::MatrixXi matches_mat(static_cast<int>(matches.size()), 2);
+  for (size_t i = 0; i < matches.size(); ++i) {
+    matches_mat(static_cast<int>(i), 0) = matches[i].first;
+    matches_mat(static_cast<int>(i), 1) = matches[i].second;
+  }
+  image_pair.matches = std::move(matches_mat);
+  image_pair.inliers = inliers;
+  image_pair.are_lc.assign(matches.size(), true);
+  corr_graph.MutableImagePairs().emplace(pair_id, std::move(image_pair));
+}
+
+// Run the native + LC two-step end-to-end matching production code path:
+// MakeLoopClosureMatchPredicate suppresses LC-flagged observations from
+// union-find, then AppendLoopClosureObservations attaches them as
+// lc_elements.
 std::unordered_map<point3D_t, Point3D> EstablishFullTracks(
     const CorrespondenceGraph& corr_graph,
     const std::unordered_map<image_t, std::vector<Eigen::Vector2d>>& keypoints,
     const TrackEstablishmentOptions& options) {
   const auto pair_ids = CollectPairIds(corr_graph);
-  auto tracks =
-      EstablishTracksFromCorrGraph(pair_ids, corr_graph, keypoints, options);
+  auto ignore_match = MakeLoopClosureMatchPredicate(pair_ids, corr_graph);
+  TrackEstablishmentOptions opts = options;
+  opts.required_tracks_per_view = std::numeric_limits<int>::max();
+  auto tracks = EstablishTracksFromCorrGraph(
+      pair_ids, corr_graph, keypoints, opts, ignore_match);
   AppendLoopClosureObservations(pair_ids, corr_graph, tracks);
   return tracks;
 }
 
-// Both endpoints of the LC match already lie on existing native tracks, but
-// on DIFFERENT tracks. Expect reciprocal lc_elements added to both; tracks
-// stay separate (no merge).
+// Both endpoints of the LC match already lie on existing tracks (different
+// ones). Expect reciprocal lc_elements added; tracks stay separate.
 //
-// Setup: regular triangle (1,2,3) with feature i <-> feature i, plus a
-// regular pair (3,4) extending each feature-i track to image 4 -> 5 native
-// tracks of length 4. LC pair (1,4) with one match (img1:feat=0 <->
-// img4:feat=1): feat-0 chain holds img1:0; feat-1 chain holds img4:1.
-//
-// Drives EstablishTracksFromCorrGraph + AppendLoopClosureObservations.
+// Calls AppendLoopClosureObservations directly with pre-built tracks.
 TEST(ProcessLoopClosurePairs, BothExistingTracks) {
   CorrespondenceGraph corr_graph;
-  for (image_t i = 1; i <= 4; ++i) corr_graph.AddImage(i, 5);
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(2, 5);
 
-  std::vector<std::pair<int, int>> reg_matches;
-  std::vector<int> reg_inliers;
-  for (int i = 0; i < 5; ++i) {
-    reg_matches.emplace_back(i, i);
-    reg_inliers.push_back(i);
+  // LC pair (1,2) with cross-track match: img1:0 <-> img2:1.
+  AddLCOnlyPair(corr_graph, 1, 2, {{0, 1}}, {0});
+
+  // Pre-build two tracks with the LC endpoints on different tracks.
+  std::unordered_map<point3D_t, Point3D> tracks;
+  {
+    Point3D p;
+    p.track.AddElement(1, 0);
+    p.track.AddElement(3, 0);
+    tracks.emplace(0, std::move(p));
   }
-  AddImagePairWithLC(corr_graph, 1, 2, reg_matches, reg_inliers, {});
-  AddImagePairWithLC(corr_graph, 1, 3, reg_matches, reg_inliers, {});
-  AddImagePairWithLC(corr_graph, 2, 3, reg_matches, reg_inliers, {});
-  AddImagePairWithLC(corr_graph, 3, 4, reg_matches, reg_inliers, {});
-
-  // LC-only pair (1,4) with the cross-track match.
-  AddImagePairWithLC(corr_graph, 1, 4, {{0, 1}}, {0}, {0});
-
-  const auto kps = MakeWellSeparatedKeypoints({1, 2, 3, 4}, 5);
-
-  TrackEstablishmentOptions opts;
-  opts.min_num_views_per_track = 3;
-  opts.intra_image_consistency_threshold = 10.0;
-  const auto tracks = EstablishFullTracks(corr_graph, kps, opts);
-
-  // Native pass yields 5 tracks; LC pass adds reciprocal lc_elements
-  // without minting any new track.
-  EXPECT_EQ(tracks.size(), 5u);
-
-  // Locate the two native tracks the LC match's endpoints fall on.
-  const auto kInvalid = std::numeric_limits<point3D_t>::max();
-  point3D_t tid_a = kInvalid;
-  point3D_t tid_b = kInvalid;
-  for (const auto& [tid, p3d] : tracks) {
-    if (TrackHasElement(p3d.track, 1, 0)) tid_a = tid;
-    if (TrackHasElement(p3d.track, 4, 1)) tid_b = tid;
+  {
+    Point3D p;
+    p.track.AddElement(2, 1);
+    p.track.AddElement(3, 1);
+    tracks.emplace(1, std::move(p));
   }
-  ASSERT_NE(tid_a, kInvalid);
-  ASSERT_NE(tid_b, kInvalid);
-  EXPECT_NE(tid_a, tid_b) << "Tracks must remain separate (no merge).";
 
-  // Reciprocal lc_elements present.
-  EXPECT_TRUE(TrackHasLCElement(tracks.at(tid_a).track, 4, 1));
-  EXPECT_TRUE(TrackHasLCElement(tracks.at(tid_b).track, 1, 0));
+  std::vector<image_pair_t> pair_ids = {ImagePairToPairId(1, 2)};
+  AppendLoopClosureObservations(pair_ids, corr_graph, tracks);
 
-  // Sanity: the LC observation is NOT a regular element of either track.
-  EXPECT_FALSE(TrackHasElement(tracks.at(tid_a).track, 4, 1));
-  EXPECT_FALSE(TrackHasElement(tracks.at(tid_b).track, 1, 0));
+  // No new tracks minted.
+  EXPECT_EQ(tracks.size(), 2u);
+  // Reciprocal lc_elements.
+  EXPECT_TRUE(TrackHasLCElement(tracks.at(0).track, 2, 1));
+  EXPECT_TRUE(TrackHasLCElement(tracks.at(1).track, 1, 0));
+  // Not regular elements.
+  EXPECT_FALSE(TrackHasElement(tracks.at(0).track, 2, 1));
+  EXPECT_FALSE(TrackHasElement(tracks.at(1).track, 1, 0));
 }
 
-// Exactly one LC endpoint lies on an existing native track; the other side
-// is orphan. Expect lc_element added to the existing track; no new track is
-// minted.
+// Exactly one LC endpoint lies on an existing track; the other is orphan.
+// Expect lc_element added to the existing track; no new track minted.
 //
-// Drives EstablishTracksFromCorrGraph + AppendLoopClosureObservations.
+// Calls AppendLoopClosureObservations directly with pre-built tracks.
 TEST(ProcessLoopClosurePairs, OneExistingTrack) {
   CorrespondenceGraph corr_graph;
-  for (image_t i = 1; i <= 3; ++i) corr_graph.AddImage(i, 5);
-  corr_graph.AddImage(4, 5);  // image 4 has no regular pair -> orphan.
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(4, 5);
 
-  std::vector<std::pair<int, int>> reg_matches;
-  std::vector<int> reg_inliers;
-  for (int i = 0; i < 5; ++i) {
-    reg_matches.emplace_back(i, i);
-    reg_inliers.push_back(i);
+  // LC pair (1,4): img1:0 (on track) <-> img4:0 (orphan).
+  AddLCOnlyPair(corr_graph, 1, 4, {{0, 0}}, {0});
+
+  // Pre-build one track containing img1:0.
+  std::unordered_map<point3D_t, Point3D> tracks;
+  {
+    Point3D p;
+    p.track.AddElement(1, 0);
+    p.track.AddElement(2, 0);
+    p.track.AddElement(3, 0);
+    tracks.emplace(0, std::move(p));
   }
-  AddImagePairWithLC(corr_graph, 1, 2, reg_matches, reg_inliers, {});
-  AddImagePairWithLC(corr_graph, 1, 3, reg_matches, reg_inliers, {});
-  AddImagePairWithLC(corr_graph, 2, 3, reg_matches, reg_inliers, {});
 
-  // LC-only pair (1, 4): img1:feat=0 (on native track) <-> img4:feat=0
-  // (orphan).
-  AddImagePairWithLC(corr_graph, 1, 4, {{0, 0}}, {0}, {0});
+  std::vector<image_pair_t> pair_ids = {ImagePairToPairId(1, 4)};
+  AppendLoopClosureObservations(pair_ids, corr_graph, tracks);
 
-  const auto kps = MakeWellSeparatedKeypoints({1, 2, 3, 4}, 5);
-
-  TrackEstablishmentOptions opts;
-  opts.min_num_views_per_track = 3;
-  opts.intra_image_consistency_threshold = 10.0;
-  const auto tracks = EstablishFullTracks(corr_graph, kps, opts);
-
-  // 5 native tracks; no new track minted (one side already on a track).
-  EXPECT_EQ(tracks.size(), 5u);
-
-  bool found_track_a = false;
-  for (const auto& [tid, p3d] : tracks) {
-    if (TrackHasElement(p3d.track, 1, 0)) {
-      EXPECT_TRUE(TrackHasLCElement(p3d.track, 4, 0));
-      found_track_a = true;
-    }
-    // (img4, feat=0) should never be a regular element.
-    EXPECT_FALSE(TrackHasElement(p3d.track, 4, 0));
-  }
-  EXPECT_TRUE(found_track_a);
+  // No new track minted.
+  EXPECT_EQ(tracks.size(), 1u);
+  EXPECT_TRUE(TrackHasLCElement(tracks.at(0).track, 4, 0));
+  EXPECT_FALSE(TrackHasElement(tracks.at(0).track, 4, 0));
 }
 
-// Both LC endpoints are orphan (neither lives on a native track). Expect 2
-// new tracks minted, each with 1 regular element + the other side as
-// lc_element. Ids land at sequential positions past the native max.
+// Both LC endpoints are orphan (neither on any track). Expect 2 new tracks
+// minted, each with 1 regular element + the other side as lc_element.
 //
-// Drives EstablishTracksFromCorrGraph + AppendLoopClosureObservations.
+// Calls AppendLoopClosureObservations directly with pre-built tracks.
 TEST(ProcessLoopClosurePairs, NeitherExistingTrack) {
   CorrespondenceGraph corr_graph;
-  for (image_t i = 1; i <= 3; ++i) corr_graph.AddImage(i, 5);
-  // Images 4, 5 are orphan.
   corr_graph.AddImage(4, 5);
   corr_graph.AddImage(5, 5);
 
-  std::vector<std::pair<int, int>> reg_matches;
-  std::vector<int> reg_inliers;
-  for (int i = 0; i < 5; ++i) {
-    reg_matches.emplace_back(i, i);
-    reg_inliers.push_back(i);
+  // LC pair (4,5): img4:2 <-> img5:3. Neither endpoint on any track.
+  AddLCOnlyPair(corr_graph, 4, 5, {{2, 3}}, {0});
+
+  // Pre-build 5 native tracks on images 1-3 (not touching 4 or 5).
+  std::unordered_map<point3D_t, Point3D> tracks;
+  for (point3D_t tid = 0; tid < 5; ++tid) {
+    Point3D p;
+    p.track.AddElement(1, static_cast<point2D_t>(tid));
+    p.track.AddElement(2, static_cast<point2D_t>(tid));
+    p.track.AddElement(3, static_cast<point2D_t>(tid));
+    tracks.emplace(tid, std::move(p));
   }
-  AddImagePairWithLC(corr_graph, 1, 2, reg_matches, reg_inliers, {});
-  AddImagePairWithLC(corr_graph, 1, 3, reg_matches, reg_inliers, {});
-  AddImagePairWithLC(corr_graph, 2, 3, reg_matches, reg_inliers, {});
 
-  // LC-only pair (4, 5) carrying one match img4:feat=2 <-> img5:feat=3.
-  AddImagePairWithLC(corr_graph, 4, 5, {{2, 3}}, {0}, {0});
+  std::vector<image_pair_t> pair_ids = {ImagePairToPairId(4, 5)};
+  AppendLoopClosureObservations(pair_ids, corr_graph, tracks);
 
-  const auto kps = MakeWellSeparatedKeypoints({1, 2, 3, 4, 5}, 5);
-
-  TrackEstablishmentOptions opts;
-  opts.min_num_views_per_track = 3;
-  opts.intra_image_consistency_threshold = 10.0;
-  const auto tracks = EstablishFullTracks(corr_graph, kps, opts);
-
-  // 5 native tracks + 2 minted = 7.
+  // 5 native + 2 minted = 7.
   EXPECT_EQ(tracks.size(), 7u);
 
   const auto kInvalid = std::numeric_limits<point3D_t>::max();
@@ -550,75 +536,58 @@ TEST(ProcessLoopClosurePairs, NeitherExistingTrack) {
   }
   ASSERT_NE(tid_for_4_2, kInvalid);
   ASSERT_NE(tid_for_5_3, kInvalid);
-  // Native ids are dense [0, 5); minted ids must be >= 5.
   EXPECT_GE(tid_for_4_2, 5u);
   EXPECT_GE(tid_for_5_3, 5u);
-  // Sequential — they differ by exactly 1.
   const point3D_t lo = std::min(tid_for_4_2, tid_for_5_3);
   const point3D_t hi = std::max(tid_for_4_2, tid_for_5_3);
   EXPECT_EQ(hi, lo + 1);
 
-  // Each minted track has exactly 1 regular element + 1 lc_element.
-  const auto& track_a = tracks.at(tid_for_4_2).track;
-  EXPECT_EQ(track_a.Length(), 1u);
-  EXPECT_EQ(track_a.lc_elements.size(), 1u);
-  EXPECT_TRUE(TrackHasLCElement(track_a, 5, 3));
+  EXPECT_EQ(tracks.at(tid_for_4_2).track.Length(), 1u);
+  EXPECT_EQ(tracks.at(tid_for_4_2).track.lc_elements.size(), 1u);
+  EXPECT_TRUE(TrackHasLCElement(tracks.at(tid_for_4_2).track, 5, 3));
 
-  const auto& track_b = tracks.at(tid_for_5_3).track;
-  EXPECT_EQ(track_b.Length(), 1u);
-  EXPECT_EQ(track_b.lc_elements.size(), 1u);
-  EXPECT_TRUE(TrackHasLCElement(track_b, 4, 2));
+  EXPECT_EQ(tracks.at(tid_for_5_3).track.Length(), 1u);
+  EXPECT_EQ(tracks.at(tid_for_5_3).track.lc_elements.size(), 1u);
+  EXPECT_TRUE(TrackHasLCElement(tracks.at(tid_for_5_3).track, 4, 2));
 }
 
-// Multiple LC matches across multiple pairs. The internal obs_to_track
-// lookup must be updated as each new track is minted so subsequent LC pairs
-// find them — otherwise we'd double-mint and end up with 4 minted tracks
-// instead of 2.
+// Multiple LC matches across multiple pairs sharing an observation.
+// obs_to_track must be updated as tracks are minted so the second pair
+// hits OneExistingTrack rather than re-minting.
 //
-// Setup: regular triangle on (1,2,3) -> 5 native tracks. Then LC pairs
-// (4,5) and (5,6), each with one LC match. The two pairs share the
-// observation (img5:feat=0). Whichever pair runs first mints a track for
-// (img5:feat=0); the second pair must hit "OneExistingTrack" via that
-// observation rather than re-mint.
-//
-// Drives EstablishTracksFromCorrGraph + AppendLoopClosureObservations.
+// Calls AppendLoopClosureObservations directly with pre-built tracks.
 TEST(ProcessLoopClosurePairs, MultipleLCMatchesAcrossPairs) {
   CorrespondenceGraph corr_graph;
-  for (image_t i = 1; i <= 6; ++i) corr_graph.AddImage(i, 5);
+  for (image_t i = 4; i <= 6; ++i) corr_graph.AddImage(i, 5);
 
-  std::vector<std::pair<int, int>> reg_matches;
-  std::vector<int> reg_inliers;
-  for (int i = 0; i < 5; ++i) {
-    reg_matches.emplace_back(i, i);
-    reg_inliers.push_back(i);
+  // Two LC pairs sharing img5:0.
+  AddLCOnlyPair(corr_graph, 4, 5, {{0, 0}}, {0});
+  AddLCOnlyPair(corr_graph, 5, 6, {{0, 0}}, {0});
+
+  // Pre-build 5 native tracks on images 1-3 (not touching 4-6).
+  std::unordered_map<point3D_t, Point3D> tracks;
+  for (point3D_t tid = 0; tid < 5; ++tid) {
+    Point3D p;
+    p.track.AddElement(1, static_cast<point2D_t>(tid));
+    p.track.AddElement(2, static_cast<point2D_t>(tid));
+    p.track.AddElement(3, static_cast<point2D_t>(tid));
+    tracks.emplace(tid, std::move(p));
   }
-  AddImagePairWithLC(corr_graph, 1, 2, reg_matches, reg_inliers, {});
-  AddImagePairWithLC(corr_graph, 1, 3, reg_matches, reg_inliers, {});
-  AddImagePairWithLC(corr_graph, 2, 3, reg_matches, reg_inliers, {});
 
-  AddImagePairWithLC(corr_graph, 4, 5, {{0, 0}}, {0}, {0});
-  AddImagePairWithLC(corr_graph, 5, 6, {{0, 0}}, {0}, {0});
+  std::vector<image_pair_t> pair_ids = {
+      ImagePairToPairId(4, 5), ImagePairToPairId(5, 6)};
+  AppendLoopClosureObservations(pair_ids, corr_graph, tracks);
 
-  const auto kps = MakeWellSeparatedKeypoints({1, 2, 3, 4, 5, 6}, 5);
-
-  TrackEstablishmentOptions opts;
-  opts.min_num_views_per_track = 3;
-  opts.intra_image_consistency_threshold = 10.0;
-  const auto tracks = EstablishFullTracks(corr_graph, kps, opts);
-
-  // 5 native + (2 minted from first LC pair processed) + (0 minted from
-  // second LC pair, "OneExistingTrack" branch on img5:feat=0) = 7.
-  // Without the obs_to_track update, the second pair would mint two more
-  // tracks (or one, depending on order) and we'd see 8 or 9.
+  // First pair: neither on track → mint 2 (img4:0, img5:0).
+  // Second pair: img5:0 now on minted track → OneExistingTrack, no mint.
+  // Total: 5 + 2 = 7.
   EXPECT_EQ(tracks.size(), 7u);
 
-  // (img5, feat=0) appears as a regular element exactly once across the
-  // minted tracks.
-  int count_5_0_regular = 0;
+  int count_5_0 = 0;
   for (const auto& [tid, p3d] : tracks) {
-    if (TrackHasElement(p3d.track, 5, 0)) ++count_5_0_regular;
+    if (TrackHasElement(p3d.track, 5, 0)) ++count_5_0;
   }
-  EXPECT_EQ(count_5_0_regular, 1);
+  EXPECT_EQ(count_5_0, 1);
 }
 
 // Smoke test: native produces 10 dense tracks (ids in [0, 10)); minted ids
@@ -660,6 +629,82 @@ TEST(ProcessLoopClosurePairs, SequentialIdsNoCollision) {
       EXPECT_GE(tid, 10u) << "minted id " << tid << " collided with native";
     }
   }
+}
+
+// Both LC endpoints fall on the SAME native track. This is a degenerate
+// case (self-loop) — AppendLoopClosureObservations should skip it silently
+// rather than adding the observation as an lc_element of itself.
+//
+// Setup: regular triangle (1,2,3) → 5 native tracks. LC pair (1,2) with
+// match (img1:feat=0 <-> img2:feat=0) — both endpoints already on the
+// same track (the feat-0 chain includes both img1 and img2).
+//
+// Drives EstablishTracksFromCorrGraph + AppendLoopClosureObservations.
+// Both LC endpoints already live on the SAME native track. The code skips
+// this case (``t1 == t2``) — no lc_elements should be added. Tested by
+// calling AppendLoopClosureObservations directly with a pre-built tracks
+// dict, bypassing MakeLoopClosureMatchPredicate (which would suppress the
+// observations from union-find).
+TEST(ProcessLoopClosurePairs, BothSameTrack) {
+  CorrespondenceGraph corr_graph;
+  corr_graph.AddImage(1, 5);
+  corr_graph.AddImage(2, 5);
+
+  // Populate an LC-only pair directly (no AddTwoViewGeometry needed since
+  // we call AppendLoopClosureObservations directly, not EstablishFullTracks).
+  const image_pair_t pair_id = ImagePairToPairId(1, 2);
+  CorrespondenceGraph::ImagePair image_pair(1, 2);
+  Eigen::MatrixXi matches_mat(1, 2);
+  matches_mat(0, 0) = 0;
+  matches_mat(0, 1) = 0;
+  image_pair.matches = std::move(matches_mat);
+  image_pair.inliers = {0};
+  image_pair.are_lc = {true};
+  corr_graph.MutableImagePairs().emplace(pair_id, std::move(image_pair));
+
+  // Pre-build a single track containing both LC endpoints.
+  std::unordered_map<point3D_t, Point3D> tracks;
+  Point3D p;
+  p.track.AddElement(1, 0);
+  p.track.AddElement(2, 0);
+  tracks.emplace(0, std::move(p));
+
+  std::vector<image_pair_t> pair_ids = {pair_id};
+  AppendLoopClosureObservations(pair_ids, corr_graph, tracks);
+
+  // No new tracks minted, no lc_elements added (same-track skip).
+  EXPECT_EQ(tracks.size(), 1u);
+  EXPECT_EQ(tracks.at(0).track.lc_elements.size(), 0u);
+}
+
+// ============================================================================
+// SubsampleTracks: max_num_tracks limit
+// ============================================================================
+
+// Verify that ``max_num_tracks`` stops the greedy subsample early.
+TEST(FindTracksForProblem, MaxNumTracksLimit) {
+  std::unordered_map<image_t, Image> images;
+  for (image_t i = 1; i <= 3; ++i) {
+    images.emplace(i, MakeRegisteredImage(i, 10));
+  }
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  for (point2D_t f = 0; f < 10; ++f) {
+    tracks_full.emplace(f,
+                        MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
+  }
+
+  const auto reg_ids = MakeRegisteredImageIds(images);
+
+  TrackSubsampleOptions options;
+  options.min_num_views_per_track = 2;
+  options.required_tracks_per_view = 1000;
+  options.max_num_tracks = 3;
+  const auto selected = SubsampleTracks(options, reg_ids, tracks_full);
+  // The break fires AFTER inserting when size > max_num_tracks, so we
+  // may get max_num_tracks + 1. The key assertion: not all 10 are kept.
+  EXPECT_LE(static_cast<int>(selected.size()), options.max_num_tracks + 1);
+  EXPECT_LT(selected.size(), tracks_full.size());
 }
 
 }  // namespace

--- a/src/colmap/sfm/track_establishment_test.cc
+++ b/src/colmap/sfm/track_establishment_test.cc
@@ -176,11 +176,10 @@ TEST(TrackEstablishment, EmptyInputReturnsEmpty) {
 // FindTracksForProblem (greedy subsample + 2-view depth gate)
 // ============================================================================
 
-// Build a registered Image with N features.
-Image MakeRegisteredImage(image_t image_id, int num_features) {
+// Build an Image with N features.
+Image MakeImage(image_t image_id, int num_features) {
   Image image;
   image.SetImageId(image_id);
-  image.is_registered = true;
   image.features.assign(num_features, Eigen::Vector2d::Zero());
   return image;
 }
@@ -196,12 +195,12 @@ Point3D MakePoint3DFromElements(
   return p;
 }
 
-// Collect registered image ids from a test fixture.
-std::unordered_set<image_t> MakeRegisteredImageIds(
+// Collect image ids from a filtered-image test fixture.
+std::unordered_set<image_t> MakeImageIds(
     const std::unordered_map<image_t, Image>& images) {
   std::unordered_set<image_t> ids;
   for (const auto& [image_id, image] : images) {
-    if (image.is_registered) ids.insert(image_id);
+    ids.insert(image_id);
   }
   return ids;
 }
@@ -213,9 +212,9 @@ std::unordered_set<image_t> MakeRegisteredImageIds(
 // Drives SubsampleTracks.
 TEST(FindTracksForProblem, LengthFilter) {
   std::unordered_map<image_t, Image> images;
-  images.emplace(1, MakeRegisteredImage(1, 5));
-  images.emplace(2, MakeRegisteredImage(2, 5));
-  images.emplace(3, MakeRegisteredImage(3, 5));
+  images.emplace(1, MakeImage(1, 5));
+  images.emplace(2, MakeImage(2, 5));
+  images.emplace(3, MakeImage(3, 5));
 
   std::unordered_map<point3D_t, Point3D> tracks_full;
   for (point2D_t f = 0; f < 5; ++f) {
@@ -223,7 +222,7 @@ TEST(FindTracksForProblem, LengthFilter) {
                         MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
   }
 
-  const auto reg_ids = MakeRegisteredImageIds(images);
+  const auto reg_ids = MakeImageIds(images);
 
   // High-min variant: tracks have length 3, demand 10.
   {
@@ -253,7 +252,7 @@ TEST(FindTracksForProblem, LengthFilter) {
 TEST(FindTracksForProblem, MaxLengthFilter) {
   std::unordered_map<image_t, Image> images;
   for (image_t i = 1; i <= 5; ++i) {
-    images.emplace(i, MakeRegisteredImage(i, 3));
+    images.emplace(i, MakeImage(i, 3));
   }
 
   std::unordered_map<point3D_t, Point3D> tracks_full;
@@ -263,7 +262,7 @@ TEST(FindTracksForProblem, MaxLengthFilter) {
                {{1, f}, {2, f}, {3, f}, {4, f}, {5, f}}));
   }
 
-  const auto reg_ids = MakeRegisteredImageIds(images);
+  const auto reg_ids = MakeImageIds(images);
 
   TrackSubsampleOptions options;
   options.min_num_views_per_track = 2;
@@ -283,7 +282,7 @@ TEST(FindTracksForProblem, MaxLengthFilter) {
 TEST(FindTracksForProblem, GreedyQuota) {
   std::unordered_map<image_t, Image> images;
   for (image_t i = 1; i <= 3; ++i) {
-    images.emplace(i, MakeRegisteredImage(i, 5));
+    images.emplace(i, MakeImage(i, 5));
   }
 
   std::unordered_map<point3D_t, Point3D> tracks_full;
@@ -292,7 +291,7 @@ TEST(FindTracksForProblem, GreedyQuota) {
                         MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
   }
 
-  const auto reg_ids = MakeRegisteredImageIds(images);
+  const auto reg_ids = MakeImageIds(images);
 
   TrackSubsampleOptions options;
   options.min_num_views_per_track = 2;
@@ -312,7 +311,7 @@ TEST(FindTracksForProblem, GreedyQuota) {
 TEST(FindTracksForProblem, MinTracksPerViewBugDocumentation) {
   std::unordered_map<image_t, Image> images;
   for (image_t i = 1; i <= 3; ++i) {
-    images.emplace(i, MakeRegisteredImage(i, 3));
+    images.emplace(i, MakeImage(i, 3));
   }
 
   std::unordered_map<point3D_t, Point3D> tracks_full;
@@ -321,7 +320,7 @@ TEST(FindTracksForProblem, MinTracksPerViewBugDocumentation) {
                         MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
   }
 
-  const auto reg_ids = MakeRegisteredImageIds(images);
+  const auto reg_ids = MakeImageIds(images);
 
   TrackSubsampleOptions options;
   options.min_num_views_per_track = 2;
@@ -685,7 +684,7 @@ TEST(ProcessLoopClosurePairs, BothSameTrack) {
 TEST(FindTracksForProblem, MaxNumTracksLimit) {
   std::unordered_map<image_t, Image> images;
   for (image_t i = 1; i <= 3; ++i) {
-    images.emplace(i, MakeRegisteredImage(i, 10));
+    images.emplace(i, MakeImage(i, 10));
   }
 
   std::unordered_map<point3D_t, Point3D> tracks_full;
@@ -694,7 +693,7 @@ TEST(FindTracksForProblem, MaxNumTracksLimit) {
                         MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
   }
 
-  const auto reg_ids = MakeRegisteredImageIds(images);
+  const auto reg_ids = MakeImageIds(images);
 
   TrackSubsampleOptions options;
   options.min_num_views_per_track = 2;

--- a/src/colmap/sfm/track_establishment_test.cc
+++ b/src/colmap/sfm/track_establishment_test.cc
@@ -2,9 +2,9 @@
 
 #include "colmap/feature/types.h"
 #include "colmap/scene/correspondence_graph.h"
-#include "colmap/scene/two_view_geometry.h"
 #include "colmap/scene/image.h"
 #include "colmap/scene/point3d.h"
+#include "colmap/scene/two_view_geometry.h"
 #include "colmap/util/types.h"
 
 #include <algorithm>
@@ -142,14 +142,20 @@ TEST(TrackEstablishment, IntraImageConsistencyDropsInconsistentTrack) {
   // Keypoints: image 1 has feature 0 and feature 1 placed FAR apart so the
   // intra-image consistency check rejects the merged track.
   std::unordered_map<image_t, std::vector<Eigen::Vector2d>> keypoints;
-  keypoints[1] = {Eigen::Vector2d(0, 0), Eigen::Vector2d(1000, 1000),
-                  Eigen::Vector2d(200, 200), Eigen::Vector2d(300, 300),
+  keypoints[1] = {Eigen::Vector2d(0, 0),
+                  Eigen::Vector2d(1000, 1000),
+                  Eigen::Vector2d(200, 200),
+                  Eigen::Vector2d(300, 300),
                   Eigen::Vector2d(400, 400)};
-  keypoints[2] = {Eigen::Vector2d(0, 0), Eigen::Vector2d(100, 100),
-                  Eigen::Vector2d(200, 200), Eigen::Vector2d(300, 300),
+  keypoints[2] = {Eigen::Vector2d(0, 0),
+                  Eigen::Vector2d(100, 100),
+                  Eigen::Vector2d(200, 200),
+                  Eigen::Vector2d(300, 300),
                   Eigen::Vector2d(400, 400)};
-  keypoints[3] = {Eigen::Vector2d(0, 0), Eigen::Vector2d(100, 100),
-                  Eigen::Vector2d(200, 200), Eigen::Vector2d(300, 300),
+  keypoints[3] = {Eigen::Vector2d(0, 0),
+                  Eigen::Vector2d(100, 100),
+                  Eigen::Vector2d(200, 200),
+                  Eigen::Vector2d(300, 300),
                   Eigen::Vector2d(400, 400)};
 
   TrackEstablishmentOptions options;
@@ -206,10 +212,10 @@ std::unordered_set<image_t> MakeImageIds(
 }
 
 // LengthFilter: with ``min_num_views_per_track=10`` every track here is too
-// short, so SubsampleTracks returns empty. Loosening to 2 surfaces every input
-// track (assuming the per-view greedy quota is satisfied).
+// short, so FilterTracksForProblem returns empty. Loosening to 2 surfaces every
+// input track.
 //
-// Drives SubsampleTracks.
+// Drives FilterTracksForProblem.
 TEST(FindTracksForProblem, LengthFilter) {
   std::unordered_map<image_t, Image> images;
   images.emplace(1, MakeImage(1, 5));
@@ -218,37 +224,53 @@ TEST(FindTracksForProblem, LengthFilter) {
 
   std::unordered_map<point3D_t, Point3D> tracks_full;
   for (point2D_t f = 0; f < 5; ++f) {
-    tracks_full.emplace(f,
-                        MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
+    tracks_full.emplace(f, MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
   }
 
   const auto reg_ids = MakeImageIds(images);
 
   // High-min variant: tracks have length 3, demand 10.
   {
-    TrackSubsampleOptions options;
+    TrackProblemFilterOptions options;
     options.min_num_views_per_track = 10;
-    options.required_tracks_per_view = 1000;  // never saturate
-    const auto selected = SubsampleTracks(
-        options, reg_ids, tracks_full);
+    const auto selected = FilterTracksForProblem(options, reg_ids, tracks_full);
     EXPECT_EQ(selected.size(), 0u);
     EXPECT_TRUE(selected.empty());
   }
 
   // Low-min variant: every length-3 track survives.
   {
-    TrackSubsampleOptions options;
+    TrackProblemFilterOptions options;
     options.min_num_views_per_track = 2;
-    options.required_tracks_per_view = 1000;
-    const auto selected = SubsampleTracks(
-        options, reg_ids, tracks_full);
+    const auto selected = FilterTracksForProblem(options, reg_ids, tracks_full);
     EXPECT_EQ(selected.size(), 5u);
   }
 }
 
+TEST(FindTracksForProblem, LcOnlyTrackDoesNotSatisfyMinViews) {
+  std::unordered_map<image_t, Image> images;
+  images.emplace(1, MakeImage(1, 5));
+  images.emplace(2, MakeImage(2, 5));
+
+  Point3D point3D;
+  point3D.track.AddElement(1, 0);
+  point3D.track.lc_elements.emplace_back(2, 0);
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  tracks_full.emplace(0, std::move(point3D));
+
+  const auto reg_ids = MakeImageIds(images);
+
+  TrackProblemFilterOptions options;
+  options.min_num_views_per_track = 2;
+  const auto selected = FilterTracksForProblem(options, reg_ids, tracks_full);
+
+  EXPECT_TRUE(selected.empty());
+}
+
 // MaxLengthFilter: tracks of length 5 dropped when max=4.
 //
-// Drives SubsampleTracks.
+// Drives FilterTracksForProblem.
 TEST(FindTracksForProblem, MaxLengthFilter) {
   std::unordered_map<image_t, Image> images;
   for (image_t i = 1; i <= 5; ++i) {
@@ -258,77 +280,17 @@ TEST(FindTracksForProblem, MaxLengthFilter) {
   std::unordered_map<point3D_t, Point3D> tracks_full;
   for (point2D_t f = 0; f < 3; ++f) {
     tracks_full.emplace(
-        f, MakePoint3DFromElements(
-               {{1, f}, {2, f}, {3, f}, {4, f}, {5, f}}));
+        f, MakePoint3DFromElements({{1, f}, {2, f}, {3, f}, {4, f}, {5, f}}));
   }
 
   const auto reg_ids = MakeImageIds(images);
 
-  TrackSubsampleOptions options;
+  TrackProblemFilterOptions options;
   options.min_num_views_per_track = 2;
   options.max_num_views_per_track = 4;
-  options.required_tracks_per_view = 1000;
-  const auto selected = SubsampleTracks(
-      options, reg_ids, tracks_full);
+  const auto selected = FilterTracksForProblem(options, reg_ids, tracks_full);
   EXPECT_EQ(selected.size(), 0u);
   EXPECT_TRUE(selected.empty());
-}
-
-// GreedyQuota: 5 length-3 tracks across 3 images, ``required_tracks_per_view=2``
-// per-view quota. Greedy keeps as soon as every image is satisfied -> 2
-// tracks suffice (each contributes to all 3 images at once).
-//
-// Drives SubsampleTracks.
-TEST(FindTracksForProblem, GreedyQuota) {
-  std::unordered_map<image_t, Image> images;
-  for (image_t i = 1; i <= 3; ++i) {
-    images.emplace(i, MakeImage(i, 5));
-  }
-
-  std::unordered_map<point3D_t, Point3D> tracks_full;
-  for (point2D_t f = 0; f < 5; ++f) {
-    tracks_full.emplace(f,
-                        MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
-  }
-
-  const auto reg_ids = MakeImageIds(images);
-
-  TrackSubsampleOptions options;
-  options.min_num_views_per_track = 2;
-  options.required_tracks_per_view = 2;
-  const auto selected = SubsampleTracks(
-      options, reg_ids, tracks_full);
-  const size_t n_selected = selected.size();
-
-  // Each track touches all 3 images so 2 tracks fully satisfy the per-view
-  // quota of 2. Bound: at most all 5 input tracks; at least 2 (the quota).
-  EXPECT_GE(n_selected, 2u);
-  EXPECT_LE(n_selected, 5u);
-}
-
-// MinTracksPerViewBugDocumentation: enshrines the actual behaviour of the
-// default ``required_tracks_per_view = INT_MAX``.
-TEST(FindTracksForProblem, MinTracksPerViewBugDocumentation) {
-  std::unordered_map<image_t, Image> images;
-  for (image_t i = 1; i <= 3; ++i) {
-    images.emplace(i, MakeImage(i, 3));
-  }
-
-  std::unordered_map<point3D_t, Point3D> tracks_full;
-  for (point2D_t f = 0; f < 3; ++f) {
-    tracks_full.emplace(f,
-                        MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
-  }
-
-  const auto reg_ids = MakeImageIds(images);
-
-  TrackSubsampleOptions options;
-  options.min_num_views_per_track = 2;
-  // options.required_tracks_per_view stays at default = INT_MAX.
-  const auto selected = SubsampleTracks(
-      options, reg_ids, tracks_full);
-  // All 3 tracks are kept — the quota gate is disabled by INT_MAX bar.
-  EXPECT_EQ(selected.size(), 3u);
 }
 
 // ============================================================================
@@ -370,9 +332,7 @@ void AddImagePairWithLC(CorrespondenceGraph& corr_graph,
 }
 
 // Helper: track contains (image_id, p2d_idx) as a regular element.
-bool TrackHasElement(const Track& track,
-                     image_t image_id,
-                     point2D_t p2d_idx) {
+bool TrackHasElement(const Track& track, image_t image_id, point2D_t p2d_idx) {
   for (const auto& el : track.Elements()) {
     if (el.image_id == image_id && el.point2D_idx == p2d_idx) return true;
   }
@@ -572,8 +532,8 @@ TEST(ProcessLoopClosurePairs, MultipleLCMatchesAcrossPairs) {
     tracks.emplace(tid, std::move(p));
   }
 
-  std::vector<image_pair_t> pair_ids = {
-      ImagePairToPairId(4, 5), ImagePairToPairId(5, 6)};
+  std::vector<image_pair_t> pair_ids = {ImagePairToPairId(4, 5),
+                                        ImagePairToPairId(5, 6)};
   AppendLoopClosureObservations(pair_ids, corr_graph, tracks);
 
   // First pair: neither on track → mint 2 (img4:0, img5:0).
@@ -621,8 +581,8 @@ TEST(ProcessLoopClosurePairs, SequentialIdsNoCollision) {
   // Native ids: dense [0, 10). Verify no collision: every track that holds
   // (img4, feat=0) or (img5, feat=0) as a regular element has id >= 10.
   for (const auto& [tid, p3d] : tracks) {
-    const bool minted_endpoint = TrackHasElement(p3d.track, 4, 0) ||
-                                 TrackHasElement(p3d.track, 5, 0);
+    const bool minted_endpoint =
+        TrackHasElement(p3d.track, 4, 0) || TrackHasElement(p3d.track, 5, 0);
     if (minted_endpoint) {
       EXPECT_GE(tid, 10u) << "minted id " << tid << " collided with native";
     }
@@ -655,8 +615,7 @@ TEST(ProcessLoopClosurePairs, NonLcMatchSharingLcEndpointStillBuildsTrack) {
   EXPECT_EQ(tracks.size(), 1u);
   bool found_regular_track = false;
   for (const auto& [tid, p3d] : tracks) {
-    if (TrackHasElement(p3d.track, 1, 0) &&
-        TrackHasElement(p3d.track, 3, 0)) {
+    if (TrackHasElement(p3d.track, 1, 0) && TrackHasElement(p3d.track, 3, 0)) {
       found_regular_track = true;
       EXPECT_TRUE(TrackHasLCElement(p3d.track, 2, 0));
     }
@@ -708,36 +667,6 @@ TEST(ProcessLoopClosurePairs, BothSameTrack) {
   // No new tracks minted, no lc_elements added (same-track skip).
   EXPECT_EQ(tracks.size(), 1u);
   EXPECT_EQ(tracks.at(0).track.lc_elements.size(), 0u);
-}
-
-// ============================================================================
-// SubsampleTracks: max_num_tracks limit
-// ============================================================================
-
-// Verify that ``max_num_tracks`` stops the greedy subsample early.
-TEST(FindTracksForProblem, MaxNumTracksLimit) {
-  std::unordered_map<image_t, Image> images;
-  for (image_t i = 1; i <= 3; ++i) {
-    images.emplace(i, MakeImage(i, 10));
-  }
-
-  std::unordered_map<point3D_t, Point3D> tracks_full;
-  for (point2D_t f = 0; f < 10; ++f) {
-    tracks_full.emplace(f,
-                        MakePoint3DFromElements({{1, f}, {2, f}, {3, f}}));
-  }
-
-  const auto reg_ids = MakeImageIds(images);
-
-  TrackSubsampleOptions options;
-  options.min_num_views_per_track = 2;
-  options.required_tracks_per_view = 1000;
-  options.max_num_tracks = 3;
-  const auto selected = SubsampleTracks(options, reg_ids, tracks_full);
-  // The break fires AFTER inserting when size > max_num_tracks, so we
-  // may get max_num_tracks + 1. The key assertion: not all 10 are kept.
-  EXPECT_LE(static_cast<int>(selected.size()), options.max_num_tracks + 1);
-  EXPECT_LT(selected.size(), tracks_full.size());
 }
 
 }  // namespace

--- a/src/colmap/sfm/track_establishment_test.cc
+++ b/src/colmap/sfm/track_establishment_test.cc
@@ -224,8 +224,6 @@ TEST(FindTracksForProblem, LengthFilter) {
   }
 
   const auto reg_ids = MakeRegisteredImageIds(images);
-  const std::unordered_map<image_t, std::vector<double>> empty_depths;
-  const std::unordered_map<image_t, std::vector<bool>> empty_validity;
 
   // High-min variant: tracks have length 3, demand 10.
   {
@@ -233,7 +231,7 @@ TEST(FindTracksForProblem, LengthFilter) {
     options.min_num_views_per_track = 10;
     options.required_tracks_per_view = 1000;  // never saturate
     const auto selected = SubsampleTracks(
-        options, reg_ids, empty_depths, empty_validity, tracks_full);
+        options, reg_ids, tracks_full);
     EXPECT_EQ(selected.size(), 0u);
     EXPECT_TRUE(selected.empty());
   }
@@ -244,7 +242,7 @@ TEST(FindTracksForProblem, LengthFilter) {
     options.min_num_views_per_track = 2;
     options.required_tracks_per_view = 1000;
     const auto selected = SubsampleTracks(
-        options, reg_ids, empty_depths, empty_validity, tracks_full);
+        options, reg_ids, tracks_full);
     EXPECT_EQ(selected.size(), 5u);
   }
 }
@@ -266,15 +264,13 @@ TEST(FindTracksForProblem, MaxLengthFilter) {
   }
 
   const auto reg_ids = MakeRegisteredImageIds(images);
-  const std::unordered_map<image_t, std::vector<double>> empty_depths;
-  const std::unordered_map<image_t, std::vector<bool>> empty_validity;
 
   TrackSubsampleOptions options;
   options.min_num_views_per_track = 2;
   options.max_num_views_per_track = 4;
   options.required_tracks_per_view = 1000;
   const auto selected = SubsampleTracks(
-      options, reg_ids, empty_depths, empty_validity, tracks_full);
+      options, reg_ids, tracks_full);
   EXPECT_EQ(selected.size(), 0u);
   EXPECT_TRUE(selected.empty());
 }
@@ -297,14 +293,12 @@ TEST(FindTracksForProblem, GreedyQuota) {
   }
 
   const auto reg_ids = MakeRegisteredImageIds(images);
-  const std::unordered_map<image_t, std::vector<double>> empty_depths;
-  const std::unordered_map<image_t, std::vector<bool>> empty_validity;
 
   TrackSubsampleOptions options;
   options.min_num_views_per_track = 2;
   options.required_tracks_per_view = 2;
   const auto selected = SubsampleTracks(
-      options, reg_ids, empty_depths, empty_validity, tracks_full);
+      options, reg_ids, tracks_full);
   const size_t n_selected = selected.size();
 
   // Each track touches all 3 images so 2 tracks fully satisfy the per-view
@@ -328,14 +322,12 @@ TEST(FindTracksForProblem, MinTracksPerViewBugDocumentation) {
   }
 
   const auto reg_ids = MakeRegisteredImageIds(images);
-  const std::unordered_map<image_t, std::vector<double>> empty_depths;
-  const std::unordered_map<image_t, std::vector<bool>> empty_validity;
 
   TrackSubsampleOptions options;
   options.min_num_views_per_track = 2;
   // options.required_tracks_per_view stays at default = INT_MAX.
   const auto selected = SubsampleTracks(
-      options, reg_ids, empty_depths, empty_validity, tracks_full);
+      options, reg_ids, tracks_full);
   // All 3 tracks are kept — the quota gate is disabled by INT_MAX bar.
   EXPECT_EQ(selected.size(), 3u);
 }

--- a/src/colmap/sfm/track_establishment_test.cc
+++ b/src/colmap/sfm/track_establishment_test.cc
@@ -410,9 +410,8 @@ void AddLCOnlyPair(CorrespondenceGraph& corr_graph,
 }
 
 // Run the native + LC two-step end-to-end matching production code path:
-// MakeLoopClosureMatchPredicate suppresses LC-flagged observations from
-// union-find, then AppendLoopClosureObservations attaches them as
-// lc_elements.
+// MakeLoopClosureMatchPredicate suppresses LC-flagged pairwise matches from
+// union-find, then AppendLoopClosureObservations attaches them as lc_elements.
 std::unordered_map<point3D_t, Point3D> EstablishFullTracks(
     const CorrespondenceGraph& corr_graph,
     const std::unordered_map<image_t, std::vector<Eigen::Vector2d>>& keypoints,
@@ -628,6 +627,41 @@ TEST(ProcessLoopClosurePairs, SequentialIdsNoCollision) {
       EXPECT_GE(tid, 10u) << "minted id " << tid << " collided with native";
     }
   }
+}
+
+// A non-LC match that reuses an LC endpoint is still allowed in the first-pass
+// union-find. Only the exact LC-flagged pairwise constraint is suppressed.
+TEST(ProcessLoopClosurePairs, NonLcMatchSharingLcEndpointStillBuildsTrack) {
+  CorrespondenceGraph corr_graph;
+  for (image_t i = 1; i <= 3; ++i) corr_graph.AddImage(i, 1);
+
+  // img1:0 participates in an LC match with img2:0 and a non-LC match with
+  // img3:0. The latter must still create a regular img1-img3 track.
+  AddImagePairWithLC(corr_graph, 1, 2, {{0, 0}}, {0}, {0});
+  AddImagePairWithLC(corr_graph, 1, 3, {{0, 0}}, {0}, {});
+
+  const auto kps = MakeWellSeparatedKeypoints({1, 2, 3}, 1);
+  const auto pair_ids = CollectPairIds(corr_graph);
+  const auto ignore_match = MakeLoopClosureMatchPredicate(pair_ids, corr_graph);
+  EXPECT_TRUE(ignore_match(1, 0, 2, 0));
+  EXPECT_TRUE(ignore_match(2, 0, 1, 0));
+  EXPECT_FALSE(ignore_match(1, 0, 3, 0));
+  EXPECT_FALSE(ignore_match(3, 0, 1, 0));
+
+  TrackEstablishmentOptions opts;
+  opts.min_num_views_per_track = 1;
+  const auto tracks = EstablishFullTracks(corr_graph, kps, opts);
+
+  EXPECT_EQ(tracks.size(), 1u);
+  bool found_regular_track = false;
+  for (const auto& [tid, p3d] : tracks) {
+    if (TrackHasElement(p3d.track, 1, 0) &&
+        TrackHasElement(p3d.track, 3, 0)) {
+      found_regular_track = true;
+      EXPECT_TRUE(TrackHasLCElement(p3d.track, 2, 0));
+    }
+  }
+  EXPECT_TRUE(found_regular_track);
 }
 
 // Both LC endpoints fall on the SAME native track. This is a degenerate

--- a/src/colmap/sfm/track_establishment_test.cc
+++ b/src/colmap/sfm/track_establishment_test.cc
@@ -1,35 +1,8 @@
-// Copyright (c), ETH Zurich and UNC Chapel Hill.
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//     * Redistributions of source code must retain the above copyright
-//       notice, this list of conditions and the following disclaimer.
-//
-//     * Redistributions in binary form must reproduce the above copyright
-//       notice, this list of conditions and the following disclaimer in the
-//       documentation and/or other materials provided with the distribution.
-//
-//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
-//       its contributors may be used to endorse or promote products derived
-//       from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-
 #include "colmap/sfm/track_establishment.h"
 
+#include "colmap/feature/types.h"
 #include "colmap/scene/correspondence_graph.h"
+#include "colmap/scene/two_view_geometry.h"
 #include "colmap/scene/image.h"
 #include "colmap/scene/point3d.h"
 #include "colmap/util/types.h"
@@ -46,26 +19,21 @@
 namespace colmap {
 namespace {
 
-// Build an ImagePair entry directly into the corr_graph's image_pairs map
-// with the ``matches`` and ``inliers`` fields populated.
-// ``EstablishTracksFromCorrGraph`` only reads those two fields plus the pair
-// keys, so we bypass ``AddTwoViewGeometry`` and the colmap flat_corrs path.
+// Populate a correspondence graph via the proper AddTwoViewGeometry path so
+// that ExtractMatchesBetweenImages can find the correspondences.
 void AddImagePair(CorrespondenceGraph& corr_graph,
                   image_t image_id1,
                   image_t image_id2,
                   const std::vector<std::pair<int, int>>& matches,
                   const std::vector<int>& inliers) {
-  const image_pair_t pair_id = ImagePairToPairId(image_id1, image_id2);
-  CorrespondenceGraph::ImagePair image_pair(image_id1, image_id2);
-  Eigen::MatrixXi matches_mat(static_cast<int>(matches.size()), 2);
-  for (size_t i = 0; i < matches.size(); ++i) {
-    matches_mat(static_cast<int>(i), 0) = matches[i].first;
-    matches_mat(static_cast<int>(i), 1) = matches[i].second;
+  struct TwoViewGeometry tvg;
+  tvg.inlier_matches.reserve(inliers.size());
+  for (const int idx : inliers) {
+    tvg.inlier_matches.emplace_back(
+        static_cast<point2D_t>(matches[idx].first),
+        static_cast<point2D_t>(matches[idx].second));
   }
-  image_pair.matches = std::move(matches_mat);
-  image_pair.inliers = inliers;
-  image_pair.num_matches = static_cast<point2D_t>(inliers.size());
-  corr_graph.MutableImagePairs().emplace(pair_id, std::move(image_pair));
+  corr_graph.AddTwoViewGeometry(image_id1, image_id2, std::move(tvg));
 }
 
 // Build a map ``image_id -> [Vector2d(0,0), Vector2d(1,1), ...]`` so all
@@ -192,61 +160,6 @@ TEST(TrackEstablishment, IntraImageConsistencyDropsInconsistentTrack) {
 
   // The single track we constructed is inconsistent; nothing else exists.
   EXPECT_TRUE(tracks.empty());
-}
-
-// ``ignore_match`` returning true for any match touching image 1 strips
-// image 1's contribution from union-find. The remaining 5 tracks then have
-// length 2 (only images 2 and 3) so default min_views=3 drops them all;
-// loosening to min_views=2 surfaces them and asserts none of the kept tracks
-// reference image 1.
-TEST(TrackEstablishment, IgnoreMatchPredicateDropsImage) {
-  CorrespondenceGraph corr_graph;
-  corr_graph.AddImage(1, 5);
-  corr_graph.AddImage(2, 5);
-  corr_graph.AddImage(3, 5);
-
-  std::vector<std::pair<int, int>> matches;
-  std::vector<int> inliers;
-  for (int i = 0; i < 5; ++i) {
-    matches.emplace_back(i, i);
-    inliers.push_back(i);
-  }
-  AddImagePair(corr_graph, 1, 2, matches, inliers);
-  AddImagePair(corr_graph, 1, 3, matches, inliers);
-  AddImagePair(corr_graph, 2, 3, matches, inliers);
-
-  const auto keypoints = MakeWellSeparatedKeypoints({1, 2, 3}, 5);
-  const auto pair_ids = CollectPairIds(corr_graph);
-
-  const MatchPredicate ignore_image1 =
-      [](image_t i1, point2D_t /*p1*/, image_t i2, point2D_t /*p2*/) {
-        return i1 == 1 || i2 == 1;
-      };
-
-  // With min_views=3, dropping image 1 leaves only length-2 tracks across
-  // images 2-3, all filtered out.
-  {
-    TrackEstablishmentOptions options;  // default min_views=3
-    const auto tracks = EstablishTracksFromCorrGraph(
-        pair_ids, corr_graph, keypoints, options, ignore_image1);
-    EXPECT_TRUE(tracks.empty());
-  }
-
-  // With min_views=2 the surviving tracks become visible; verify image 1 is
-  // entirely absent.
-  {
-    TrackEstablishmentOptions options;
-    options.min_num_views_per_track = 2;
-    const auto tracks = EstablishTracksFromCorrGraph(
-        pair_ids, corr_graph, keypoints, options, ignore_image1);
-    EXPECT_EQ(tracks.size(), 5);
-    for (const auto& [pid, point3D] : tracks) {
-      EXPECT_EQ(point3D.track.Length(), 2);
-      for (const auto& el : point3D.track.Elements()) {
-        EXPECT_NE(el.image_id, 1u);
-      }
-    }
-  }
 }
 
 // Empty ``valid_pair_ids`` yields no tracks and no crash.
@@ -431,14 +344,9 @@ TEST(FindTracksForProblem, MinTracksPerViewBugDocumentation) {
 // ProcessLoopClosurePairs (second pass over LC-marked inlier matches)
 // ============================================================================
 //
-// These tests now drive the two-step ``EstablishTracksFromCorrGraph`` (with
-// ``MakeLoopClosureMatchPredicate`` filtering LC matches out of the union-
-// find pass) followed by ``AppendLoopClosureObservations`` (which adds LC
-// observations as parallel ``Track::lc_elements``). Setup:
-//   * Regular matches (``are_lc[idx]=false``) drive native track construction.
-//   * LC matches (``are_lc[idx]=true``) are skipped by
-//     ``MakeLoopClosureMatchPredicate`` and consumed by
-//     ``AppendLoopClosureObservations``.
+// Two-step: ``EstablishTracksFromCorrGraph`` builds native tracks from all
+// correspondences in the CG; ``AppendLoopClosureObservations`` then reads
+// ``ImagePair.are_lc`` to attach LC observations as ``Track::lc_elements``.
 // The post-condition tracks dict is what we assert on.
 
 // Variant of ``AddImagePair`` that also populates ``are_lc``. Each
@@ -494,10 +402,8 @@ std::unordered_map<point3D_t, Point3D> EstablishFullTracks(
     const std::unordered_map<image_t, std::vector<Eigen::Vector2d>>& keypoints,
     const TrackEstablishmentOptions& options) {
   const auto pair_ids = CollectPairIds(corr_graph);
-  const auto ignore_lc =
-      MakeLoopClosureMatchPredicate(pair_ids, corr_graph);
-  auto tracks = EstablishTracksFromCorrGraph(
-      pair_ids, corr_graph, keypoints, options, ignore_lc);
+  auto tracks =
+      EstablishTracksFromCorrGraph(pair_ids, corr_graph, keypoints, options);
   AppendLoopClosureObservations(pair_ids, corr_graph, tracks);
   return tracks;
 }

--- a/src/colmap/sfm/view_graph_manipulation.cc
+++ b/src/colmap/sfm/view_graph_manipulation.cc
@@ -117,7 +117,7 @@ void DecomposeRelPose(CorrespondenceGraph& view_graph,
         return;
       }
       // (Already filtered to prior-calibrated pairs above, so the
-      // early-return-without-prior-focal path never fires.)
+      // early-return-without-prior-focal branch never fires.)
 
       // Normalize translation to unit norm when non-zero.
       auto& tvg = image_pair.two_view_geometry;

--- a/src/colmap/sfm/view_graph_manipulation.cc
+++ b/src/colmap/sfm/view_graph_manipulation.cc
@@ -116,8 +116,8 @@ void DecomposeRelPose(CorrespondenceGraph& view_graph,
         image_pair.two_view_geometry.config = TwoViewGeometry::CALIBRATED;
         return;
       }
-      // (Already filtered to prior-calibrated pairs above, so the second
-      // glomap branch — the early-return-without-prior-focal — never fires.)
+      // (Already filtered to prior-calibrated pairs above, so the
+      // early-return-without-prior-focal path never fires.)
 
       // Normalize translation to unit norm when non-zero.
       auto& tvg = image_pair.two_view_geometry;

--- a/src/colmap/sfm/view_graph_manipulation.cc
+++ b/src/colmap/sfm/view_graph_manipulation.cc
@@ -57,9 +57,13 @@ void UpdateImagePairsConfig(CorrespondenceGraph& view_graph,
     const camera_t cid2 = rec.Image(image_pair.image_id2).CameraId();
     if (!camera_validity[cid1] || !camera_validity[cid2]) continue;
 
+    // Skip pairs whose decomposition never yielded a relative pose (e.g.
+    // F-only path or RANSAC failure). Without cam2_from_cam1 we cannot
+    // recompute F from intrinsics; leaving the pair UNCALIBRATED lets
+    // downstream filters drop it instead of crashing here.
+    if (!tvg.cam2_from_cam1.has_value()) continue;
+
     tvg.config = TwoViewGeometry::CALIBRATED;
-    THROW_CHECK(tvg.cam2_from_cam1.has_value())
-        << "UNCALIBRATED pair upgraded to CALIBRATED must have cam2_from_cam1";
     const Camera& c1 = rec.Camera(cid1);
     const Camera& c2 = rec.Camera(cid2);
     tvg.F = FundamentalFromEssentialMatrix(
@@ -112,8 +116,8 @@ void DecomposeRelPose(CorrespondenceGraph& view_graph,
         image_pair.two_view_geometry.config = TwoViewGeometry::CALIBRATED;
         return;
       }
-      // (Already filtered to prior-calibrated pairs above, so the
-      // early-return-without-prior-focal branch never fires.)
+      // (Already filtered to prior-calibrated pairs above, so the second
+      // glomap branch — the early-return-without-prior-focal — never fires.)
 
       // Normalize translation to unit norm when non-zero.
       auto& tvg = image_pair.two_view_geometry;

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -134,13 +134,10 @@ void BindGlobalPositioner(py::module& m) {
               &GlobalPositionerOptions::random_init_scale,
               "Cube size for random init of camera centers / points (linear).");
 
-  // LC per-bucket loss configs. ``LossConfig`` carries
-  // (type=LossFunctionType enum, scale, weight). Defaults give
-  // unweighted TrivialLoss — equivalent to no override.
-  PyGlobalPositionerOptions
-      .def_readwrite("loss_lc_geometry",
-                     &GlobalPositionerOptions::loss_lc_geometry)
-      .def_readwrite("loss_lc_depth", &GlobalPositionerOptions::loss_lc_depth);
+  // LC geometry loss config. ``LossConfig`` carries
+  // (type=LossFunctionType enum, scale, weight).
+  PyGlobalPositionerOptions.def_readwrite(
+      "loss_lc_geometry", &GlobalPositionerOptions::loss_lc_geometry);
 
   MakeDataclass(PyGlobalPositionerOptions);
 

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -54,10 +54,9 @@ void BindGlobalPositioner(py::module& m) {
           .def_readwrite("random_seed",
                          &GlobalPositionerOptions::random_seed,
                          "PRNG seed for random initialization. Default -1 "
-                         "(non-deterministic random_device, matches upstream "
-                         "colmap4). When -1 the ctor honors a GP_SEED env "
-                         "var as a documented escape for byte-identity "
-                         "recipes; set explicitly (>=0) to override.")
+                         "(non-deterministic random_device). When -1 the "
+                         "ctor honors a GP_SEED env var for deterministic "
+                         "reproducibility; set explicitly (>=0) to override.")
           .def_readwrite("loss",
                          &GlobalPositionerOptions::loss,
                          "Top-level robust loss applied to the BATA "
@@ -350,8 +349,8 @@ void BindRotationEstimator(py::module& m) {
               "(degrees).")
           // --- Video / loop-closure extensions ---
           .def_readwrite(
-              "skip_risky_LC_pairs",
-              &RotationEstimatorOptions::skip_risky_LC_pairs,
+              "skip_risky_lc_pairs",
+              &RotationEstimatorOptions::skip_risky_lc_pairs,
               "Drop pairs whose LC inliers exceed non-LC inliers.")
           .def_readwrite(
               "use_video_constraints",
@@ -412,7 +411,7 @@ void BindRotationEstimator(py::module& m) {
       "Returns True if rotation averaging succeeded. When "
       "``extract_final_weights=True``, returns ``{success, final_weights}`` "
       "dict instead. ``correspondence_graph`` is required when "
-      "``options.skip_risky_LC_pairs=True`` so the LC-majority filter can "
+      "``options.skip_risky_lc_pairs=True`` so the LC-majority filter can "
       "read ImagePair.{inliers, are_lc} (PoseGraph::Edge does not carry "
       "them).");
 }

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -4,8 +4,6 @@
 
 #include "pycolmap/helpers.h"
 
-#include <cmath>
-
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -118,12 +116,6 @@ void BindGlobalPositioner(py::module& m) {
               },
               "Ceres solver parameter tolerance.")
           // Optional extensions (default OFF — vanilla call = vanilla GP).
-          .def_readwrite(
-              "use_metric_depth_constraint",
-              &GlobalPositionerOptions::use_metric_depth_constraint,
-              "If true, each observation contributes a 1-D MetricDepthError "
-              "residual on top of the BATA direction residual. Requires "
-              "image.depth_prior_validity[idx] populated.")
           .def_readwrite("use_init",
                          &GlobalPositionerOptions::use_init,
                          "If true, skip random init for both camera centers "
@@ -136,91 +128,15 @@ void BindGlobalPositioner(py::module& m) {
           .def_readwrite(
               "random_init_scale",
               &GlobalPositionerOptions::random_init_scale,
-              "Cube size for random init of camera centers / points (linear).")
-          .def_readwrite(
-              "use_log_scale_for_depth_map_scales",
-              &GlobalPositionerOptions::use_log_scale_for_depth_map_scales,
-              "If true, dmap_scales_ are log-space and use exp() in "
-              "MetricDepthError.")
-          .def_readwrite(
-              "use_log_residual_for_depth",
-              &GlobalPositionerOptions::use_log_residual_for_depth,
-              "If true, use log-space residual in MetricDepthError for "
-              "points in front of camera.")
-          .def_readwrite(
-              "zero_residual_behind",
-              &GlobalPositionerOptions::zero_residual_behind,
-              "If true, set MetricDepthError residual to 0 for points "
-              "behind camera.")
-          .def_readwrite(
-              "smooth_log_linear_transition",
-              &GlobalPositionerOptions::smooth_log_linear_transition,
-              "If true, C1-blend log<->linear residual at threshold "
-              "(use_log_residual_for_depth=true only).")
-          .def_readwrite(
-              "log_linear_threshold",
-              &GlobalPositionerOptions::log_linear_threshold,
-              "z-depth threshold for smooth_log_linear_transition.")
-          .def_readwrite(
-              "scale_prior_stddev",
-              &GlobalPositionerOptions::scale_prior_stddev,
-              "Per-image scale-prior stddev (linear or log).")
-          .def_readwrite(
-              "filter_depth_outliers",
-              &GlobalPositionerOptions::filter_depth_outliers,
-              "If true, run pre-Solve 3-sigma log-space depth-outlier "
-              "filter.")
-          .def_property(
-              "initial_dmap_scales",
-              [](const GlobalPositionerOptions& self) -> py::object {
-                if (!self.initial_dmap_scales.has_value()) {
-                  return py::none();
-                }
-                py::dict d;
-                for (const auto& [image_id, scale] :
-                     *self.initial_dmap_scales) {
-                  d[py::cast(image_id)] = scale;
-                }
-                return d;
-              },
-              [](GlobalPositionerOptions& self, py::object value) {
-                if (value.is_none()) {
-                  self.initial_dmap_scales.reset();
-                  return;
-                }
-                std::unordered_map<image_t, double> map;
-                for (auto item : py::cast<py::dict>(value)) {
-                  map[py::cast<image_t>(item.first)] =
-                      py::cast<double>(item.second);
-                }
-                self.initial_dmap_scales = std::move(map);
-              },
-              "Caller-supplied {image_id: linear_scale} seed for dmap_scales_ "
-              "(GP1 -> GP2 handoff). None = use defaults.");
+              "Cube size for random init of camera centers / points (linear).");
 
-  // 10 per-bucket loss configs. ``LossConfig`` carries
+  // LC per-bucket loss configs. ``LossConfig`` carries
   // (type=LossFunctionType enum, scale, weight). Defaults give
   // unweighted TrivialLoss — equivalent to no override.
   PyGlobalPositionerOptions
-      .def_readwrite("loss_normal_geometry",
-                     &GlobalPositionerOptions::loss_normal_geometry)
-      .def_readwrite("loss_normal_depth",
-                     &GlobalPositionerOptions::loss_normal_depth)
       .def_readwrite("loss_lc_geometry",
                      &GlobalPositionerOptions::loss_lc_geometry)
-      .def_readwrite("loss_lc_depth", &GlobalPositionerOptions::loss_lc_depth)
-      .def_readwrite("loss_normal_geometry_inlier",
-                     &GlobalPositionerOptions::loss_normal_geometry_inlier)
-      .def_readwrite("loss_normal_depth_inlier",
-                     &GlobalPositionerOptions::loss_normal_depth_inlier)
-      .def_readwrite("loss_normal_depth_outlier",
-                     &GlobalPositionerOptions::loss_normal_depth_outlier)
-      .def_readwrite("loss_normal_geometry_trackstart",
-                     &GlobalPositionerOptions::loss_normal_geometry_trackstart)
-      .def_readwrite("loss_normal_depth_trackstart",
-                     &GlobalPositionerOptions::loss_normal_depth_trackstart)
-      .def_readwrite("loss_scale_prior",
-                     &GlobalPositionerOptions::loss_scale_prior);
+      .def_readwrite("loss_lc_depth", &GlobalPositionerOptions::loss_lc_depth);
 
   MakeDataclass(PyGlobalPositionerOptions);
 
@@ -235,26 +151,14 @@ void BindGlobalPositioner(py::module& m) {
           py::gil_scoped_release release;
           success = positioner.Solve(pose_graph, reconstruction);
         }
-        // Convert dmap_scales_ to linear-space dict for return.
-        py::dict dmap_scale_map;
-        for (const auto& [image_id, scale] : positioner.GetDmapScales()) {
-          const double linear = options.use_log_scale_for_depth_map_scales
-                                    ? std::exp(scale)
-                                    : scale;
-          dmap_scale_map[py::cast(image_id)] = linear;
-        }
-        py::dict result;
-        result["success"] = success;
-        result["dmap_scale_map"] = dmap_scale_map;
-        return result;
+        return success;
       },
       "options"_a,
       "pose_graph"_a,
       "reconstruction"_a,
       "Solve global positioning using point-to-camera constraints. Returns "
-      "a dict {'success': bool, 'dmap_scale_map': Dict[image_id, float]}. "
-      "``reconstruction`` is mutated in place with the optimized poses + "
-      "track xyz.");
+      "True on success. ``reconstruction`` is mutated in place with the "
+      "optimized poses + track xyz.");
 }
 
 void BindGravityRefiner(py::module& m) {
@@ -375,9 +279,7 @@ void BindRotationEstimator(py::module& m) {
          PoseGraph& pose_graph,
          Reconstruction& reconstruction,
          const std::vector<PosePrior>& pose_priors,
-         const CorrespondenceGraph* correspondence_graph,
-         bool extract_final_weights) {
-        std::unordered_map<image_pair_t, double> final_weights;
+         const CorrespondenceGraph* correspondence_graph) {
         bool success = false;
         {
           py::gil_scoped_release release;
@@ -386,31 +288,19 @@ void BindRotationEstimator(py::module& m) {
               pose_graph,
               reconstruction,
               pose_priors,
-              extract_final_weights ? &final_weights : nullptr,
+              nullptr,
               correspondence_graph);
         }
-        if (!extract_final_weights) {
-          return py::cast(success);
-        }
-        py::dict result;
-        result["success"] = success;
-        py::dict weights_map;
-        for (const auto& [pair_id, weight] : final_weights) {
-          weights_map[py::cast(pair_id)] = weight;
-        }
-        result["final_weights"] = weights_map;
-        return py::cast<py::object>(result);
+        return py::cast(success);
       },
       "options"_a,
       "pose_graph"_a,
       "reconstruction"_a,
       "pose_priors"_a,
       "correspondence_graph"_a = nullptr,
-      "extract_final_weights"_a = false,
       "High-level rotation averaging solver that handles rig expansion. "
-      "Returns True if rotation averaging succeeded. When "
-      "``extract_final_weights=True``, returns ``{success, final_weights}`` "
-      "dict instead. ``correspondence_graph`` is required when "
+      "Returns True if rotation averaging succeeded. "
+      "``correspondence_graph`` is required when "
       "``options.skip_risky_lc_pairs=True`` so the LC-majority filter can "
       "read ImagePair.{inliers, are_lc} (PoseGraph::Edge does not carry "
       "them).");

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -16,9 +16,7 @@ namespace py = pybind11;
 
 void BindGlobalPositioner(py::module& m) {
   // ``LossConfig`` is bound by ``BindBundleAdjuster`` (estimators/
-  // bundle_adjustment.cc), which runs earlier in ``BindEstimators``;
-  // ``GlobalPositionerOptions::main_loss`` and the per-bucket configs
-  // below reference that already-registered class.
+  // bundle_adjustment.cc), which runs earlier in ``BindEstimators``.
   auto PyGlobalPositionerOptions =
       py::classh<GlobalPositionerOptions>(m, "GlobalPositionerOptions")
           .def(py::init<>())

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -70,6 +70,11 @@ void BindGlobalPositioner(py::module& m) {
               "Apply 0.5x ScaledLoss to BATA residuals from cameras whose "
               "focal length lacks an EXIF prior. Default true. Set false "
               "to disable the downweight.")
+          .def_readwrite(
+              "uncalibrated_loss_downweight",
+              &GlobalPositionerOptions::uncalibrated_loss_downweight,
+              "Scale factor applied to the loss of uncalibrated cameras when "
+              "apply_uncalibrated_loss_downweight is true. Default 0.5.")
           .def_property(
               "num_threads",
               [](const GlobalPositionerOptions& self) {

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -4,6 +4,8 @@
 
 #include "pycolmap/helpers.h"
 
+#include <cmath>
+
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -13,6 +15,10 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 void BindGlobalPositioner(py::module& m) {
+  // ``LossConfig`` is bound by ``BindBundleAdjuster`` (estimators/
+  // bundle_adjustment.cc), which runs earlier in ``BindEstimators``;
+  // ``GlobalPositionerOptions::main_loss`` and the per-bucket configs
+  // below reference that already-registered class.
   auto PyGlobalPositionerOptions =
       py::classh<GlobalPositionerOptions>(m, "GlobalPositionerOptions")
           .def(py::init<>())
@@ -49,13 +55,17 @@ void BindGlobalPositioner(py::module& m) {
                          "Minimum number of views per track.")
           .def_readwrite("random_seed",
                          &GlobalPositionerOptions::random_seed,
-                         "PRNG seed for random initialization. -1 for "
-                         "non-deterministic.")
+                         "PRNG seed for random initialization. Default -1 "
+                         "(non-deterministic random_device, matches upstream "
+                         "colmap4). When -1 the ctor honors a GP_SEED env "
+                         "var as a documented escape for byte-identity "
+                         "recipes; set explicitly (>=0) to override.")
           .def_readwrite("loss",
                          &GlobalPositionerOptions::loss,
                          "Top-level robust loss applied to the BATA "
                          "direction residual (LossConfig: type, scale, "
-                         "weight). Default HUBER@0.1.")
+                         "weight). Default HUBER@0.1 — was hardcoded in "
+                         "upstream colmap GP.")
           .def_readwrite("use_parameter_block_ordering",
                          &GlobalPositionerOptions::use_parameter_block_ordering,
                          "Whether to use custom parameter block ordering.")
@@ -65,15 +75,6 @@ void BindGlobalPositioner(py::module& m) {
               "Apply 0.5x ScaledLoss to BATA residuals from cameras whose "
               "focal length lacks an EXIF prior. Default true. Set false "
               "to disable the downweight.")
-          .def_readwrite("use_init",
-                         &GlobalPositionerOptions::use_init,
-                         "If true, skip random init for both camera centers "
-                         "and track xyz.")
-          .def_readwrite(
-              "random_init_scale",
-              &GlobalPositionerOptions::random_init_scale,
-              "Cube size for random init of camera centers / points (linear).")
-          // Pass-through to ceres::Solver::Options sub-fields.
           .def_property(
               "num_threads",
               [](const GlobalPositionerOptions& self) {
@@ -118,7 +119,112 @@ void BindGlobalPositioner(py::module& m) {
               [](GlobalPositionerOptions& self, double v) {
                 self.solver_options.parameter_tolerance = v;
               },
-              "Ceres solver parameter tolerance.");
+              "Ceres solver parameter tolerance.")
+          // Optional extensions (default OFF — vanilla call = vanilla GP).
+          .def_readwrite(
+              "use_metric_depth_constraint",
+              &GlobalPositionerOptions::use_metric_depth_constraint,
+              "If true, each observation contributes a 1-D MetricDepthError "
+              "residual on top of the BATA direction residual. Requires "
+              "image.depth_prior_validity[idx] populated.")
+          .def_readwrite("use_init",
+                         &GlobalPositionerOptions::use_init,
+                         "If true, skip random init for both camera centers "
+                         "and track xyz.")
+          .def_readwrite(
+              "use_lc_observations",
+              &GlobalPositionerOptions::use_lc_observations,
+              "If true, AddPoint3DToProblem also iterates "
+              "track.lc_elements (loop-closure observations).")
+          .def_readwrite(
+              "random_init_scale",
+              &GlobalPositionerOptions::random_init_scale,
+              "Cube size for random init of camera centers / points (linear).")
+          .def_readwrite(
+              "use_log_scale_for_depth_map_scales",
+              &GlobalPositionerOptions::use_log_scale_for_depth_map_scales,
+              "If true, dmap_scales_ are log-space and use exp() in "
+              "MetricDepthError.")
+          .def_readwrite(
+              "use_log_residual_for_depth",
+              &GlobalPositionerOptions::use_log_residual_for_depth,
+              "If true, use log-space residual in MetricDepthError for "
+              "points in front of camera.")
+          .def_readwrite(
+              "zero_residual_behind",
+              &GlobalPositionerOptions::zero_residual_behind,
+              "If true, set MetricDepthError residual to 0 for points "
+              "behind camera.")
+          .def_readwrite(
+              "smooth_log_linear_transition",
+              &GlobalPositionerOptions::smooth_log_linear_transition,
+              "If true, C1-blend log<->linear residual at threshold "
+              "(use_log_residual_for_depth=true only).")
+          .def_readwrite(
+              "log_linear_threshold",
+              &GlobalPositionerOptions::log_linear_threshold,
+              "z-depth threshold for smooth_log_linear_transition.")
+          .def_readwrite(
+              "scale_prior_stddev",
+              &GlobalPositionerOptions::scale_prior_stddev,
+              "Per-image scale-prior stddev (linear or log).")
+          .def_readwrite(
+              "filter_depth_outliers",
+              &GlobalPositionerOptions::filter_depth_outliers,
+              "If true, run pre-Solve 3-sigma log-space depth-outlier "
+              "filter.")
+          .def_property(
+              "initial_dmap_scales",
+              [](const GlobalPositionerOptions& self) -> py::object {
+                if (!self.initial_dmap_scales.has_value()) {
+                  return py::none();
+                }
+                py::dict d;
+                for (const auto& [image_id, scale] :
+                     *self.initial_dmap_scales) {
+                  d[py::cast(image_id)] = scale;
+                }
+                return d;
+              },
+              [](GlobalPositionerOptions& self, py::object value) {
+                if (value.is_none()) {
+                  self.initial_dmap_scales.reset();
+                  return;
+                }
+                std::unordered_map<image_t, double> map;
+                for (auto item : py::cast<py::dict>(value)) {
+                  map[py::cast<image_t>(item.first)] =
+                      py::cast<double>(item.second);
+                }
+                self.initial_dmap_scales = std::move(map);
+              },
+              "Caller-supplied {image_id: linear_scale} seed for dmap_scales_ "
+              "(GP1 -> GP2 handoff). None = use defaults.");
+
+  // 10 per-bucket loss configs. ``LossConfig`` carries
+  // (type=LossFunctionType enum, scale, weight). Defaults give
+  // unweighted TrivialLoss — equivalent to no override.
+  PyGlobalPositionerOptions
+      .def_readwrite("loss_normal_geometry",
+                     &GlobalPositionerOptions::loss_normal_geometry)
+      .def_readwrite("loss_normal_depth",
+                     &GlobalPositionerOptions::loss_normal_depth)
+      .def_readwrite("loss_lc_geometry",
+                     &GlobalPositionerOptions::loss_lc_geometry)
+      .def_readwrite("loss_lc_depth", &GlobalPositionerOptions::loss_lc_depth)
+      .def_readwrite("loss_normal_geometry_inlier",
+                     &GlobalPositionerOptions::loss_normal_geometry_inlier)
+      .def_readwrite("loss_normal_depth_inlier",
+                     &GlobalPositionerOptions::loss_normal_depth_inlier)
+      .def_readwrite("loss_normal_depth_outlier",
+                     &GlobalPositionerOptions::loss_normal_depth_outlier)
+      .def_readwrite("loss_normal_geometry_trackstart",
+                     &GlobalPositionerOptions::loss_normal_geometry_trackstart)
+      .def_readwrite("loss_normal_depth_trackstart",
+                     &GlobalPositionerOptions::loss_normal_depth_trackstart)
+      .def_readwrite("loss_scale_prior",
+                     &GlobalPositionerOptions::loss_scale_prior);
+
   MakeDataclass(PyGlobalPositionerOptions);
 
   m.def(
@@ -126,16 +232,32 @@ void BindGlobalPositioner(py::module& m) {
       [](const GlobalPositionerOptions& options,
          const PoseGraph& pose_graph,
          Reconstruction& reconstruction) {
-        py::gil_scoped_release release;
-        bool success =
-            RunGlobalPositioning(options, pose_graph, reconstruction);
-        return success;
+        GlobalPositioner positioner(options);
+        bool success = false;
+        {
+          py::gil_scoped_release release;
+          success = positioner.Solve(pose_graph, reconstruction);
+        }
+        // Convert dmap_scales_ to linear-space dict for return.
+        py::dict dmap_scale_map;
+        for (const auto& [image_id, scale] : positioner.GetDmapScales()) {
+          const double linear = options.use_log_scale_for_depth_map_scales
+                                    ? std::exp(scale)
+                                    : scale;
+          dmap_scale_map[py::cast(image_id)] = linear;
+        }
+        py::dict result;
+        result["success"] = success;
+        result["dmap_scale_map"] = dmap_scale_map;
+        return result;
       },
       "options"_a,
       "pose_graph"_a,
       "reconstruction"_a,
       "Solve global positioning using point-to-camera constraints. Returns "
-      "True if optimization succeeded.");
+      "a dict {'success': bool, 'dmap_scale_map': Dict[image_id, float]}. "
+      "``reconstruction`` is mutated in place with the optimized poses + "
+      "track xyz.");
 }
 
 void BindGravityRefiner(py::module& m) {
@@ -227,7 +349,27 @@ void BindRotationEstimator(py::module& m) {
               "max_rotation_error_deg",
               &RotationEstimatorOptions::max_rotation_error_deg,
               "Filter pairs with rotation error exceeding this threshold "
-              "(degrees).");
+              "(degrees).")
+          // --- Video / loop-closure extensions ---
+          .def_readwrite(
+              "skip_risky_LC_pairs",
+              &RotationEstimatorOptions::skip_risky_LC_pairs,
+              "Drop pairs whose LC inliers exceed non-LC inliers.")
+          .def_readwrite(
+              "use_video_constraints",
+              &RotationEstimatorOptions::use_video_constraints,
+              "Use Ceres video-aware solver with differential loss "
+              "functions. Mutually exclusive with use_gravity. Also gates "
+              "the LC-penalty branch in the MST initializer.")
+          .def_readwrite(
+              "video_tracking_huber_scale",
+              &RotationEstimatorOptions::video_tracking_huber_scale,
+              "Huber loss scale for tracking pairs in the video solver.")
+          .def_readwrite(
+              "video_lc_cauchy_scale",
+              &RotationEstimatorOptions::video_lc_cauchy_scale,
+              "Cauchy loss scale for loop-closure pairs in the video "
+              "solver.");
   MakeDataclass(PyRotationEstimatorOptions);
 
   m.def(
@@ -235,17 +377,46 @@ void BindRotationEstimator(py::module& m) {
       [](const RotationEstimatorOptions& options,
          PoseGraph& pose_graph,
          Reconstruction& reconstruction,
-         const std::vector<PosePrior>& pose_priors) {
-        py::gil_scoped_release release;
-        return RunRotationAveraging(
-            options, pose_graph, reconstruction, pose_priors);
+         const std::vector<PosePrior>& pose_priors,
+         const CorrespondenceGraph* correspondence_graph,
+         bool extract_final_weights) {
+        std::unordered_map<image_pair_t, double> final_weights;
+        bool success = false;
+        {
+          py::gil_scoped_release release;
+          success = RunRotationAveraging(
+              options,
+              pose_graph,
+              reconstruction,
+              pose_priors,
+              extract_final_weights ? &final_weights : nullptr,
+              correspondence_graph);
+        }
+        if (!extract_final_weights) {
+          return py::cast(success);
+        }
+        py::dict result;
+        result["success"] = success;
+        py::dict weights_map;
+        for (const auto& [pair_id, weight] : final_weights) {
+          weights_map[py::cast(pair_id)] = weight;
+        }
+        result["final_weights"] = weights_map;
+        return py::cast<py::object>(result);
       },
       "options"_a,
       "pose_graph"_a,
       "reconstruction"_a,
       "pose_priors"_a,
+      "correspondence_graph"_a = nullptr,
+      "extract_final_weights"_a = false,
       "High-level rotation averaging solver that handles rig expansion. "
-      "Returns True if rotation averaging succeeded.");
+      "Returns True if rotation averaging succeeded. When "
+      "``extract_final_weights=True``, returns ``{success, final_weights}`` "
+      "dict instead. ``correspondence_graph`` is required when "
+      "``options.skip_risky_LC_pairs=True`` so the LC-majority filter can "
+      "read ImagePair.{inliers, are_lc} (PoseGraph::Edge does not carry "
+      "them).");
 }
 
 void BindMotionAveraging(py::module& m) {

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -190,6 +190,14 @@ void BindSfM(py::module& m) {
                            &Opts::track_required_tracks_per_view)
             .def_readwrite("track_min_num_views_per_track",
                            &Opts::track_min_num_views_per_track)
+            .def_readwrite("track_max_num_views_per_track",
+                           &Opts::track_max_num_views_per_track)
+            .def_readwrite("track_max_num_tracks",
+                           &Opts::track_max_num_tracks)
+            .def_readwrite("track_lc_second_pass",
+                           &Opts::track_lc_second_pass)
+            .def_readwrite("track_two_view_depth_gate",
+                           &Opts::track_two_view_depth_gate)
             .def_readwrite("max_angular_reproj_error_deg",
                            &Opts::max_angular_reproj_error_deg)
             .def_readwrite("max_normalized_reproj_error",

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -190,12 +190,7 @@ void BindSfM(py::module& m) {
                            &Opts::track_required_tracks_per_view)
             .def_readwrite("track_min_num_views_per_track",
                            &Opts::track_min_num_views_per_track)
-            .def_readwrite("track_max_num_views_per_track",
-                           &Opts::track_max_num_views_per_track)
-            .def_readwrite("track_max_num_tracks",
-                           &Opts::track_max_num_tracks)
-            .def_readwrite("track_lc_second_pass",
-                           &Opts::track_lc_second_pass)
+            .def_readwrite("track_lc_second_pass", &Opts::track_lc_second_pass)
             .def_readwrite("max_angular_reproj_error_deg",
                            &Opts::max_angular_reproj_error_deg)
             .def_readwrite("max_normalized_reproj_error",

--- a/src/pycolmap/pipeline/sfm.cc
+++ b/src/pycolmap/pipeline/sfm.cc
@@ -196,8 +196,6 @@ void BindSfM(py::module& m) {
                            &Opts::track_max_num_tracks)
             .def_readwrite("track_lc_second_pass",
                            &Opts::track_lc_second_pass)
-            .def_readwrite("track_two_view_depth_gate",
-                           &Opts::track_two_view_depth_gate)
             .def_readwrite("max_angular_reproj_error_deg",
                            &Opts::max_angular_reproj_error_deg)
             .def_readwrite("max_normalized_reproj_error",

--- a/src/pycolmap/scene/correspondence_graph.cc
+++ b/src/pycolmap/scene/correspondence_graph.cc
@@ -13,9 +13,61 @@
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>
 
+#include <utility>
+
 using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
+
+namespace {
+
+using ImagePair = CorrespondenceGraph::ImagePair;
+
+const Eigen::MatrixXi& ImagePairMatches(const ImagePair& image_pair) {
+  return image_pair.matches;
+}
+
+const std::vector<int>& ImagePairInliers(const ImagePair& image_pair) {
+  return image_pair.inliers;
+}
+
+const std::vector<bool>& ImagePairLoopClosureFlags(
+    const ImagePair& image_pair) {
+  return image_pair.are_lc;
+}
+
+void CheckMatches(const Eigen::MatrixXi& matches) {
+  THROW_CHECK_EQ(matches.cols(), 2);
+  for (Eigen::Index row = 0; row < matches.rows(); ++row) {
+    THROW_CHECK_GE(matches(row, 0), 0);
+    THROW_CHECK_GE(matches(row, 1), 0);
+  }
+}
+
+void SetImagePairMatches(ImagePair& image_pair, Eigen::MatrixXi matches) {
+  CheckMatches(matches);
+  image_pair.matches = std::move(matches);
+  image_pair.num_matches = static_cast<point2D_t>(image_pair.matches.rows());
+  image_pair.inliers.clear();
+  image_pair.are_lc.assign(image_pair.matches.rows(), false);
+}
+
+void SetImagePairInliers(ImagePair& image_pair, std::vector<int> inliers) {
+  for (const int idx : inliers) {
+    THROW_CHECK_GE(idx, 0);
+    THROW_CHECK_LT(idx, image_pair.matches.rows());
+  }
+  image_pair.inliers = std::move(inliers);
+}
+
+void SetImagePairLoopClosureFlags(ImagePair& image_pair,
+                                  std::vector<bool> are_lc) {
+  THROW_CHECK_EQ(are_lc.size(),
+                 static_cast<size_t>(image_pair.matches.rows()));
+  image_pair.are_lc = std::move(are_lc);
+}
+
+}  // namespace
 
 void BindCorrespondenceGraph(py::module& m) {
   py::classh<CorrespondenceGraph::Correspondence> PyCorrespondence(
@@ -53,41 +105,13 @@ void BindCorrespondenceGraph(py::module& m) {
       .def_readwrite("pair_id", &CorrespondenceGraph::ImagePair::pair_id)
       .def_readwrite("is_valid", &CorrespondenceGraph::ImagePair::is_valid)
       .def_readwrite("weight", &CorrespondenceGraph::ImagePair::weight)
-      .def_property(
-          "matches",
-          [](const CorrespondenceGraph::ImagePair& p)
-              -> const Eigen::MatrixXi& { return p.matches; },
-          [](CorrespondenceGraph::ImagePair& p, Eigen::MatrixXi v) {
-            THROW_CHECK_EQ(v.cols(), 2);
-            for (Eigen::Index row = 0; row < v.rows(); ++row) {
-              THROW_CHECK_GE(v(row, 0), 0);
-              THROW_CHECK_GE(v(row, 1), 0);
-            }
-            p.matches = std::move(v);
-            p.num_matches = static_cast<point2D_t>(p.matches.rows());
-            p.inliers.clear();
-            p.are_lc.assign(p.matches.rows(), false);
-          })
-      .def_property(
-          "inliers",
-          [](const CorrespondenceGraph::ImagePair& p)
-              -> const std::vector<int>& { return p.inliers; },
-          [](CorrespondenceGraph::ImagePair& p, std::vector<int> v) {
-            for (const int idx : v) {
-              THROW_CHECK_GE(idx, 0);
-              THROW_CHECK_LT(idx, p.matches.rows());
-            }
-            p.inliers = std::move(v);
-          })
+      .def_property("matches", &ImagePairMatches, &SetImagePairMatches)
+      .def_property("inliers", &ImagePairInliers, &SetImagePairInliers)
       .def_readwrite("cov_t", &CorrespondenceGraph::ImagePair::cov_t)
       .def_property(
           "are_lc",
-          [](const CorrespondenceGraph::ImagePair& p)
-              -> const std::vector<bool>& { return p.are_lc; },
-          [](CorrespondenceGraph::ImagePair& p, std::vector<bool> v) {
-            THROW_CHECK_EQ(v.size(), static_cast<size_t>(p.matches.rows()));
-            p.are_lc = std::move(v);
-          })
+          &ImagePairLoopClosureFlags,
+          &SetImagePairLoopClosureFlags)
       .def_readwrite("num_matches",
                      &CorrespondenceGraph::ImagePair::num_matches)
       .def_readwrite("two_view_geometry",

--- a/src/pycolmap/scene/correspondence_graph.cc
+++ b/src/pycolmap/scene/correspondence_graph.cc
@@ -46,17 +46,46 @@ void BindCorrespondenceGraph(py::module& m) {
   py::classh<CorrespondenceGraph::ImagePair> PyImagePair(m, "ImagePair");
   PyImagePair.def(py::init<>())
       .def(py::init<image_t, image_t>(), "image_id1"_a, "image_id2"_a)
-      .def_readwrite("image_id1",
-                     &CorrespondenceGraph::ImagePair::image_id1)
-      .def_readwrite("image_id2",
-                     &CorrespondenceGraph::ImagePair::image_id2)
+      .def_readwrite("image_id1", &CorrespondenceGraph::ImagePair::image_id1)
+      .def_readwrite("image_id2", &CorrespondenceGraph::ImagePair::image_id2)
       .def_readwrite("pair_id", &CorrespondenceGraph::ImagePair::pair_id)
       .def_readwrite("is_valid", &CorrespondenceGraph::ImagePair::is_valid)
       .def_readwrite("weight", &CorrespondenceGraph::ImagePair::weight)
-      .def_readwrite("matches", &CorrespondenceGraph::ImagePair::matches)
-      .def_readwrite("inliers", &CorrespondenceGraph::ImagePair::inliers)
+      .def_property(
+          "matches",
+          [](const CorrespondenceGraph::ImagePair& p)
+              -> const Eigen::MatrixXi& { return p.matches; },
+          [](CorrespondenceGraph::ImagePair& p, Eigen::MatrixXi v) {
+            THROW_CHECK_EQ(v.cols(), 2);
+            for (Eigen::Index row = 0; row < v.rows(); ++row) {
+              THROW_CHECK_GE(v(row, 0), 0);
+              THROW_CHECK_GE(v(row, 1), 0);
+            }
+            p.matches = std::move(v);
+            p.num_matches = static_cast<point2D_t>(p.matches.rows());
+            p.inliers.clear();
+            p.are_lc.assign(p.matches.rows(), false);
+          })
+      .def_property(
+          "inliers",
+          [](const CorrespondenceGraph::ImagePair& p)
+              -> const std::vector<int>& { return p.inliers; },
+          [](CorrespondenceGraph::ImagePair& p, std::vector<int> v) {
+            for (const int idx : v) {
+              THROW_CHECK_GE(idx, 0);
+              THROW_CHECK_LT(idx, p.matches.rows());
+            }
+            p.inliers = std::move(v);
+          })
       .def_readwrite("cov_t", &CorrespondenceGraph::ImagePair::cov_t)
-      .def_readwrite("are_lc", &CorrespondenceGraph::ImagePair::are_lc)
+      .def_property(
+          "are_lc",
+          [](const CorrespondenceGraph::ImagePair& p)
+              -> const std::vector<bool>& { return p.are_lc; },
+          [](CorrespondenceGraph::ImagePair& p, std::vector<bool> v) {
+            THROW_CHECK_EQ(v.size(), static_cast<size_t>(p.matches.rows()));
+            p.are_lc = std::move(v);
+          })
       .def_readwrite("num_matches",
                      &CorrespondenceGraph::ImagePair::num_matches)
       .def_readwrite("two_view_geometry",

--- a/src/pycolmap/scene/correspondence_graph.cc
+++ b/src/pycolmap/scene/correspondence_graph.cc
@@ -55,7 +55,9 @@ void BindCorrespondenceGraph(py::module& m) {
       .def_readwrite("weight", &CorrespondenceGraph::ImagePair::weight)
       .def_readwrite("matches", &CorrespondenceGraph::ImagePair::matches)
       .def_readwrite("inliers", &CorrespondenceGraph::ImagePair::inliers)
+      .def_readwrite("is_LC", &CorrespondenceGraph::ImagePair::is_LC)
       .def_readwrite("cov_t", &CorrespondenceGraph::ImagePair::cov_t)
+      .def_readwrite("are_lc", &CorrespondenceGraph::ImagePair::are_lc)
       .def_readwrite("num_matches",
                      &CorrespondenceGraph::ImagePair::num_matches)
       .def_readwrite("two_view_geometry",

--- a/src/pycolmap/scene/correspondence_graph.cc
+++ b/src/pycolmap/scene/correspondence_graph.cc
@@ -55,7 +55,6 @@ void BindCorrespondenceGraph(py::module& m) {
       .def_readwrite("weight", &CorrespondenceGraph::ImagePair::weight)
       .def_readwrite("matches", &CorrespondenceGraph::ImagePair::matches)
       .def_readwrite("inliers", &CorrespondenceGraph::ImagePair::inliers)
-      .def_readwrite("is_LC", &CorrespondenceGraph::ImagePair::is_LC)
       .def_readwrite("cov_t", &CorrespondenceGraph::ImagePair::cov_t)
       .def_readwrite("are_lc", &CorrespondenceGraph::ImagePair::are_lc)
       .def_readwrite("num_matches",

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -152,6 +152,8 @@ void BindSceneImage(py::module& m) {
            &Image::HasPixelCovariances,
            "Check if pixel covariances are set and match points2D count.")
       .def_readwrite("angular_stddevs", &Image::angular_stddevs)
+      // FORK-REMOVAL TODO — `features` / `features_undist` are fork-only
+      // fields. See `.claude/notes/glomap_audit/fork_removal_todo.md`.
       .def_readwrite("features", &Image::features)
       .def_readwrite("features_undist", &Image::features_undist)
       .def(

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -153,8 +153,6 @@ void BindSceneImage(py::module& m) {
            "Check if pixel covariances are set and match points2D count.")
       .def_readwrite("angular_stddevs", &Image::angular_stddevs)
       .def_readwrite("is_registered", &Image::is_registered)
-      // FORK-REMOVAL TODO — `features` / `features_undist` are fork-only
-      // fields. See `.claude/notes/glomap_audit/fork_removal_todo.md`.
       .def_readwrite("features", &Image::features)
       .def_readwrite("features_undist", &Image::features_undist)
       .def(

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -152,7 +152,6 @@ void BindSceneImage(py::module& m) {
            &Image::HasPixelCovariances,
            "Check if pixel covariances are set and match points2D count.")
       .def_readwrite("angular_stddevs", &Image::angular_stddevs)
-      .def_readwrite("is_registered", &Image::is_registered)
       .def_readwrite("features", &Image::features)
       .def_readwrite("features_undist", &Image::features_undist)
       .def(

--- a/src/pycolmap/scene/image.cc
+++ b/src/pycolmap/scene/image.cc
@@ -152,6 +152,7 @@ void BindSceneImage(py::module& m) {
            &Image::HasPixelCovariances,
            "Check if pixel covariances are set and match points2D count.")
       .def_readwrite("angular_stddevs", &Image::angular_stddevs)
+      .def_readwrite("is_registered", &Image::is_registered)
       // FORK-REMOVAL TODO — `features` / `features_undist` are fork-only
       // fields. See `.claude/notes/glomap_audit/fork_removal_todo.md`.
       .def_readwrite("features", &Image::features)

--- a/src/pycolmap/scene/track.cc
+++ b/src/pycolmap/scene/track.cc
@@ -72,6 +72,7 @@ void BindTrack(py::module& m) {
            &Track::Reserve,
            "num_elements"_a,
            "Reserve capacity for elements.")
-      .def("compress", &Track::Compress, "Shrink capacity to fit size.");
+      .def("compress", &Track::Compress, "Shrink capacity to fit size.")
+      .def_readwrite("lc_elements", &Track::lc_elements);
   MakeDataclass(PyTrack);
 }

--- a/src/pycolmap/sfm/bindings.cc
+++ b/src/pycolmap/sfm/bindings.cc
@@ -6,16 +6,16 @@ void BindObservationManager(py::module& m);
 void BindIncrementalTriangulator(py::module& m);
 void BindIncrementalMapper(py::module& m);
 void BindViewGraphManipulation(py::module& m);
-void BindTrackEstablishment(py::module& m);
-void BindImagePairInliers(py::module& m);
 void BindTrackFilter(py::module& m);
+void BindImagePairInliers(py::module& m);
+void BindTrackEstablishment(py::module& m);
 
 void BindSfm(py::module& m) {
   BindObservationManager(m);
   BindIncrementalTriangulator(m);
   BindIncrementalMapper(m);
   BindViewGraphManipulation(m);
-  BindTrackEstablishment(m);
-  BindImagePairInliers(m);
   BindTrackFilter(m);
+  BindImagePairInliers(m);
+  BindTrackEstablishment(m);
 }

--- a/src/pycolmap/sfm/bindings.cc
+++ b/src/pycolmap/sfm/bindings.cc
@@ -6,14 +6,16 @@ void BindObservationManager(py::module& m);
 void BindIncrementalTriangulator(py::module& m);
 void BindIncrementalMapper(py::module& m);
 void BindViewGraphManipulation(py::module& m);
-void BindTrackFilter(py::module& m);
+void BindTrackEstablishment(py::module& m);
 void BindImagePairInliers(py::module& m);
+void BindTrackFilter(py::module& m);
 
 void BindSfm(py::module& m) {
   BindObservationManager(m);
   BindIncrementalTriangulator(m);
   BindIncrementalMapper(m);
   BindViewGraphManipulation(m);
-  BindTrackFilter(m);
+  BindTrackEstablishment(m);
   BindImagePairInliers(m);
+  BindTrackFilter(m);
 }

--- a/src/pycolmap/sfm/track_establishment.cc
+++ b/src/pycolmap/sfm/track_establishment.cc
@@ -1,6 +1,5 @@
-// Pycolmap binding for the LC-aware track-establishment +
-// subsample free functions in
-// ``colmap/sfm/track_establishment.{h,cc}``.
+// Binding for EstablishTracksFromCorrGraph, AppendLoopClosureObservations,
+// and SubsampleTracks.
 
 #include "colmap/scene/correspondence_graph.h"
 #include "colmap/scene/image.h"

--- a/src/pycolmap/sfm/track_establishment.cc
+++ b/src/pycolmap/sfm/track_establishment.cc
@@ -84,11 +84,7 @@ py::dict RunFindTracksForProblem(py::dict images_py,
                                  const TrackSubsampleOptions& options) {
   std::unordered_set<image_t> registered_image_ids;
   for (auto item : images_py) {
-    const auto image_id = py::cast<image_t>(item.first);
-    const auto image = py::cast<Image>(item.second);
-    if (image.is_registered) {
-      registered_image_ids.insert(image_id);
-    }
+    registered_image_ids.insert(py::cast<image_t>(item.first));
   }
 
   std::unordered_map<point3D_t, Point3D> tracks_full;
@@ -157,5 +153,5 @@ void BindTrackEstablishment(py::module& m) {
         "tracks_full"_a,
         "options"_a,
         "Greedy length-sorted subsample of ``tracks_full``. Reads "
-        "``Image::is_registered`` from ``images``.");
+        "registered image ids from the keys of the filtered ``images`` dict.");
 }

--- a/src/pycolmap/sfm/track_establishment.cc
+++ b/src/pycolmap/sfm/track_establishment.cc
@@ -24,6 +24,19 @@ namespace py = pybind11;
 
 namespace {
 
+std::vector<image_pair_t> CollectValidPairIds(
+    CorrespondenceGraph& correspondence_graph) {
+  std::vector<image_pair_t> pair_ids;
+  pair_ids.reserve(correspondence_graph.NumImagePairs());
+  for (const auto& [pair_id, image_pair] :
+       correspondence_graph.MutableImagePairs()) {
+    if (image_pair.is_valid) {
+      pair_ids.push_back(pair_id);
+    }
+  }
+  return pair_ids;
+}
+
 py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
                                 py::dict images_py,
                                 const TrackEstablishmentOptions& options,
@@ -42,14 +55,8 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
     image_id_to_keypoints.emplace(image_id, image.features);
   }
 
-  std::vector<image_pair_t> valid_pair_ids;
-  valid_pair_ids.reserve(correspondence_graph.NumImagePairs());
-  for (const auto& [pair_id, image_pair] :
-       correspondence_graph.MutableImagePairs()) {
-    if (image_pair.is_valid) {
-      valid_pair_ids.push_back(pair_id);
-    }
-  }
+  const std::vector<image_pair_t> valid_pair_ids =
+      CollectValidPairIds(correspondence_graph);
 
   std::unordered_map<point3D_t, Point3D> tracks;
   {

--- a/src/pycolmap/sfm/track_establishment.cc
+++ b/src/pycolmap/sfm/track_establishment.cc
@@ -1,22 +1,23 @@
 // Binding for EstablishTracksFromCorrGraph, AppendLoopClosureObservations,
-// and SubsampleTracks.
+// and FilterTracksForProblem.
+
+#include "colmap/sfm/track_establishment.h"
 
 #include "colmap/scene/correspondence_graph.h"
 #include "colmap/scene/image.h"
 #include "colmap/scene/point3d.h"
 #include "colmap/scene/track.h"
-#include "colmap/sfm/track_establishment.h"
 #include "colmap/util/types.h"
 
 #include "pycolmap/helpers.h"
 
-#include <pybind11/eigen.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <limits>
 #include <unordered_map>
 #include <unordered_set>
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 using namespace colmap;
 using namespace pybind11::literals;
@@ -44,8 +45,7 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
   std::unordered_map<image_t, Image> images;
   images.reserve(images_py.size());
   for (auto item : images_py) {
-    images.emplace(py::cast<image_t>(item.first),
-                   py::cast<Image>(item.second));
+    images.emplace(py::cast<image_t>(item.first), py::cast<Image>(item.second));
   }
 
   std::unordered_map<image_t, std::vector<Eigen::Vector2d>>
@@ -64,8 +64,8 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
     MatchPredicate ignore_match;
     TrackEstablishmentOptions to = options;
     if (lc_second_pass) {
-      ignore_match = MakeLoopClosureMatchPredicate(
-          valid_pair_ids, correspondence_graph);
+      ignore_match =
+          MakeLoopClosureMatchPredicate(valid_pair_ids, correspondence_graph);
       to.required_tracks_per_view = std::numeric_limits<int>::max();
     }
     tracks = EstablishTracksFromCorrGraph(valid_pair_ids,
@@ -88,7 +88,7 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
 
 py::dict RunFindTracksForProblem(py::dict images_py,
                                  py::dict tracks_full_py,
-                                 const TrackSubsampleOptions& options) {
+                                 const TrackProblemFilterOptions& options) {
   std::unordered_set<image_t> registered_image_ids;
   for (auto item : images_py) {
     registered_image_ids.insert(py::cast<image_t>(item.first));
@@ -104,7 +104,8 @@ py::dict RunFindTracksForProblem(py::dict images_py,
   std::unordered_map<point3D_t, Point3D> selected;
   {
     py::gil_scoped_release release;
-    selected = SubsampleTracks(options, registered_image_ids, tracks_full);
+    selected =
+        FilterTracksForProblem(options, registered_image_ids, tracks_full);
   }
 
   py::dict tracks_out;
@@ -130,16 +131,12 @@ void BindTrackEstablishment(py::module& m) {
   MakeDataclass(PyEstOpts);
 
   auto PySubOpts =
-      py::classh<TrackSubsampleOptions>(m, "TrackSubsampleOptions")
+      py::classh<TrackProblemFilterOptions>(m, "TrackProblemFilterOptions")
           .def(py::init<>())
           .def_readwrite("min_num_views_per_track",
-                         &TrackSubsampleOptions::min_num_views_per_track)
+                         &TrackProblemFilterOptions::min_num_views_per_track)
           .def_readwrite("max_num_views_per_track",
-                         &TrackSubsampleOptions::max_num_views_per_track)
-          .def_readwrite("required_tracks_per_view",
-                         &TrackSubsampleOptions::required_tracks_per_view)
-          .def_readwrite("max_num_tracks",
-                         &TrackSubsampleOptions::max_num_tracks);
+                         &TrackProblemFilterOptions::max_num_views_per_track);
   MakeDataclass(PySubOpts);
 
   m.def("establish_full_tracks",
@@ -159,6 +156,6 @@ void BindTrackEstablishment(py::module& m) {
         "images"_a,
         "tracks_full"_a,
         "options"_a,
-        "Greedy length-sorted subsample of ``tracks_full``. Reads "
+        "Filter ``tracks_full`` for the optimization problem. Reads "
         "registered image ids from the keys of the filtered ``images`` dict.");
 }

--- a/src/pycolmap/sfm/track_establishment.cc
+++ b/src/pycolmap/sfm/track_establishment.cc
@@ -41,7 +41,8 @@ std::vector<image_pair_t> CollectValidPairIds(
 py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
                                 py::dict images_py,
                                 const TrackEstablishmentOptions& options,
-                                bool lc_second_pass) {
+                                bool lc_second_pass,
+                                CorrespondenceGraph* lc_correspondence_graph) {
   std::unordered_map<image_t, Image> images;
   images.reserve(images_py.size());
   for (auto item : images_py) {
@@ -61,12 +62,15 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
   std::unordered_map<point3D_t, Point3D> tracks;
   {
     py::gil_scoped_release release;
-    MatchPredicate ignore_match;
     TrackEstablishmentOptions to = options;
+    MatchPredicate ignore_match;
     if (lc_second_pass) {
-      ignore_match =
-          MakeLoopClosureMatchPredicate(valid_pair_ids, correspondence_graph);
       to.required_tracks_per_view = std::numeric_limits<int>::max();
+      CorrespondenceGraph& lc_cg = lc_correspondence_graph
+                                       ? *lc_correspondence_graph
+                                       : correspondence_graph;
+      const std::vector<image_pair_t> lc_pair_ids = CollectValidPairIds(lc_cg);
+      ignore_match = MakeLoopClosureMatchPredicate(lc_pair_ids, lc_cg);
     }
     tracks = EstablishTracksFromCorrGraph(valid_pair_ids,
                                           correspondence_graph,
@@ -74,8 +78,11 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
                                           to,
                                           ignore_match);
     if (lc_second_pass) {
-      AppendLoopClosureObservations(
-          valid_pair_ids, correspondence_graph, tracks);
+      CorrespondenceGraph& lc_cg = lc_correspondence_graph
+                                       ? *lc_correspondence_graph
+                                       : correspondence_graph;
+      const std::vector<image_pair_t> lc_pair_ids = CollectValidPairIds(lc_cg);
+      AppendLoopClosureObservations(lc_pair_ids, lc_cg, tracks);
     }
   }
 
@@ -145,11 +152,13 @@ void BindTrackEstablishment(py::module& m) {
         "images"_a,
         "options"_a,
         "lc_second_pass"_a = false,
+        "lc_correspondence_graph"_a = nullptr,
         "Build tracks from a CorrespondenceGraph + dict-of-images via "
         "the union-find helper. When ``lc_second_pass=True``, "
         "AppendLoopClosureObservations runs after to populate "
         "``Track::lc_elements`` from inliers flagged "
-        "``ImagePair::are_lc==true``.");
+        "``ImagePair::are_lc==true`` in ``lc_correspondence_graph`` "
+        "(falls back to ``correspondence_graph`` if not provided).");
 
   m.def("find_tracks_for_problem",
         &RunFindTracksForProblem,

--- a/src/pycolmap/sfm/track_establishment.cc
+++ b/src/pycolmap/sfm/track_establishment.cc
@@ -1,0 +1,172 @@
+// Pycolmap binding for the LC-aware track-establishment +
+// subsample free functions in
+// ``colmap/sfm/track_establishment.{h,cc}``.
+
+#include "colmap/scene/correspondence_graph.h"
+#include "colmap/scene/image.h"
+#include "colmap/scene/point3d.h"
+#include "colmap/scene/track.h"
+#include "colmap/sfm/track_establishment.h"
+#include "colmap/util/types.h"
+
+#include "pycolmap/helpers.h"
+
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+
+using namespace colmap;
+using namespace pybind11::literals;
+namespace py = pybind11;
+
+namespace {
+
+py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
+                                py::dict images_py,
+                                const TrackEstablishmentOptions& options,
+                                bool lc_second_pass) {
+  std::unordered_map<image_t, Image> images;
+  images.reserve(images_py.size());
+  for (auto item : images_py) {
+    images.emplace(py::cast<image_t>(item.first),
+                   py::cast<Image>(item.second));
+  }
+
+  std::unordered_map<image_t, std::vector<Eigen::Vector2d>>
+      image_id_to_keypoints;
+  image_id_to_keypoints.reserve(images.size());
+  for (const auto& [image_id, image] : images) {
+    image_id_to_keypoints.emplace(image_id, image.features);
+  }
+
+  std::vector<image_pair_t> valid_pair_ids;
+  valid_pair_ids.reserve(correspondence_graph.NumImagePairs());
+  for (const auto& [pair_id, image_pair] :
+       correspondence_graph.MutableImagePairs()) {
+    if (image_pair.is_valid) {
+      valid_pair_ids.push_back(pair_id);
+    }
+  }
+
+  std::unordered_map<point3D_t, Point3D> tracks;
+  {
+    py::gil_scoped_release release;
+    MatchPredicate ignore_match;
+    TrackEstablishmentOptions to = options;
+    if (lc_second_pass) {
+      ignore_match = MakeLoopClosureMatchPredicate(
+          valid_pair_ids, correspondence_graph);
+      to.required_tracks_per_view = std::numeric_limits<int>::max();
+    }
+    tracks = EstablishTracksFromCorrGraph(valid_pair_ids,
+                                          correspondence_graph,
+                                          image_id_to_keypoints,
+                                          to,
+                                          ignore_match);
+    if (lc_second_pass) {
+      AppendLoopClosureObservations(
+          valid_pair_ids, correspondence_graph, tracks);
+    }
+  }
+
+  py::dict tracks_out;
+  for (auto& [tid, p3d] : tracks) {
+    tracks_out[py::cast(tid)] = py::cast(std::move(p3d));
+  }
+  return tracks_out;
+}
+
+py::dict RunFindTracksForProblem(CorrespondenceGraph& /*correspondence_graph*/,
+                                 py::dict images_py,
+                                 py::dict tracks_full_py,
+                                 const TrackSubsampleOptions& options) {
+  std::unordered_set<image_t> registered_image_ids;
+  std::unordered_map<image_t, std::vector<double>> depth_priors;
+  std::unordered_map<image_t, std::vector<bool>> depth_prior_validity;
+  for (auto item : images_py) {
+    const auto image_id = py::cast<image_t>(item.first);
+    const auto image = py::cast<Image>(item.second);
+    if (image.is_registered) {
+      registered_image_ids.insert(image_id);
+    }
+  }
+
+  std::unordered_map<point3D_t, Point3D> tracks_full;
+  tracks_full.reserve(tracks_full_py.size());
+  for (auto item : tracks_full_py) {
+    tracks_full.emplace(py::cast<point3D_t>(item.first),
+                        py::cast<Point3D>(item.second));
+  }
+
+  std::unordered_map<point3D_t, Point3D> selected;
+  {
+    py::gil_scoped_release release;
+    selected = SubsampleTracks(options,
+                               registered_image_ids,
+                               depth_priors,
+                               depth_prior_validity,
+                               tracks_full);
+  }
+
+  py::dict tracks_out;
+  for (auto& [tid, p3d] : selected) {
+    tracks_out[py::cast(tid)] = py::cast(std::move(p3d));
+  }
+  return tracks_out;
+}
+
+}  // namespace
+
+void BindTrackEstablishment(py::module& m) {
+  auto PyEstOpts =
+      py::classh<TrackEstablishmentOptions>(m, "TrackEstablishmentOptions")
+          .def(py::init<>())
+          .def_readwrite(
+              "intra_image_consistency_threshold",
+              &TrackEstablishmentOptions::intra_image_consistency_threshold)
+          .def_readwrite("min_num_views_per_track",
+                         &TrackEstablishmentOptions::min_num_views_per_track)
+          .def_readwrite("required_tracks_per_view",
+                         &TrackEstablishmentOptions::required_tracks_per_view);
+  MakeDataclass(PyEstOpts);
+
+  auto PySubOpts =
+      py::classh<TrackSubsampleOptions>(m, "TrackSubsampleOptions")
+          .def(py::init<>())
+          .def_readwrite("min_num_views_per_track",
+                         &TrackSubsampleOptions::min_num_views_per_track)
+          .def_readwrite("max_num_views_per_track",
+                         &TrackSubsampleOptions::max_num_views_per_track)
+          .def_readwrite("required_tracks_per_view",
+                         &TrackSubsampleOptions::required_tracks_per_view)
+          .def_readwrite("max_num_tracks",
+                         &TrackSubsampleOptions::max_num_tracks)
+          .def_readwrite("two_view_depth_gate",
+                         &TrackSubsampleOptions::two_view_depth_gate);
+  MakeDataclass(PySubOpts);
+
+  m.def("establish_full_tracks",
+        &RunEstablishFullTracks,
+        "correspondence_graph"_a,
+        "images"_a,
+        "options"_a,
+        "lc_second_pass"_a = false,
+        "Build tracks from a CorrespondenceGraph + dict-of-images via "
+        "the union-find helper. When ``lc_second_pass=True``, "
+        "AppendLoopClosureObservations runs after to populate "
+        "``Track::lc_elements`` from inliers flagged "
+        "``ImagePair::are_lc==true``.");
+
+  m.def("find_tracks_for_problem",
+        &RunFindTracksForProblem,
+        "correspondence_graph"_a,
+        "images"_a,
+        "tracks_full"_a,
+        "options"_a,
+        "Greedy length-sorted subsample of ``tracks_full``. Reads "
+        "``Image::is_registered`` from ``images``.");
+}

--- a/src/pycolmap/sfm/track_establishment.cc
+++ b/src/pycolmap/sfm/track_establishment.cc
@@ -79,13 +79,10 @@ py::dict RunEstablishFullTracks(CorrespondenceGraph& correspondence_graph,
   return tracks_out;
 }
 
-py::dict RunFindTracksForProblem(CorrespondenceGraph& /*correspondence_graph*/,
-                                 py::dict images_py,
+py::dict RunFindTracksForProblem(py::dict images_py,
                                  py::dict tracks_full_py,
                                  const TrackSubsampleOptions& options) {
   std::unordered_set<image_t> registered_image_ids;
-  std::unordered_map<image_t, std::vector<double>> depth_priors;
-  std::unordered_map<image_t, std::vector<bool>> depth_prior_validity;
   for (auto item : images_py) {
     const auto image_id = py::cast<image_t>(item.first);
     const auto image = py::cast<Image>(item.second);
@@ -104,11 +101,7 @@ py::dict RunFindTracksForProblem(CorrespondenceGraph& /*correspondence_graph*/,
   std::unordered_map<point3D_t, Point3D> selected;
   {
     py::gil_scoped_release release;
-    selected = SubsampleTracks(options,
-                               registered_image_ids,
-                               depth_priors,
-                               depth_prior_validity,
-                               tracks_full);
+    selected = SubsampleTracks(options, registered_image_ids, tracks_full);
   }
 
   py::dict tracks_out;
@@ -143,9 +136,7 @@ void BindTrackEstablishment(py::module& m) {
           .def_readwrite("required_tracks_per_view",
                          &TrackSubsampleOptions::required_tracks_per_view)
           .def_readwrite("max_num_tracks",
-                         &TrackSubsampleOptions::max_num_tracks)
-          .def_readwrite("two_view_depth_gate",
-                         &TrackSubsampleOptions::two_view_depth_gate);
+                         &TrackSubsampleOptions::max_num_tracks);
   MakeDataclass(PySubOpts);
 
   m.def("establish_full_tracks",
@@ -162,7 +153,6 @@ void BindTrackEstablishment(py::module& m) {
 
   m.def("find_tracks_for_problem",
         &RunFindTracksForProblem,
-        "correspondence_graph"_a,
         "images"_a,
         "tracks_full"_a,
         "options"_a,


### PR DESCRIPTION
## Summary

LC/sequence extension slice on top of `move_upstream`. This PR lets colmap carry and use loop-closure observations without depending on the depth/runtime layer from `glomap-refactor-3`.

## Main changes

- Adds LC scene metadata: per-match `ImagePair::are_lc` and `Track::lc_elements` for LC observations.
- Makes `CorrespondenceGraph::AddTwoViewGeometry` preserve LC runtime metadata (`image_id1`, `image_id2`, `matches`, `inliers`, `are_lc`).
- Adds LC-aware rotation averaging hooks: video constraints, risky-LC-pair filtering, and tracking-prioritized MST behavior.
- Adds LC-aware global positioning hooks: LC observations, LC-aware frame-center handling, and configurable uncalibrated-loss downweighting.
- Adds LC track establishment with `EstablishFullTracks`, `AppendLoopClosureObservations`, `MakeLoopClosureMatchPredicate`, and optional separate LC correspondence graph input.
- Narrows problem filtering to `TrackProblemFilterOptions` / `FilterTracksForProblem`; depth gates and legacy max-track/per-view quotas are not part of this LC slice.
- Exposes the LC runtime APIs in pycolmap, including `establish_full_tracks(..., lc_correspondence_graph=...)`.

## Stack

- Base: #8, `move_upstream` -> `colmap4`
- This PR: `move_upstream_lc` -> `move_upstream`
- Top: #9, `glomap-refactor-3` -> `move_upstream_lc`

## Verification

Latest verified branch tip: `189c8ffd`.

- `build_cpp.sh` passed.
- `build_py.sh` passed.
- `scene/correspondence_graph_test` passed.
- `sfm/track_establishment_test` passed.
- `sfm/image_pair_inliers_test` passed.
- LC-only pycolmap smoke passed with a separate regular and LC correspondence graph, without depth fields.
