### PR TITLE
Add global positioning residual replay

### DIFF
--- a/python/pycolmap/__init__.py
+++ b/python/pycolmap/__init__.py
@@ -69,11 +69,21 @@ __all__ = import_module_symbols(
     globals(), _core, exclude={"cost_functions", "pyceres"}
 )
 
-from .global_positioning_trace import (  # noqa: E402,F401
+from .global_positioning_trace import (  # noqa: E402,F401,I001
+    GlobalPositioningParameterSnapshot as GlobalPositioningParameterSnapshot,
+    GlobalPositioningSnapshotArray as GlobalPositioningSnapshotArray,
     GlobalPositioningTrace as GlobalPositioningTrace,
 )
 
-__all__.extend(["__version__", "__ceres_version__", "GlobalPositioningTrace"])
+__all__.extend(
+    [
+        "__version__",
+        "__ceres_version__",
+        "GlobalPositioningParameterSnapshot",
+        "GlobalPositioningSnapshotArray",
+        "GlobalPositioningTrace",
+    ]
+)
 
 __version__ = _core.__version__ + "-zador"
 __ceres_version__ = _core.__ceres_version__

--- a/python/pycolmap/__init__.py
+++ b/python/pycolmap/__init__.py
@@ -51,11 +51,13 @@ try:
     from . import _core
 except ImportError as e:
     raise RuntimeError(
-        textwrap.dedent("""
+        textwrap.dedent(
+            """
         Cannot import the C++ backend pycolmap._core.
         Make sure that you successfully install the package with
           $ python -m pip install pycolmap/
-        """)
+        """
+        )
     ) from e
 
 # Type checkers cannot deal with dynamic manipulation of globals.
@@ -66,7 +68,12 @@ if TYPE_CHECKING:
 __all__ = import_module_symbols(
     globals(), _core, exclude={"cost_functions", "pyceres"}
 )
-__all__.extend(["__version__", "__ceres_version__"])
+
+from .global_positioning_trace import (  # noqa: E402,F401
+    GlobalPositioningTrace as GlobalPositioningTrace,
+)
+
+__all__.extend(["__version__", "__ceres_version__", "GlobalPositioningTrace"])
 
 __version__ = _core.__version__ + "-zador"
 __ceres_version__ = _core.__ceres_version__

--- a/python/pycolmap/__init__.py
+++ b/python/pycolmap/__init__.py
@@ -70,9 +70,16 @@ __all__ = import_module_symbols(
 )
 
 from .global_positioning_trace import (  # noqa: E402,F401,I001
-    GlobalPositioningParameterSnapshot as GlobalPositioningParameterSnapshot,
-    GlobalPositioningSnapshotArray as GlobalPositioningSnapshotArray,
-    GlobalPositioningTrace as GlobalPositioningTrace,
+    GlobalPositioningParameterSnapshot,
+    GlobalPositioningReplayEvaluation,
+    GlobalPositioningReplayJacobianBlock,
+    GlobalPositioningReplayResidualBlock,
+    GlobalPositioningResidualLedgerBlock,
+    GlobalPositioningResidualLedgerLoss,
+    GlobalPositioningResidualLedgerParameterBlock,
+    GlobalPositioningSnapshotArray,
+    GlobalPositioningTrace,
+    GlobalPositioningTraceReplay,
 )
 
 __all__.extend(
@@ -80,8 +87,15 @@ __all__.extend(
         "__version__",
         "__ceres_version__",
         "GlobalPositioningParameterSnapshot",
+        "GlobalPositioningReplayEvaluation",
+        "GlobalPositioningReplayJacobianBlock",
+        "GlobalPositioningReplayResidualBlock",
+        "GlobalPositioningResidualLedgerBlock",
+        "GlobalPositioningResidualLedgerLoss",
+        "GlobalPositioningResidualLedgerParameterBlock",
         "GlobalPositioningSnapshotArray",
         "GlobalPositioningTrace",
+        "GlobalPositioningTraceReplay",
     ]
 )
 

--- a/python/pycolmap/global_positioning_trace.py
+++ b/python/pycolmap/global_positioning_trace.py
@@ -141,30 +141,143 @@ def _require_nested_float_blocks(
     return nested_values
 
 
-def _artifact_path(
+def _require_shape(value: Any, label: str) -> tuple[int, ...]:
+    shape = tuple(_require_int_list(value, label))
+    if not shape:
+        raise ValueError(f"{label}: expected non-empty shape")
+    for idx, dim in enumerate(shape):
+        if dim < 0:
+            raise ValueError(f"{label}[{idx}]: expected non-negative dim")
+    return shape
+
+
+def _shape_element_count(shape: tuple[int, ...]) -> int:
+    count = 1
+    for dim in shape:
+        count *= dim
+    return count
+
+
+def _validate_trace_metadata(
+    metadata_path: Path,
+    metadata: dict[str, Any],
+    *,
+    expected_iteration: int | None = None,
+    expected_run_id: str | None = None,
+) -> int:
+    schema_version = _require_int(
+        _require_key(metadata, "schema_version", str(metadata_path)),
+        f"{metadata_path}: schema_version",
+    )
+    if schema_version != 1:
+        raise ValueError(
+            f"{metadata_path}: unsupported schema_version {schema_version}"
+        )
+
+    run_id = _require_str(
+        _require_key(metadata, "run_id", str(metadata_path)),
+        f"{metadata_path}: run_id",
+    )
+    if expected_run_id is not None and run_id != expected_run_id:
+        raise ValueError(
+            f"{metadata_path}: run_id {run_id!r}, expected {expected_run_id!r}"
+        )
+
+    iteration = _require_int(
+        _require_key(metadata, "iteration", str(metadata_path)),
+        f"{metadata_path}: iteration",
+    )
+    if iteration < 0:
+        raise ValueError(f"{metadata_path}: iteration must be non-negative")
+    if expected_iteration is not None and iteration != expected_iteration:
+        raise ValueError(
+            f"{metadata_path}: iteration {iteration}, "
+            f"expected {expected_iteration}"
+        )
+
+    dtype = _require_str(
+        _require_key(metadata, "dtype", str(metadata_path)),
+        f"{metadata_path}: dtype",
+    )
+    byte_order = _require_str(
+        _require_key(metadata, "byte_order", str(metadata_path)),
+        f"{metadata_path}: byte_order",
+    )
+    if dtype != "float64":
+        raise ValueError(f"{metadata_path}: dtype must be float64")
+    if byte_order != "little_endian":
+        raise ValueError(f"{metadata_path}: byte_order must be little_endian")
+    return iteration
+
+
+@dataclass(frozen=True)
+class _ResolvedFloat64Artifact:
+    path: Path
+    ids: tuple[int, ...] | None
+    shape: tuple[int, ...]
+    element_count: int
+
+
+def _artifact_metadata(
     metadata_path: Path,
     metadata: dict[str, Any],
     name: str,
-    expected_count: int,
-) -> Path:
+    *,
+    required: bool = True,
+) -> dict[str, Any] | None:
     artifacts = _require_key(metadata, "artifacts", str(metadata_path))
     if not isinstance(artifacts, dict):
         raise TypeError(f"{metadata_path}: artifacts must be a JSON object")
+    if not required and name not in artifacts:
+        return None
     artifact = _require_key(artifacts, name, f"{metadata_path}: artifacts")
     if not isinstance(artifact, dict):
         raise TypeError(
             f"{metadata_path}: artifacts.{name} must be a JSON object"
         )
+    return artifact
+
+
+def _resolve_float64_artifact(
+    metadata_path: Path,
+    metadata: dict[str, Any],
+    name: str,
+    *,
+    expected_shape: tuple[int, ...] | None = None,
+    expected_ids: tuple[int, ...] | None = None,
+    required: bool = True,
+) -> _ResolvedFloat64Artifact | None:
+    artifact = _artifact_metadata(
+        metadata_path, metadata, name, required=required
+    )
+    if artifact is None:
+        return None
 
     filename = _require_str(
         _require_key(artifact, "file", f"{metadata_path}: artifacts.{name}"),
-        "file",
+        f"{metadata_path}: artifacts.{name}.file",
     )
-    dtype = _require_key(
-        artifact, "dtype", f"{metadata_path}: artifacts.{name}"
+    relative_path = Path(filename)
+    if (
+        relative_path.is_absolute()
+        or relative_path.name != filename
+        or filename in {".", ".."}
+        or "/" in filename
+        or "\\" in filename
+    ):
+        raise ValueError(
+            f"{metadata_path}: artifacts.{name}.file must be a bare relative "
+            "filename"
+        )
+    dtype = _require_str(
+        _require_key(artifact, "dtype", f"{metadata_path}: artifacts.{name}"),
+        f"{metadata_path}: artifacts.{name}.dtype",
     )
-    byte_order = _require_key(
-        artifact, "byte_order", f"{metadata_path}: artifacts.{name}"
+    byte_order = _require_str(
+        _require_key(
+            artifact, "byte_order", f"{metadata_path}: artifacts.{name}"
+        ),
+        f"{metadata_path}: artifacts.{name}.byte_order",
     )
     if dtype != "float64":
         raise ValueError(
@@ -175,34 +288,79 @@ def _artifact_path(
             f"{metadata_path}: artifacts.{name}.byte_order must be "
             "little_endian"
         )
-    shape = _require_key(
-        artifact, "shape", f"{metadata_path}: artifacts.{name}"
+    shape = _require_shape(
+        _require_key(artifact, "shape", f"{metadata_path}: artifacts.{name}"),
+        f"{metadata_path}: artifacts.{name}.shape",
     )
-    if not isinstance(shape, list) or len(shape) != 1:
-        raise TypeError(
-            f"{metadata_path}: artifacts.{name}.shape must be [count]"
-        )
-    shape_count = _require_int(
-        shape[0], f"{metadata_path}: artifacts.{name}.shape[0]"
-    )
-    if shape_count != expected_count:
+    if expected_shape is not None and shape != expected_shape:
         raise ValueError(
-            f"{metadata_path}: artifacts.{name}.shape[0] is {shape_count}, "
-            f"expected {expected_count}"
+            f"{metadata_path}: artifacts.{name}.shape is {shape}, "
+            f"expected {expected_shape}"
         )
 
+    ids = None
+    if expected_ids is not None or "ids" in artifact:
+        ids = tuple(
+            _require_int_list(
+                _require_key(
+                    artifact, "ids", f"{metadata_path}: artifacts.{name}"
+                ),
+                f"{metadata_path}: artifacts.{name}.ids",
+            )
+        )
+        if expected_ids is not None and ids != expected_ids:
+            raise ValueError(
+                f"{metadata_path}: artifacts.{name}.ids does not match "
+                "top-level IDs"
+            )
+        if shape[0] != len(ids):
+            raise ValueError(
+                f"{metadata_path}: artifacts.{name}.shape has {shape[0]} "
+                f"rows, expected {len(ids)} artifact IDs"
+            )
+
+    element_count = _shape_element_count(shape)
     path = metadata_path.parent / filename
-    expected_size = expected_count * 8
+    expected_size = element_count * 8
     actual_size = path.stat().st_size
     if actual_size != expected_size:
         raise ValueError(
             f"{path}: byte size {actual_size}, expected {expected_size}"
         )
-    return path
+    return _ResolvedFloat64Artifact(path, ids, shape, element_count)
 
 
-def _memmap_float64(path: Path, count: int) -> np.memmap:
-    return np.memmap(path, dtype="<f8", mode="r", shape=(count,))
+def _memmap_float64(path: Path, shape: tuple[int, ...]) -> np.ndarray:
+    if _shape_element_count(shape) == 0:
+        return np.empty(shape, dtype=np.float64)
+    return np.memmap(path, dtype="<f8", mode="r", shape=shape)
+
+
+def _discover_iteration_metadata(directory: Path) -> dict[int, Path]:
+    metadata_by_iteration: dict[int, Path] = {}
+    if not directory.is_dir():
+        return metadata_by_iteration
+
+    for metadata_path in sorted(directory.glob("iter_*.json")):
+        metadata = _load_json(metadata_path)
+        iteration = _require_int(
+            _require_key(metadata, "iteration", str(metadata_path)),
+            f"{metadata_path}: iteration",
+        )
+        expected_name = f"iter_{iteration:06d}.json"
+        if metadata_path.name != expected_name:
+            raise ValueError(
+                f"{metadata_path}: filename does not match metadata "
+                f"iteration; expected {expected_name}"
+            )
+        if iteration in metadata_by_iteration:
+            previous = metadata_by_iteration[iteration]
+            raise ValueError(
+                f"Duplicate trace iteration {iteration}: "
+                f"{previous} and {metadata_path}"
+            )
+        metadata_by_iteration[iteration] = metadata_path
+    return metadata_by_iteration
 
 
 @dataclass(frozen=True)
@@ -221,6 +379,25 @@ class GlobalPositioningJacobianBlock:
     offset: int
     residual_dim: int
     values: np.ndarray
+
+
+@dataclass(frozen=True)
+class GlobalPositioningSnapshotArray:
+    ids: tuple[int, ...]
+    shape: tuple[int, ...]
+    values: np.ndarray
+
+
+@dataclass(frozen=True)
+class GlobalPositioningParameterSnapshot:
+    metadata_path: Path
+    metadata: dict[str, Any]
+    iteration: int
+    frame_centers: GlobalPositioningSnapshotArray
+    points3D: GlobalPositioningSnapshotArray
+    scales: GlobalPositioningSnapshotArray
+    dmap_scales: GlobalPositioningSnapshotArray | None = None
+    cams_in_rig: GlobalPositioningSnapshotArray | None = None
 
 
 class GlobalPositioningResidualBlock:
@@ -312,12 +489,21 @@ class GlobalPositioningResidualBlock:
 
 
 class GlobalPositioningResidualValues:
-    def __init__(self, metadata_path: Path):
+    def __init__(
+        self,
+        metadata_path: Path,
+        *,
+        expected_iteration: int | None = None,
+        expected_run_id: str | None = None,
+        expected_residual_ids: tuple[str, ...] | None = None,
+    ):
         self.metadata_path = Path(metadata_path)
         self.metadata = _load_json(self.metadata_path)
-        self.iteration = _require_int(
-            _require_key(self.metadata, "iteration", str(self.metadata_path)),
-            "iteration",
+        self.iteration = _validate_trace_metadata(
+            self.metadata_path,
+            self.metadata,
+            expected_iteration=expected_iteration,
+            expected_run_id=expected_run_id,
         )
         self.num_residual_blocks = _require_int(
             _require_key(
@@ -355,6 +541,15 @@ class GlobalPositioningResidualValues:
             ),
             "evaluation_success",
         )
+        self._validate_residual_structure()
+        if (
+            expected_residual_ids is not None
+            and tuple(self.residual_ids) != expected_residual_ids
+        ):
+            raise ValueError(
+                "residual_values.residual_ids does not match "
+                "residual_blocks.jsonl order"
+            )
         self.has_raw_jacobians = _require_bool(
             _require_key(
                 self.metadata, "has_raw_jacobians", str(self.metadata_path)
@@ -366,29 +561,35 @@ class GlobalPositioningResidualValues:
             for idx, residual_id in enumerate(self.residual_ids)
         }
 
-        self._raw_residuals_path = _artifact_path(
+        raw_residuals_artifact = _resolve_float64_artifact(
             self.metadata_path,
             self.metadata,
             "raw_residuals",
-            self.total_scalar_residuals,
+            expected_shape=(self.total_scalar_residuals,),
         )
-        self._raw_costs_path = _artifact_path(
+        raw_costs_artifact = _resolve_float64_artifact(
             self.metadata_path,
             self.metadata,
             "raw_costs",
-            self.num_residual_blocks,
+            expected_shape=(self.num_residual_blocks,),
         )
-        self._robust_costs_path = _artifact_path(
+        robust_costs_artifact = _resolve_float64_artifact(
             self.metadata_path,
             self.metadata,
             "robust_costs",
-            self.num_residual_blocks,
+            expected_shape=(self.num_residual_blocks,),
         )
+        assert raw_residuals_artifact is not None
+        assert raw_costs_artifact is not None
+        assert robust_costs_artifact is not None
+        self._raw_residuals_artifact = raw_residuals_artifact
+        self._raw_costs_artifact = raw_costs_artifact
+        self._robust_costs_artifact = robust_costs_artifact
 
         self.total_jacobian_scalars = 0
         self.parameter_blocks: list[list[GlobalPositioningParameterBlock]] = []
         self.raw_jacobian_offsets: list[list[int]] = []
-        self._raw_jacobians_path: Path | None = None
+        self._raw_jacobians_artifact: _ResolvedFloat64Artifact | None = None
         if self.has_raw_jacobians:
             self.total_jacobian_scalars = _require_int(
                 _require_key(
@@ -433,23 +634,181 @@ class GlobalPositioningResidualValues:
                 ),
                 "parameter_block_lower_bounds",
             )
+            self._validate_jacobian_contract()
             self.parameter_blocks = self._parse_parameter_blocks(
                 parameter_block_descriptors,
                 parameter_block_sizes,
                 parameter_block_is_constant,
                 parameter_block_lower_bounds,
             )
-            self._raw_jacobians_path = _artifact_path(
+            self._validate_jacobian_structure(
+                parameter_block_sizes,
+                self.raw_jacobian_offsets,
+                parameter_block_is_constant,
+                parameter_block_lower_bounds,
+                parameter_block_descriptors,
+            )
+            self._raw_jacobians_artifact = _resolve_float64_artifact(
                 self.metadata_path,
                 self.metadata,
                 "raw_jacobians",
-                self.total_jacobian_scalars,
+                expected_shape=(self.total_jacobian_scalars,),
+            )
+            assert self._raw_jacobians_artifact is not None
+
+        self._raw_residuals: np.ndarray | None = None
+        self._raw_costs: np.ndarray | None = None
+        self._robust_costs: np.ndarray | None = None
+        self._raw_jacobians: np.ndarray | None = None
+
+    def _validate_jacobian_contract(self) -> None:
+        raw_jacobian_layout = _require_str(
+            _require_key(
+                self.metadata,
+                "raw_jacobian_layout",
+                str(self.metadata_path),
+            ),
+            "raw_jacobian_layout",
+        )
+        if (
+            raw_jacobian_layout
+            != "residual_block_major/parameter_block_major/row_major"
+        ):
+            raise ValueError(
+                "raw_jacobian_layout must be "
+                "'residual_block_major/parameter_block_major/row_major'"
+            )
+        jacobian_domain = _require_str(
+            _require_key(
+                self.metadata, "jacobian_domain", str(self.metadata_path)
+            ),
+            "jacobian_domain",
+        )
+        if jacobian_domain != "raw_cost_function_ambient_parameters":
+            raise ValueError(
+                "jacobian_domain must be 'raw_cost_function_ambient_parameters'"
+            )
+        for field_name in [
+            "loss_applied_to_jacobians",
+            "manifold_applied_to_jacobians",
+            "constant_parameter_blocks_included",
+        ]:
+            _require_bool(
+                _require_key(
+                    self.metadata, field_name, str(self.metadata_path)
+                ),
+                field_name,
+            )
+        if self.metadata["loss_applied_to_jacobians"]:
+            raise ValueError("loss_applied_to_jacobians must be false")
+        if self.metadata["manifold_applied_to_jacobians"]:
+            raise ValueError("manifold_applied_to_jacobians must be false")
+        if not self.metadata["constant_parameter_blocks_included"]:
+            raise ValueError("constant_parameter_blocks_included must be true")
+
+    def _validate_residual_structure(self) -> None:
+        if self.num_residual_blocks < 0:
+            raise ValueError("num_residual_blocks must be non-negative")
+        if self.total_scalar_residuals < 0:
+            raise ValueError("total_scalar_residuals must be non-negative")
+        for name, values in [
+            ("residual_ids", self.residual_ids),
+            ("residual_dims", self.residual_dims),
+            ("residual_offsets", self.residual_offsets),
+            ("evaluation_success", self.evaluation_success),
+        ]:
+            if len(values) != self.num_residual_blocks:
+                raise ValueError(
+                    f"{name}: length {len(values)}, "
+                    f"expected {self.num_residual_blocks}"
+                )
+        if len(set(self.residual_ids)) != len(self.residual_ids):
+            raise ValueError("residual_ids must be unique")
+
+        expected_offset = 0
+        for residual_idx, (residual_dim, residual_offset) in enumerate(
+            zip(self.residual_dims, self.residual_offsets, strict=True)
+        ):
+            if residual_dim < 0:
+                raise ValueError(
+                    f"residual_dims[{residual_idx}] must be non-negative"
+                )
+            if residual_offset != expected_offset:
+                raise ValueError(
+                    f"residual_offsets[{residual_idx}] is {residual_offset}, "
+                    f"expected {expected_offset}"
+                )
+            expected_offset += residual_dim
+        if expected_offset != self.total_scalar_residuals:
+            raise ValueError(
+                f"sum(residual_dims) is {expected_offset}, "
+                f"expected total_scalar_residuals {self.total_scalar_residuals}"
             )
 
-        self._raw_residuals: np.memmap | None = None
-        self._raw_costs: np.memmap | None = None
-        self._robust_costs: np.memmap | None = None
-        self._raw_jacobians: np.memmap | None = None
+    def _validate_jacobian_structure(
+        self,
+        sizes: list[list[int]],
+        offsets: list[list[int]],
+        is_constant: list[list[bool]],
+        lower_bounds: list[list[list[float]]],
+        descriptors: Any,
+    ) -> None:
+        if self.total_jacobian_scalars < 0:
+            raise ValueError("total_jacobian_scalars must be non-negative")
+        if not isinstance(descriptors, list):
+            raise TypeError("parameter_blocks: expected list")
+        for name, values in [
+            ("parameter_block_sizes", sizes),
+            ("raw_jacobian_offsets", offsets),
+            ("parameter_block_is_constant", is_constant),
+            ("parameter_block_lower_bounds", lower_bounds),
+            ("parameter_blocks", descriptors),
+        ]:
+            if len(values) != self.num_residual_blocks:
+                raise ValueError(
+                    f"{name}: outer length {len(values)}, "
+                    f"expected {self.num_residual_blocks}"
+                )
+
+        expected_offset = 0
+        for residual_idx in range(self.num_residual_blocks):
+            block_count = len(sizes[residual_idx])
+            for name, values in [
+                ("raw_jacobian_offsets", offsets),
+                ("parameter_block_is_constant", is_constant),
+                ("parameter_block_lower_bounds", lower_bounds),
+                ("parameter_blocks", descriptors),
+            ]:
+                if len(values[residual_idx]) != block_count:
+                    raise ValueError(
+                        f"{name}[{residual_idx}]: length "
+                        f"{len(values[residual_idx])}, expected {block_count}"
+                    )
+            for block_idx, block_size in enumerate(sizes[residual_idx]):
+                if block_size <= 0:
+                    raise ValueError(
+                        f"parameter_block_sizes[{residual_idx}][{block_idx}] "
+                        "must be positive"
+                    )
+                if len(lower_bounds[residual_idx][block_idx]) != block_size:
+                    raise ValueError(
+                        f"parameter_block_lower_bounds[{residual_idx}]"
+                        f"[{block_idx}]: length "
+                        f"{len(lower_bounds[residual_idx][block_idx])}, "
+                        f"expected {block_size}"
+                    )
+                residual_offset = offsets[residual_idx][block_idx]
+                if residual_offset != expected_offset:
+                    raise ValueError(
+                        f"raw_jacobian_offsets[{residual_idx}][{block_idx}] "
+                        f"is {residual_offset}, expected {expected_offset}"
+                    )
+                expected_offset += self.residual_dims[residual_idx] * block_size
+        if expected_offset != self.total_jacobian_scalars:
+            raise ValueError(
+                f"raw Jacobian scalar count is {expected_offset}, "
+                f"expected total_jacobian_scalars {self.total_jacobian_scalars}"
+            )
 
     @staticmethod
     def _parse_parameter_blocks(
@@ -498,36 +857,40 @@ class GlobalPositioningResidualValues:
         return blocks
 
     @property
-    def raw_residuals(self) -> np.memmap:
+    def raw_residuals(self) -> np.ndarray:
         if self._raw_residuals is None:
             self._raw_residuals = _memmap_float64(
-                self._raw_residuals_path, self.total_scalar_residuals
+                self._raw_residuals_artifact.path,
+                self._raw_residuals_artifact.shape,
             )
         return self._raw_residuals
 
     @property
-    def raw_costs(self) -> np.memmap:
+    def raw_costs(self) -> np.ndarray:
         if self._raw_costs is None:
             self._raw_costs = _memmap_float64(
-                self._raw_costs_path, self.num_residual_blocks
+                self._raw_costs_artifact.path,
+                self._raw_costs_artifact.shape,
             )
         return self._raw_costs
 
     @property
-    def robust_costs(self) -> np.memmap:
+    def robust_costs(self) -> np.ndarray:
         if self._robust_costs is None:
             self._robust_costs = _memmap_float64(
-                self._robust_costs_path, self.num_residual_blocks
+                self._robust_costs_artifact.path,
+                self._robust_costs_artifact.shape,
             )
         return self._robust_costs
 
     @property
-    def raw_jacobians(self) -> np.memmap | None:
-        if self._raw_jacobians_path is None:
+    def raw_jacobians(self) -> np.ndarray | None:
+        if self._raw_jacobians_artifact is None:
             return None
         if self._raw_jacobians is None:
             self._raw_jacobians = _memmap_float64(
-                self._raw_jacobians_path, self.total_jacobian_scalars
+                self._raw_jacobians_artifact.path,
+                self._raw_jacobians_artifact.shape,
             )
         return self._raw_jacobians
 
@@ -539,6 +902,218 @@ class GlobalPositioningResidualValues:
         return GlobalPositioningResidualBlock(self, residual)
 
 
+def _require_top_level_ids_and_shape(
+    metadata_path: Path,
+    metadata: dict[str, Any],
+    ids_key: str,
+    shape_key: str,
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    ids = tuple(
+        _require_int_list(
+            _require_key(metadata, ids_key, str(metadata_path)),
+            f"{metadata_path}: {ids_key}",
+        )
+    )
+    shape = _require_shape(
+        _require_key(metadata, shape_key, str(metadata_path)),
+        f"{metadata_path}: {shape_key}",
+    )
+    if shape[0] != len(ids):
+        raise ValueError(
+            f"{metadata_path}: {shape_key} has {shape[0]} rows, "
+            f"expected {len(ids)} {ids_key}"
+        )
+    return ids, shape
+
+
+def _optional_top_level_ids_and_shape(
+    metadata_path: Path,
+    metadata: dict[str, Any],
+    ids_key: str,
+    shape_key: str,
+) -> tuple[tuple[int, ...], tuple[int, ...]] | None:
+    if ids_key not in metadata and shape_key not in metadata:
+        return None
+    return _require_top_level_ids_and_shape(
+        metadata_path, metadata, ids_key, shape_key
+    )
+
+
+def _normalize_max_points(max_points: int | None) -> int | None:
+    if max_points is None or max_points == -1:
+        return None
+    if not isinstance(max_points, int) or isinstance(max_points, bool):
+        raise TypeError(
+            f"max_points: expected int, None, or -1; "
+            f"got {type(max_points).__name__}"
+        )
+    if max_points < -1:
+        raise ValueError(f"max_points must be >= -1 or None, got {max_points}")
+    return max_points
+
+
+def _load_snapshot_array(
+    metadata_path: Path,
+    metadata: dict[str, Any],
+    name: str,
+    *,
+    expected_ids: tuple[int, ...] | None = None,
+    expected_shape: tuple[int, ...] | None = None,
+    max_rows: int | None = None,
+    required: bool = True,
+) -> GlobalPositioningSnapshotArray | None:
+    artifact = _resolve_float64_artifact(
+        metadata_path,
+        metadata,
+        name,
+        expected_shape=expected_shape,
+        expected_ids=expected_ids,
+        required=required,
+    )
+    if artifact is None:
+        return None
+
+    values = _memmap_float64(artifact.path, artifact.shape)
+    ids = artifact.ids if artifact.ids is not None else ()
+    shape = artifact.shape
+    if max_rows is not None:
+        row_count = min(max_rows, shape[0])
+        values = values[:row_count]
+        ids = ids[:row_count]
+        shape = (row_count, *shape[1:])
+
+    return GlobalPositioningSnapshotArray(ids=ids, shape=shape, values=values)
+
+
+def _empty_snapshot_array() -> GlobalPositioningSnapshotArray:
+    return GlobalPositioningSnapshotArray(
+        ids=(),
+        shape=(0,),
+        values=np.empty((0,), dtype=np.float64),
+    )
+
+
+class GlobalPositioningParameterSnapshotLoader:
+    def __init__(
+        self,
+        metadata_path: Path,
+        *,
+        expected_iteration: int | None = None,
+        expected_run_id: str | None = None,
+        max_points: int | None = None,
+    ):
+        self.metadata_path = Path(metadata_path)
+        self.metadata = _load_json(self.metadata_path)
+        self.iteration = _validate_trace_metadata(
+            self.metadata_path,
+            self.metadata,
+            expected_iteration=expected_iteration,
+            expected_run_id=expected_run_id,
+        )
+        self.max_points = _normalize_max_points(max_points)
+
+    def load(self) -> GlobalPositioningParameterSnapshot:
+        frame_ids, frame_centers_shape = _require_top_level_ids_and_shape(
+            self.metadata_path,
+            self.metadata,
+            "frame_ids",
+            "frame_centers_world_shape",
+        )
+        point3D_ids, points3D_shape = _require_top_level_ids_and_shape(
+            self.metadata_path,
+            self.metadata,
+            "point3D_ids",
+            "points3D_world_shape",
+        )
+        scales_expected = _optional_top_level_ids_and_shape(
+            self.metadata_path,
+            self.metadata,
+            "bata_scale_ids",
+            "bata_scales_shape",
+        )
+
+        dmap_expected = _optional_top_level_ids_and_shape(
+            self.metadata_path,
+            self.metadata,
+            "dmap_image_ids",
+            "dmap_scales_stored_shape",
+        )
+        artifacts = _require_key(
+            self.metadata, "artifacts", str(self.metadata_path)
+        )
+        if not isinstance(artifacts, dict):
+            raise TypeError(
+                f"{self.metadata_path}: artifacts must be a JSON object"
+            )
+        if dmap_expected is not None and "dmap_scales" not in artifacts:
+            dmap_ids, dmap_shape = dmap_expected
+            if dmap_ids or _shape_element_count(dmap_shape) != 0:
+                raise KeyError(
+                    f"{self.metadata_path}: artifacts missing optional "
+                    "dmap_scales despite non-empty top-level dmap metadata"
+                )
+
+        frame_centers = _load_snapshot_array(
+            self.metadata_path,
+            self.metadata,
+            "frame_centers",
+            expected_ids=frame_ids,
+            expected_shape=frame_centers_shape,
+        )
+        points3D = _load_snapshot_array(
+            self.metadata_path,
+            self.metadata,
+            "points3D",
+            expected_ids=point3D_ids,
+            expected_shape=points3D_shape,
+            max_rows=self.max_points,
+        )
+        scales = _empty_snapshot_array()
+        if scales_expected is not None:
+            scale_ids, scales_shape = scales_expected
+            loaded_scales = _load_snapshot_array(
+                self.metadata_path,
+                self.metadata,
+                "scales",
+                expected_ids=scale_ids,
+                expected_shape=scales_shape,
+            )
+            assert loaded_scales is not None
+            scales = loaded_scales
+        assert frame_centers is not None
+        assert points3D is not None
+
+        dmap_scales = None
+        if "dmap_scales" in artifacts:
+            dmap_ids, dmap_shape = dmap_expected or (None, None)
+            dmap_scales = _load_snapshot_array(
+                self.metadata_path,
+                self.metadata,
+                "dmap_scales",
+                expected_ids=dmap_ids,
+                expected_shape=dmap_shape,
+                required=False,
+            )
+
+        cams_in_rig = _load_snapshot_array(
+            self.metadata_path,
+            self.metadata,
+            "cams_in_rig",
+            required=False,
+        )
+
+        return GlobalPositioningParameterSnapshot(
+            metadata_path=self.metadata_path,
+            metadata=self.metadata,
+            iteration=self.iteration,
+            frame_centers=frame_centers,
+            points3D=points3D,
+            scales=scales,
+            dmap_scales=dmap_scales,
+            cams_in_rig=cams_in_rig,
+        )
+
+
 class GlobalPositioningTrace:
     def __init__(self, path: Path):
         self.path = Path(path)
@@ -547,18 +1122,12 @@ class GlobalPositioningTrace:
             "residual_blocks.jsonl"
         )
         self.residual_skips = self._read_optional_jsonl("residual_skips.jsonl")
-        self._residual_values_by_iteration: dict[int, Path] = {}
-        residual_values_dir = self.path / "residual_values"
-        if residual_values_dir.is_dir():
-            for metadata_path in sorted(
-                residual_values_dir.glob("iter_*.json")
-            ):
-                metadata = _load_json(metadata_path)
-                iteration = _require_int(
-                    _require_key(metadata, "iteration", str(metadata_path)),
-                    "iteration",
-                )
-                self._residual_values_by_iteration[iteration] = metadata_path
+        self._residual_values_by_iteration = _discover_iteration_metadata(
+            self.path / "residual_values"
+        )
+        self._snapshots_by_iteration = _discover_iteration_metadata(
+            self.path / "snapshots"
+        )
 
     @classmethod
     def load(cls, path: str | Path) -> GlobalPositioningTrace:
@@ -569,6 +1138,33 @@ class GlobalPositioningTrace:
         if not path.exists():
             return []
         return _iter_jsonl(path)
+
+    def _ledger_residual_ids(self) -> tuple[str, ...] | None:
+        if not self.residual_blocks:
+            return None
+        residual_ids = []
+        for idx, record in enumerate(self.residual_blocks):
+            attrs = _require_key(record, "attrs", f"residual_blocks[{idx}]")
+            if not isinstance(attrs, dict):
+                raise TypeError(
+                    f"residual_blocks[{idx}].attrs must be an object"
+                )
+            residual_ids.append(
+                _require_str(
+                    _require_key(
+                        attrs, "residual_id", f"residual_blocks[{idx}].attrs"
+                    ),
+                    f"residual_blocks[{idx}].attrs.residual_id",
+                )
+            )
+        return tuple(residual_ids)
+
+    def _manifest_run_id(self) -> str | None:
+        if "run_id" not in self.manifest:
+            return None
+        return _require_str(
+            self.manifest["run_id"], str(self.path / "manifest.json")
+        )
 
     @property
     def status(self) -> str:
@@ -592,6 +1188,10 @@ class GlobalPositioningTrace:
     def residual_value_iterations(self) -> tuple[int, ...]:
         return tuple(sorted(self._residual_values_by_iteration))
 
+    @property
+    def snapshot_iterations(self) -> tuple[int, ...]:
+        return tuple(sorted(self._snapshots_by_iteration))
+
     def residual_values(
         self, iteration: int | None = None
     ) -> GlobalPositioningResidualValues:
@@ -608,5 +1208,22 @@ class GlobalPositioningTrace:
                 f"Trace has no residual values for iteration {iteration}"
             )
         return GlobalPositioningResidualValues(
-            self._residual_values_by_iteration[iteration]
+            self._residual_values_by_iteration[iteration],
+            expected_iteration=iteration,
+            expected_run_id=self._manifest_run_id(),
+            expected_residual_ids=self._ledger_residual_ids(),
         )
+
+    def snapshot(
+        self, iteration: int, max_points: int | None = None
+    ) -> GlobalPositioningParameterSnapshot:
+        if iteration not in self._snapshots_by_iteration:
+            raise KeyError(
+                f"Trace has no parameter snapshot for iteration {iteration}"
+            )
+        return GlobalPositioningParameterSnapshotLoader(
+            self._snapshots_by_iteration[iteration],
+            expected_iteration=iteration,
+            expected_run_id=self._manifest_run_id(),
+            max_points=max_points,
+        ).load()

--- a/python/pycolmap/global_positioning_trace.py
+++ b/python/pycolmap/global_positioning_trace.py
@@ -1,0 +1,612 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return value
+
+
+def _iter_jsonl(path: Path) -> list[dict[str, Any]]:
+    records = []
+    with path.open("r", encoding="utf-8") as stream:
+        for line_number, line in enumerate(stream, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            value = json.loads(line)
+            if not isinstance(value, dict):
+                raise ValueError(
+                    f"{path}:{line_number}: expected a JSON object"
+                )
+            records.append(value)
+    return records
+
+
+def _require_key(mapping: dict[str, Any], key: str, label: str) -> Any:
+    if key not in mapping:
+        raise KeyError(f"{label}: missing key {key!r}")
+    return mapping[key]
+
+
+def _require_int(value: Any, label: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{label}: expected int, got {type(value).__name__}")
+    return value
+
+
+def _require_bool(value: Any, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{label}: expected bool, got {type(value).__name__}")
+    return value
+
+
+def _require_str(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise TypeError(f"{label}: expected non-empty string")
+    return value
+
+
+def _require_int_list(value: Any, label: str) -> list[int]:
+    if not isinstance(value, list):
+        raise TypeError(f"{label}: expected list")
+    return [
+        _require_int(item, f"{label}[{idx}]") for idx, item in enumerate(value)
+    ]
+
+
+def _require_bool_list(value: Any, label: str) -> list[bool]:
+    if not isinstance(value, list):
+        raise TypeError(f"{label}: expected list")
+    return [
+        _require_bool(item, f"{label}[{idx}]") for idx, item in enumerate(value)
+    ]
+
+
+def _require_str_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list):
+        raise TypeError(f"{label}: expected list")
+    return [
+        _require_str(item, f"{label}[{idx}]") for idx, item in enumerate(value)
+    ]
+
+
+def _require_nested_int_list(value: Any, label: str) -> list[list[int]]:
+    if not isinstance(value, list):
+        raise TypeError(f"{label}: expected list")
+    return [
+        _require_int_list(item, f"{label}[{idx}]")
+        for idx, item in enumerate(value)
+    ]
+
+
+def _require_nested_bool_list(value: Any, label: str) -> list[list[bool]]:
+    if not isinstance(value, list):
+        raise TypeError(f"{label}: expected list")
+    return [
+        _require_bool_list(item, f"{label}[{idx}]")
+        for idx, item in enumerate(value)
+    ]
+
+
+def _coerce_trace_float(value: Any, label: str) -> float:
+    if isinstance(value, str):
+        if value == "nan":
+            return float("nan")
+        if value == "inf":
+            return float("inf")
+        if value == "-inf":
+            return float("-inf")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    raise TypeError(
+        f"{label}: expected numeric value, got {type(value).__name__}"
+    )
+
+
+def _require_nested_float_blocks(
+    value: Any, label: str
+) -> list[list[list[float]]]:
+    if not isinstance(value, list):
+        raise TypeError(f"{label}: expected list")
+    nested_values: list[list[list[float]]] = []
+    for residual_idx, residual_blocks in enumerate(value):
+        if not isinstance(residual_blocks, list):
+            raise TypeError(f"{label}[{residual_idx}]: expected list")
+        parsed_blocks = []
+        for block_idx, block_values in enumerate(residual_blocks):
+            if not isinstance(block_values, list):
+                raise TypeError(
+                    f"{label}[{residual_idx}][{block_idx}]: expected list"
+                )
+            parsed_blocks.append(
+                [
+                    _coerce_trace_float(
+                        bound,
+                        f"{label}[{residual_idx}][{block_idx}][{bound_idx}]",
+                    )
+                    for bound_idx, bound in enumerate(block_values)
+                ]
+            )
+        nested_values.append(parsed_blocks)
+    return nested_values
+
+
+def _artifact_path(
+    metadata_path: Path,
+    metadata: dict[str, Any],
+    name: str,
+    expected_count: int,
+) -> Path:
+    artifacts = _require_key(metadata, "artifacts", str(metadata_path))
+    if not isinstance(artifacts, dict):
+        raise TypeError(f"{metadata_path}: artifacts must be a JSON object")
+    artifact = _require_key(artifacts, name, f"{metadata_path}: artifacts")
+    if not isinstance(artifact, dict):
+        raise TypeError(
+            f"{metadata_path}: artifacts.{name} must be a JSON object"
+        )
+
+    filename = _require_str(
+        _require_key(artifact, "file", f"{metadata_path}: artifacts.{name}"),
+        "file",
+    )
+    dtype = _require_key(
+        artifact, "dtype", f"{metadata_path}: artifacts.{name}"
+    )
+    byte_order = _require_key(
+        artifact, "byte_order", f"{metadata_path}: artifacts.{name}"
+    )
+    if dtype != "float64":
+        raise ValueError(
+            f"{metadata_path}: artifacts.{name}.dtype must be float64"
+        )
+    if byte_order != "little_endian":
+        raise ValueError(
+            f"{metadata_path}: artifacts.{name}.byte_order must be "
+            "little_endian"
+        )
+    shape = _require_key(
+        artifact, "shape", f"{metadata_path}: artifacts.{name}"
+    )
+    if not isinstance(shape, list) or len(shape) != 1:
+        raise TypeError(
+            f"{metadata_path}: artifacts.{name}.shape must be [count]"
+        )
+    shape_count = _require_int(
+        shape[0], f"{metadata_path}: artifacts.{name}.shape[0]"
+    )
+    if shape_count != expected_count:
+        raise ValueError(
+            f"{metadata_path}: artifacts.{name}.shape[0] is {shape_count}, "
+            f"expected {expected_count}"
+        )
+
+    path = metadata_path.parent / filename
+    expected_size = expected_count * 8
+    actual_size = path.stat().st_size
+    if actual_size != expected_size:
+        raise ValueError(
+            f"{path}: byte size {actual_size}, expected {expected_size}"
+        )
+    return path
+
+
+def _memmap_float64(path: Path, count: int) -> np.memmap:
+    return np.memmap(path, dtype="<f8", mode="r", shape=(count,))
+
+
+@dataclass(frozen=True)
+class GlobalPositioningParameterBlock:
+    role: str
+    kind: str
+    id: int
+    size: int
+    is_constant: bool | None = None
+    lower_bounds: tuple[float, ...] | None = None
+
+
+@dataclass(frozen=True)
+class GlobalPositioningJacobianBlock:
+    parameter_block: GlobalPositioningParameterBlock
+    offset: int
+    residual_dim: int
+    values: np.ndarray
+
+
+class GlobalPositioningResidualBlock:
+    def __init__(
+        self, residual_values: GlobalPositioningResidualValues, index: int
+    ):
+        self._residual_values = residual_values
+        self.index = index
+
+    @property
+    def residual_id(self) -> str:
+        return self._residual_values.residual_ids[self.index]
+
+    @property
+    def residual_dim(self) -> int:
+        return self._residual_values.residual_dims[self.index]
+
+    @property
+    def residual_offset(self) -> int:
+        return self._residual_values.residual_offsets[self.index]
+
+    @property
+    def evaluation_success(self) -> bool:
+        return self._residual_values.evaluation_success[self.index]
+
+    @property
+    def raw_residuals(self) -> np.ndarray:
+        begin = self.residual_offset
+        end = begin + self.residual_dim
+        return self._residual_values.raw_residuals[begin:end]
+
+    @property
+    def raw_cost(self) -> float:
+        return float(self._residual_values.raw_costs[self.index])
+
+    @property
+    def robust_cost(self) -> float:
+        return float(self._residual_values.robust_costs[self.index])
+
+    @property
+    def parameter_blocks(self) -> tuple[GlobalPositioningParameterBlock, ...]:
+        if not self._residual_values.has_raw_jacobians:
+            return ()
+        return tuple(self._residual_values.parameter_blocks[self.index])
+
+    @property
+    def jacobian_blocks(self) -> tuple[GlobalPositioningJacobianBlock, ...]:
+        if not self._residual_values.has_raw_jacobians:
+            return ()
+        raw_jacobians = self._residual_values.raw_jacobians
+        if raw_jacobians is None:
+            return ()
+
+        blocks = []
+        for parameter_block, offset in zip(
+            self._residual_values.parameter_blocks[self.index],
+            self._residual_values.raw_jacobian_offsets[self.index],
+            strict=True,
+        ):
+            end = offset + self.residual_dim * parameter_block.size
+            values = raw_jacobians[offset:end].reshape(
+                (self.residual_dim, parameter_block.size)
+            )
+            blocks.append(
+                GlobalPositioningJacobianBlock(
+                    parameter_block, offset, self.residual_dim, values
+                )
+            )
+        return tuple(blocks)
+
+    def jacobian(
+        self, block: int | str, *, id: int | None = None
+    ) -> np.ndarray:
+        jacobian_blocks = self.jacobian_blocks
+        if isinstance(block, int):
+            return jacobian_blocks[block].values
+        matches = [
+            item
+            for item in jacobian_blocks
+            if item.parameter_block.role == block
+            and (id is None or item.parameter_block.id == id)
+        ]
+        if len(matches) != 1:
+            raise KeyError(
+                f"Expected exactly one Jacobian block for role={block!r}, "
+                f"id={id!r}; found {len(matches)}"
+            )
+        return matches[0].values
+
+
+class GlobalPositioningResidualValues:
+    def __init__(self, metadata_path: Path):
+        self.metadata_path = Path(metadata_path)
+        self.metadata = _load_json(self.metadata_path)
+        self.iteration = _require_int(
+            _require_key(self.metadata, "iteration", str(self.metadata_path)),
+            "iteration",
+        )
+        self.num_residual_blocks = _require_int(
+            _require_key(
+                self.metadata, "num_residual_blocks", str(self.metadata_path)
+            ),
+            "num_residual_blocks",
+        )
+        self.total_scalar_residuals = _require_int(
+            _require_key(
+                self.metadata, "total_scalar_residuals", str(self.metadata_path)
+            ),
+            "total_scalar_residuals",
+        )
+        self.residual_ids = _require_str_list(
+            _require_key(
+                self.metadata, "residual_ids", str(self.metadata_path)
+            ),
+            "residual_ids",
+        )
+        self.residual_dims = _require_int_list(
+            _require_key(
+                self.metadata, "residual_dims", str(self.metadata_path)
+            ),
+            "residual_dims",
+        )
+        self.residual_offsets = _require_int_list(
+            _require_key(
+                self.metadata, "residual_offsets", str(self.metadata_path)
+            ),
+            "residual_offsets",
+        )
+        self.evaluation_success = _require_bool_list(
+            _require_key(
+                self.metadata, "evaluation_success", str(self.metadata_path)
+            ),
+            "evaluation_success",
+        )
+        self.has_raw_jacobians = _require_bool(
+            _require_key(
+                self.metadata, "has_raw_jacobians", str(self.metadata_path)
+            ),
+            "has_raw_jacobians",
+        )
+        self._residual_id_to_index = {
+            residual_id: idx
+            for idx, residual_id in enumerate(self.residual_ids)
+        }
+
+        self._raw_residuals_path = _artifact_path(
+            self.metadata_path,
+            self.metadata,
+            "raw_residuals",
+            self.total_scalar_residuals,
+        )
+        self._raw_costs_path = _artifact_path(
+            self.metadata_path,
+            self.metadata,
+            "raw_costs",
+            self.num_residual_blocks,
+        )
+        self._robust_costs_path = _artifact_path(
+            self.metadata_path,
+            self.metadata,
+            "robust_costs",
+            self.num_residual_blocks,
+        )
+
+        self.total_jacobian_scalars = 0
+        self.parameter_blocks: list[list[GlobalPositioningParameterBlock]] = []
+        self.raw_jacobian_offsets: list[list[int]] = []
+        self._raw_jacobians_path: Path | None = None
+        if self.has_raw_jacobians:
+            self.total_jacobian_scalars = _require_int(
+                _require_key(
+                    self.metadata,
+                    "total_jacobian_scalars",
+                    str(self.metadata_path),
+                ),
+                "total_jacobian_scalars",
+            )
+            parameter_block_sizes = _require_nested_int_list(
+                _require_key(
+                    self.metadata,
+                    "parameter_block_sizes",
+                    str(self.metadata_path),
+                ),
+                "parameter_block_sizes",
+            )
+            self.raw_jacobian_offsets = _require_nested_int_list(
+                _require_key(
+                    self.metadata,
+                    "raw_jacobian_offsets",
+                    str(self.metadata_path),
+                ),
+                "raw_jacobian_offsets",
+            )
+            parameter_block_descriptors = _require_key(
+                self.metadata, "parameter_blocks", str(self.metadata_path)
+            )
+            parameter_block_is_constant = _require_nested_bool_list(
+                _require_key(
+                    self.metadata,
+                    "parameter_block_is_constant",
+                    str(self.metadata_path),
+                ),
+                "parameter_block_is_constant",
+            )
+            parameter_block_lower_bounds = _require_nested_float_blocks(
+                _require_key(
+                    self.metadata,
+                    "parameter_block_lower_bounds",
+                    str(self.metadata_path),
+                ),
+                "parameter_block_lower_bounds",
+            )
+            self.parameter_blocks = self._parse_parameter_blocks(
+                parameter_block_descriptors,
+                parameter_block_sizes,
+                parameter_block_is_constant,
+                parameter_block_lower_bounds,
+            )
+            self._raw_jacobians_path = _artifact_path(
+                self.metadata_path,
+                self.metadata,
+                "raw_jacobians",
+                self.total_jacobian_scalars,
+            )
+
+        self._raw_residuals: np.memmap | None = None
+        self._raw_costs: np.memmap | None = None
+        self._robust_costs: np.memmap | None = None
+        self._raw_jacobians: np.memmap | None = None
+
+    @staticmethod
+    def _parse_parameter_blocks(
+        descriptors: Any,
+        sizes: list[list[int]],
+        is_constant: list[list[bool]],
+        lower_bounds: list[list[list[float]]],
+    ) -> list[list[GlobalPositioningParameterBlock]]:
+        if not isinstance(descriptors, list):
+            raise TypeError("parameter_blocks: expected list")
+        blocks: list[list[GlobalPositioningParameterBlock]] = []
+        for residual_idx, residual_descriptors in enumerate(descriptors):
+            if not isinstance(residual_descriptors, list):
+                raise TypeError(
+                    f"parameter_blocks[{residual_idx}]: expected list"
+                )
+            residual_blocks = []
+            for block_idx, descriptor in enumerate(residual_descriptors):
+                if not isinstance(descriptor, dict):
+                    raise TypeError(
+                        f"parameter_blocks[{residual_idx}][{block_idx}]: "
+                        "expected object"
+                    )
+                role = _require_str(
+                    _require_key(descriptor, "role", "parameter_block"), "role"
+                )
+                kind = _require_str(
+                    _require_key(descriptor, "kind", "parameter_block"), "kind"
+                )
+                block_id = _require_int(
+                    _require_key(descriptor, "id", "parameter_block"), "id"
+                )
+                residual_blocks.append(
+                    GlobalPositioningParameterBlock(
+                        role=role,
+                        kind=kind,
+                        id=block_id,
+                        size=sizes[residual_idx][block_idx],
+                        is_constant=is_constant[residual_idx][block_idx],
+                        lower_bounds=tuple(
+                            lower_bounds[residual_idx][block_idx]
+                        ),
+                    )
+                )
+            blocks.append(residual_blocks)
+        return blocks
+
+    @property
+    def raw_residuals(self) -> np.memmap:
+        if self._raw_residuals is None:
+            self._raw_residuals = _memmap_float64(
+                self._raw_residuals_path, self.total_scalar_residuals
+            )
+        return self._raw_residuals
+
+    @property
+    def raw_costs(self) -> np.memmap:
+        if self._raw_costs is None:
+            self._raw_costs = _memmap_float64(
+                self._raw_costs_path, self.num_residual_blocks
+            )
+        return self._raw_costs
+
+    @property
+    def robust_costs(self) -> np.memmap:
+        if self._robust_costs is None:
+            self._robust_costs = _memmap_float64(
+                self._robust_costs_path, self.num_residual_blocks
+            )
+        return self._robust_costs
+
+    @property
+    def raw_jacobians(self) -> np.memmap | None:
+        if self._raw_jacobians_path is None:
+            return None
+        if self._raw_jacobians is None:
+            self._raw_jacobians = _memmap_float64(
+                self._raw_jacobians_path, self.total_jacobian_scalars
+            )
+        return self._raw_jacobians
+
+    def residual(self, residual: int | str) -> GlobalPositioningResidualBlock:
+        if isinstance(residual, str):
+            residual = self._residual_id_to_index[residual]
+        if residual < 0 or residual >= self.num_residual_blocks:
+            raise IndexError(f"Residual index {residual} out of range")
+        return GlobalPositioningResidualBlock(self, residual)
+
+
+class GlobalPositioningTrace:
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self.manifest = _load_json(self.path / "manifest.json")
+        self.residual_blocks = self._read_optional_jsonl(
+            "residual_blocks.jsonl"
+        )
+        self.residual_skips = self._read_optional_jsonl("residual_skips.jsonl")
+        self._residual_values_by_iteration: dict[int, Path] = {}
+        residual_values_dir = self.path / "residual_values"
+        if residual_values_dir.is_dir():
+            for metadata_path in sorted(
+                residual_values_dir.glob("iter_*.json")
+            ):
+                metadata = _load_json(metadata_path)
+                iteration = _require_int(
+                    _require_key(metadata, "iteration", str(metadata_path)),
+                    "iteration",
+                )
+                self._residual_values_by_iteration[iteration] = metadata_path
+
+    @classmethod
+    def load(cls, path: str | Path) -> GlobalPositioningTrace:
+        return cls(Path(path))
+
+    def _read_optional_jsonl(self, filename: str) -> list[dict[str, Any]]:
+        path = self.path / filename
+        if not path.exists():
+            return []
+        return _iter_jsonl(path)
+
+    @property
+    def status(self) -> str:
+        return _require_str(
+            _require_key(
+                self.manifest, "status", str(self.path / "manifest.json")
+            ),
+            "status",
+        )
+
+    @property
+    def trace_level(self) -> str:
+        return _require_str(
+            _require_key(
+                self.manifest, "trace_level", str(self.path / "manifest.json")
+            ),
+            "trace_level",
+        )
+
+    @property
+    def residual_value_iterations(self) -> tuple[int, ...]:
+        return tuple(sorted(self._residual_values_by_iteration))
+
+    def residual_values(
+        self, iteration: int | None = None
+    ) -> GlobalPositioningResidualValues:
+        if iteration is None:
+            iterations = self.residual_value_iterations
+            if len(iterations) != 1:
+                raise ValueError(
+                    f"Trace has {len(iterations)} residual-value iterations; "
+                    "pass iteration explicitly"
+                )
+            iteration = iterations[0]
+        if iteration not in self._residual_values_by_iteration:
+            raise KeyError(
+                f"Trace has no residual values for iteration {iteration}"
+            )
+        return GlobalPositioningResidualValues(
+            self._residual_values_by_iteration[iteration]
+        )

--- a/python/pycolmap/global_positioning_trace.py
+++ b/python/pycolmap/global_positioning_trace.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 import json
+import math
+import struct
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+
+_RAW_BINARY_STORAGE_FORMAT = "global_positioning_raw_binary_v1"
+_RAW_LEDGER_MAGIC = b"GPTRLGR1"
+_RAW_ARRAY_MAGIC = b"GPTRARR1"
+_RAW_RESIDUAL_VALUES_MAGIC = b"GPTRRSV1"
+_RAW_ENDIAN = "<"
+_RAW_NONE_ID = -1
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -14,6 +23,50 @@ def _load_json(path: Path) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"{path}: expected a JSON object")
     return value
+
+
+def _read_exact(stream: Any, size: int, label: str) -> bytes:
+    payload = stream.read(size)
+    if len(payload) != size:
+        raise ValueError(f"{label}: truncated binary file")
+    return payload
+
+
+def _read_struct(stream: Any, fmt: str, label: str) -> tuple[Any, ...]:
+    size = struct.calcsize(_RAW_ENDIAN + fmt)
+    return struct.unpack(_RAW_ENDIAN + fmt, _read_exact(stream, size, label))
+
+
+def _read_binary_string(stream: Any, label: str) -> str:
+    (size,) = _read_struct(stream, "I", f"{label}.size")
+    payload = _read_exact(stream, size, label)
+    return payload.decode("utf-8")
+
+
+def _read_binary_json(stream: Any, label: str) -> dict[str, Any]:
+    text = _read_binary_string(stream, label)
+    value = json.loads(text) if text else {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{label}: expected encoded JSON object")
+    return value
+
+
+def _read_magic(stream: Any, expected: bytes, label: str) -> None:
+    actual = _read_exact(stream, len(expected), label)
+    if actual != expected:
+        raise ValueError(f"{label}: bad magic {actual!r}, expected {expected!r}")
+
+
+def _resolve_raw_trace_path(root: Path, relative_path: Path, label: str) -> Path:
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        raise ValueError(f"{label}: invalid path {str(relative_path)!r}")
+    root_resolved = root.resolve()
+    resolved = (root / relative_path).resolve(strict=False)
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError as exc:
+        raise ValueError(f"{label}: path escapes trace root: {relative_path}") from exc
+    return resolved
 
 
 def _iter_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -25,9 +78,7 @@ def _iter_jsonl(path: Path) -> list[dict[str, Any]]:
                 continue
             value = json.loads(line)
             if not isinstance(value, dict):
-                raise ValueError(
-                    f"{path}:{line_number}: expected a JSON object"
-                )
+                raise ValueError(f"{path}:{line_number}: expected a JSON object")
             records.append(value)
     return records
 
@@ -50,6 +101,15 @@ def _require_bool(value: Any, label: str) -> bool:
     return value
 
 
+def _require_optional_iteration(value: Any, label: str) -> int | None:
+    if value is None:
+        return None
+    iteration = _require_int(value, label)
+    if iteration < 0:
+        raise ValueError(f"{label}: expected non-negative iteration")
+    return iteration
+
+
 def _require_str(value: Any, label: str) -> str:
     if not isinstance(value, str) or not value:
         raise TypeError(f"{label}: expected non-empty string")
@@ -59,33 +119,26 @@ def _require_str(value: Any, label: str) -> str:
 def _require_int_list(value: Any, label: str) -> list[int]:
     if not isinstance(value, list):
         raise TypeError(f"{label}: expected list")
-    return [
-        _require_int(item, f"{label}[{idx}]") for idx, item in enumerate(value)
-    ]
+    return [_require_int(item, f"{label}[{idx}]") for idx, item in enumerate(value)]
 
 
 def _require_bool_list(value: Any, label: str) -> list[bool]:
     if not isinstance(value, list):
         raise TypeError(f"{label}: expected list")
-    return [
-        _require_bool(item, f"{label}[{idx}]") for idx, item in enumerate(value)
-    ]
+    return [_require_bool(item, f"{label}[{idx}]") for idx, item in enumerate(value)]
 
 
 def _require_str_list(value: Any, label: str) -> list[str]:
     if not isinstance(value, list):
         raise TypeError(f"{label}: expected list")
-    return [
-        _require_str(item, f"{label}[{idx}]") for idx, item in enumerate(value)
-    ]
+    return [_require_str(item, f"{label}[{idx}]") for idx, item in enumerate(value)]
 
 
 def _require_nested_int_list(value: Any, label: str) -> list[list[int]]:
     if not isinstance(value, list):
         raise TypeError(f"{label}: expected list")
     return [
-        _require_int_list(item, f"{label}[{idx}]")
-        for idx, item in enumerate(value)
+        _require_int_list(item, f"{label}[{idx}]") for idx, item in enumerate(value)
     ]
 
 
@@ -93,8 +146,7 @@ def _require_nested_bool_list(value: Any, label: str) -> list[list[bool]]:
     if not isinstance(value, list):
         raise TypeError(f"{label}: expected list")
     return [
-        _require_bool_list(item, f"{label}[{idx}]")
-        for idx, item in enumerate(value)
+        _require_bool_list(item, f"{label}[{idx}]") for idx, item in enumerate(value)
     ]
 
 
@@ -108,14 +160,16 @@ def _coerce_trace_float(value: Any, label: str) -> float:
             return float("-inf")
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return float(value)
-    raise TypeError(
-        f"{label}: expected numeric value, got {type(value).__name__}"
-    )
+    raise TypeError(f"{label}: expected numeric value, got {type(value).__name__}")
 
 
-def _require_nested_float_blocks(
-    value: Any, label: str
-) -> list[list[list[float]]]:
+def _coerce_optional_trace_float(value: Any, label: str) -> float | None:
+    if value is None:
+        return None
+    return _coerce_trace_float(value, label)
+
+
+def _require_nested_float_blocks(value: Any, label: str) -> list[list[list[float]]]:
     if not isinstance(value, list):
         raise TypeError(f"{label}: expected list")
     nested_values: list[list[list[float]]] = []
@@ -125,9 +179,7 @@ def _require_nested_float_blocks(
         parsed_blocks = []
         for block_idx, block_values in enumerate(residual_blocks):
             if not isinstance(block_values, list):
-                raise TypeError(
-                    f"{label}[{residual_idx}][{block_idx}]: expected list"
-                )
+                raise TypeError(f"{label}[{residual_idx}][{block_idx}]: expected list")
             parsed_blocks.append(
                 [
                     _coerce_trace_float(
@@ -191,8 +243,7 @@ def _validate_trace_metadata(
         raise ValueError(f"{metadata_path}: iteration must be non-negative")
     if expected_iteration is not None and iteration != expected_iteration:
         raise ValueError(
-            f"{metadata_path}: iteration {iteration}, "
-            f"expected {expected_iteration}"
+            f"{metadata_path}: iteration {iteration}, " f"expected {expected_iteration}"
         )
 
     dtype = _require_str(
@@ -232,9 +283,7 @@ def _artifact_metadata(
         return None
     artifact = _require_key(artifacts, name, f"{metadata_path}: artifacts")
     if not isinstance(artifact, dict):
-        raise TypeError(
-            f"{metadata_path}: artifacts.{name} must be a JSON object"
-        )
+        raise TypeError(f"{metadata_path}: artifacts.{name} must be a JSON object")
     return artifact
 
 
@@ -247,9 +296,7 @@ def _resolve_float64_artifact(
     expected_ids: tuple[int, ...] | None = None,
     required: bool = True,
 ) -> _ResolvedFloat64Artifact | None:
-    artifact = _artifact_metadata(
-        metadata_path, metadata, name, required=required
-    )
+    artifact = _artifact_metadata(metadata_path, metadata, name, required=required)
     if artifact is None:
         return None
 
@@ -274,19 +321,14 @@ def _resolve_float64_artifact(
         f"{metadata_path}: artifacts.{name}.dtype",
     )
     byte_order = _require_str(
-        _require_key(
-            artifact, "byte_order", f"{metadata_path}: artifacts.{name}"
-        ),
+        _require_key(artifact, "byte_order", f"{metadata_path}: artifacts.{name}"),
         f"{metadata_path}: artifacts.{name}.byte_order",
     )
     if dtype != "float64":
-        raise ValueError(
-            f"{metadata_path}: artifacts.{name}.dtype must be float64"
-        )
+        raise ValueError(f"{metadata_path}: artifacts.{name}.dtype must be float64")
     if byte_order != "little_endian":
         raise ValueError(
-            f"{metadata_path}: artifacts.{name}.byte_order must be "
-            "little_endian"
+            f"{metadata_path}: artifacts.{name}.byte_order must be " "little_endian"
         )
     shape = _require_shape(
         _require_key(artifact, "shape", f"{metadata_path}: artifacts.{name}"),
@@ -302,16 +344,13 @@ def _resolve_float64_artifact(
     if expected_ids is not None or "ids" in artifact:
         ids = tuple(
             _require_int_list(
-                _require_key(
-                    artifact, "ids", f"{metadata_path}: artifacts.{name}"
-                ),
+                _require_key(artifact, "ids", f"{metadata_path}: artifacts.{name}"),
                 f"{metadata_path}: artifacts.{name}.ids",
             )
         )
         if expected_ids is not None and ids != expected_ids:
             raise ValueError(
-                f"{metadata_path}: artifacts.{name}.ids does not match "
-                "top-level IDs"
+                f"{metadata_path}: artifacts.{name}.ids does not match " "top-level IDs"
             )
         if shape[0] != len(ids):
             raise ValueError(
@@ -321,12 +360,18 @@ def _resolve_float64_artifact(
 
     element_count = _shape_element_count(shape)
     path = metadata_path.parent / filename
+    metadata_dir = metadata_path.parent.resolve()
+    resolved_path = path.resolve(strict=False)
+    try:
+        resolved_path.relative_to(metadata_dir)
+    except ValueError as exc:
+        raise ValueError(
+            f"{metadata_path}: artifacts.{name}.file escapes metadata directory"
+        ) from exc
     expected_size = element_count * 8
     actual_size = path.stat().st_size
     if actual_size != expected_size:
-        raise ValueError(
-            f"{path}: byte size {actual_size}, expected {expected_size}"
-        )
+        raise ValueError(f"{path}: byte size {actual_size}, expected {expected_size}")
     return _ResolvedFloat64Artifact(path, ids, shape, element_count)
 
 
@@ -374,6 +419,70 @@ class GlobalPositioningParameterBlock:
 
 
 @dataclass(frozen=True)
+class GlobalPositioningResidualLedgerParameterBlock:
+    role: str
+    kind: str
+    id: int
+    size: int
+
+
+@dataclass(frozen=True)
+class GlobalPositioningResidualLedgerLoss:
+    bucket: str
+    type: str
+    scale: float | None
+    weight: float | None
+    source: str
+    observation_count_weight: float | None = None
+
+
+@dataclass(frozen=True)
+class GlobalPositioningResidualLedgerBlock:
+    residual_id: str
+    event_type: str
+    replay_schema_version: int
+    parameter_blocks: tuple[GlobalPositioningResidualLedgerParameterBlock, ...]
+    loss: GlobalPositioningResidualLedgerLoss
+    fixed_parameters_status: str
+    fixed_parameters: dict[str, Any]
+    attrs: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class GlobalPositioningTraceEvent:
+    schema_version: int
+    run_id: str
+    seq: int
+    event_type: str
+    stage: str
+    iteration: int | None
+    timestamp_ns: int
+    attrs: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class GlobalPositioningIterationMetric:
+    schema_version: int
+    run_id: str
+    seq: int
+    event_type: str
+    stage: str
+    iteration: int
+    timestamp_ns: int
+    step_is_successful: bool
+    cost: float
+    cost_change: float
+    gradient_max_norm: float
+    step_norm: float
+    trust_region_radius: float
+    linear_solver_iterations: int
+    iteration_time_sec: float
+    cumulative_time_sec: float
+    attrs: dict[str, Any]
+    gradient_norm: float | None = None
+
+
+@dataclass(frozen=True)
 class GlobalPositioningJacobianBlock:
     parameter_block: GlobalPositioningParameterBlock
     offset: int
@@ -400,10 +509,95 @@ class GlobalPositioningParameterSnapshot:
     cams_in_rig: GlobalPositioningSnapshotArray | None = None
 
 
+@dataclass(frozen=True)
+class GlobalPositioningReplayJacobianBlock:
+    parameter_block: GlobalPositioningResidualLedgerParameterBlock
+    offset: int
+    residual_dim: int
+    values: np.ndarray
+
+
+@dataclass(frozen=True)
+class GlobalPositioningReplayResidualBlock:
+    residual_id: str
+    residual_dim: int
+    residual_offset: int
+    evaluation_success: bool
+    raw_residuals: np.ndarray
+    raw_cost: float
+    robust_cost: float
+    loss_rho: np.ndarray
+    parameter_blocks: tuple[GlobalPositioningResidualLedgerParameterBlock, ...]
+    jacobian_blocks: tuple[GlobalPositioningReplayJacobianBlock, ...] = ()
+
+    @property
+    def loss_rho0(self) -> float:
+        return float(self.loss_rho[0])
+
+    @property
+    def loss_rho1(self) -> float:
+        return float(self.loss_rho[1])
+
+    @property
+    def loss_rho2(self) -> float:
+        return float(self.loss_rho[2])
+
+    @property
+    def loss_derivative_scale(self) -> float:
+        return self.loss_rho1
+
+
+@dataclass(frozen=True)
+class GlobalPositioningReplayEvaluation:
+    iteration: int
+    raw_residuals: np.ndarray
+    raw_costs: np.ndarray
+    loss_rho_values: np.ndarray
+    robust_costs: np.ndarray
+    evaluation_success: tuple[bool, ...]
+    residual_ids: tuple[str, ...]
+    residual_dims: tuple[int, ...]
+    residual_offsets: tuple[int, ...]
+    parameter_blocks: tuple[
+        tuple[GlobalPositioningResidualLedgerParameterBlock, ...], ...
+    ]
+    raw_jacobians: tuple[tuple[GlobalPositioningReplayJacobianBlock, ...], ...] = ()
+
+    @property
+    def has_raw_jacobians(self) -> bool:
+        return bool(self.raw_jacobians)
+
+    @property
+    def has_loss_rho_values(self) -> bool:
+        return True
+
+    def residual(self, residual: int | str) -> GlobalPositioningReplayResidualBlock:
+        if isinstance(residual, str):
+            try:
+                residual = self.residual_ids.index(residual)
+            except ValueError as exc:
+                raise KeyError(f"Unknown residual id {residual!r}") from exc
+        if residual < 0 or residual >= len(self.residual_ids):
+            raise IndexError(f"Residual index {residual} out of range")
+        offset = self.residual_offsets[residual]
+        dim = self.residual_dims[residual]
+        jacobian_blocks = self.raw_jacobians[residual] if self.raw_jacobians else ()
+        return GlobalPositioningReplayResidualBlock(
+            residual_id=self.residual_ids[residual],
+            residual_dim=dim,
+            residual_offset=offset,
+            evaluation_success=self.evaluation_success[residual],
+            raw_residuals=self.raw_residuals[offset : offset + dim],
+            raw_cost=float(self.raw_costs[residual]),
+            robust_cost=float(self.robust_costs[residual]),
+            loss_rho=self.loss_rho_values[residual],
+            parameter_blocks=self.parameter_blocks[residual],
+            jacobian_blocks=jacobian_blocks,
+        )
+
+
 class GlobalPositioningResidualBlock:
-    def __init__(
-        self, residual_values: GlobalPositioningResidualValues, index: int
-    ):
+    def __init__(self, residual_values: GlobalPositioningResidualValues, index: int):
         self._residual_values = residual_values
         self.index = index
 
@@ -488,9 +682,7 @@ class GlobalPositioningResidualBlock:
             )
         return tuple(blocks)
 
-    def jacobian(
-        self, block: int | str, *, id: int | None = None
-    ) -> np.ndarray:
+    def jacobian(self, block: int | str, *, id: int | None = None) -> np.ndarray:
         jacobian_blocks = self.jacobian_blocks
         if isinstance(block, int):
             return jacobian_blocks[block].values
@@ -526,9 +718,7 @@ class GlobalPositioningResidualValues:
             expected_run_id=expected_run_id,
         )
         self.num_residual_blocks = _require_int(
-            _require_key(
-                self.metadata, "num_residual_blocks", str(self.metadata_path)
-            ),
+            _require_key(self.metadata, "num_residual_blocks", str(self.metadata_path)),
             "num_residual_blocks",
         )
         self.total_scalar_residuals = _require_int(
@@ -538,27 +728,19 @@ class GlobalPositioningResidualValues:
             "total_scalar_residuals",
         )
         self.residual_ids = _require_str_list(
-            _require_key(
-                self.metadata, "residual_ids", str(self.metadata_path)
-            ),
+            _require_key(self.metadata, "residual_ids", str(self.metadata_path)),
             "residual_ids",
         )
         self.residual_dims = _require_int_list(
-            _require_key(
-                self.metadata, "residual_dims", str(self.metadata_path)
-            ),
+            _require_key(self.metadata, "residual_dims", str(self.metadata_path)),
             "residual_dims",
         )
         self.residual_offsets = _require_int_list(
-            _require_key(
-                self.metadata, "residual_offsets", str(self.metadata_path)
-            ),
+            _require_key(self.metadata, "residual_offsets", str(self.metadata_path)),
             "residual_offsets",
         )
         self.evaluation_success = _require_bool_list(
-            _require_key(
-                self.metadata, "evaluation_success", str(self.metadata_path)
-            ),
+            _require_key(self.metadata, "evaluation_success", str(self.metadata_path)),
             "evaluation_success",
         )
         self._validate_residual_structure()
@@ -571,14 +753,11 @@ class GlobalPositioningResidualValues:
                 "residual_blocks.jsonl order"
             )
         self.has_raw_jacobians = _require_bool(
-            _require_key(
-                self.metadata, "has_raw_jacobians", str(self.metadata_path)
-            ),
+            _require_key(self.metadata, "has_raw_jacobians", str(self.metadata_path)),
             "has_raw_jacobians",
         )
         self._residual_id_to_index = {
-            residual_id: idx
-            for idx, residual_id in enumerate(self.residual_ids)
+            residual_id: idx for idx, residual_id in enumerate(self.residual_ids)
         }
 
         raw_residuals_artifact = _resolve_float64_artifact(
@@ -695,15 +874,12 @@ class GlobalPositioningResidualValues:
 
     def _validate_loss_rho_contract(self) -> None:
         loss_rho_layout = _require_str(
-            _require_key(
-                self.metadata, "loss_rho_layout", str(self.metadata_path)
-            ),
+            _require_key(self.metadata, "loss_rho_layout", str(self.metadata_path)),
             "loss_rho_layout",
         )
         if loss_rho_layout != "residual_block_major/rho0_rho1_rho2":
             raise ValueError(
-                "loss_rho_layout must be "
-                "'residual_block_major/rho0_rho1_rho2'"
+                "loss_rho_layout must be 'residual_block_major/rho0_rho1_rho2'"
             )
 
     def _validate_loss_rho_costs(self) -> None:
@@ -763,9 +939,7 @@ class GlobalPositioningResidualValues:
                 "'residual_block_major/parameter_block_major/row_major'"
             )
         jacobian_domain = _require_str(
-            _require_key(
-                self.metadata, "jacobian_domain", str(self.metadata_path)
-            ),
+            _require_key(self.metadata, "jacobian_domain", str(self.metadata_path)),
             "jacobian_domain",
         )
         if jacobian_domain != "raw_cost_function_ambient_parameters":
@@ -778,9 +952,7 @@ class GlobalPositioningResidualValues:
             "constant_parameter_blocks_included",
         ]:
             _require_bool(
-                _require_key(
-                    self.metadata, field_name, str(self.metadata_path)
-                ),
+                _require_key(self.metadata, field_name, str(self.metadata_path)),
                 field_name,
             )
         if self.metadata["loss_applied_to_jacobians"]:
@@ -814,9 +986,7 @@ class GlobalPositioningResidualValues:
             zip(self.residual_dims, self.residual_offsets, strict=True)
         ):
             if residual_dim < 0:
-                raise ValueError(
-                    f"residual_dims[{residual_idx}] must be non-negative"
-                )
+                raise ValueError(f"residual_dims[{residual_idx}] must be non-negative")
             if residual_offset != expected_offset:
                 raise ValueError(
                     f"residual_offsets[{residual_idx}] is {residual_offset}, "
@@ -906,9 +1076,7 @@ class GlobalPositioningResidualValues:
         blocks: list[list[GlobalPositioningParameterBlock]] = []
         for residual_idx, residual_descriptors in enumerate(descriptors):
             if not isinstance(residual_descriptors, list):
-                raise TypeError(
-                    f"parameter_blocks[{residual_idx}]: expected list"
-                )
+                raise TypeError(f"parameter_blocks[{residual_idx}]: expected list")
             residual_blocks = []
             for block_idx, descriptor in enumerate(residual_descriptors):
                 if not isinstance(descriptor, dict):
@@ -932,9 +1100,7 @@ class GlobalPositioningResidualValues:
                         id=block_id,
                         size=sizes[residual_idx][block_idx],
                         is_constant=is_constant[residual_idx][block_idx],
-                        lower_bounds=tuple(
-                            lower_bounds[residual_idx][block_idx]
-                        ),
+                        lower_bounds=tuple(lower_bounds[residual_idx][block_idx]),
                     )
                 )
             blocks.append(residual_blocks)
@@ -1024,9 +1190,7 @@ def _optional_top_level_ids_and_shape(
 ) -> tuple[tuple[int, ...], tuple[int, ...]] | None:
     if ids_key not in metadata and shape_key not in metadata:
         return None
-    return _require_top_level_ids_and_shape(
-        metadata_path, metadata, ids_key, shape_key
-    )
+    return _require_top_level_ids_and_shape(metadata_path, metadata, ids_key, shape_key)
 
 
 def _normalize_max_points(max_points: int | None) -> int | None:
@@ -1128,13 +1292,9 @@ class GlobalPositioningParameterSnapshotLoader:
             "dmap_image_ids",
             "dmap_scales_stored_shape",
         )
-        artifacts = _require_key(
-            self.metadata, "artifacts", str(self.metadata_path)
-        )
+        artifacts = _require_key(self.metadata, "artifacts", str(self.metadata_path))
         if not isinstance(artifacts, dict):
-            raise TypeError(
-                f"{self.metadata_path}: artifacts must be a JSON object"
-            )
+            raise TypeError(f"{self.metadata_path}: artifacts must be a JSON object")
         if dmap_expected is not None and "dmap_scales" not in artifacts:
             dmap_ids, dmap_shape = dmap_expected
             if dmap_ids or _shape_element_count(dmap_shape) != 0:
@@ -1204,13 +1364,1638 @@ class GlobalPositioningParameterSnapshotLoader:
         )
 
 
+def _parse_ledger_parameter_blocks(
+    value: Any, label: str
+) -> tuple[GlobalPositioningResidualLedgerParameterBlock, ...]:
+    if not isinstance(value, list):
+        raise TypeError(f"{label}: expected list")
+    blocks = []
+    for idx, descriptor in enumerate(value):
+        descriptor_label = f"{label}[{idx}]"
+        if not isinstance(descriptor, dict):
+            raise TypeError(f"{descriptor_label}: expected object")
+        role = _require_str(
+            _require_key(descriptor, "role", descriptor_label),
+            f"{descriptor_label}.role",
+        )
+        kind = _require_str(
+            _require_key(descriptor, "kind", descriptor_label),
+            f"{descriptor_label}.kind",
+        )
+        block_id = _require_int(
+            _require_key(descriptor, "id", descriptor_label),
+            f"{descriptor_label}.id",
+        )
+        size = _require_int(
+            _require_key(descriptor, "size", descriptor_label),
+            f"{descriptor_label}.size",
+        )
+        if size <= 0:
+            raise ValueError(f"{descriptor_label}.size must be positive")
+        blocks.append(
+            GlobalPositioningResidualLedgerParameterBlock(
+                role=role,
+                kind=kind,
+                id=block_id,
+                size=size,
+            )
+        )
+    return tuple(blocks)
+
+
+def _parse_ledger_loss(value: Any, label: str) -> GlobalPositioningResidualLedgerLoss:
+    if not isinstance(value, dict):
+        raise TypeError(f"{label}: expected object")
+    observation_count_weight = None
+    if "observation_count_weight" in value:
+        observation_count_weight = _coerce_trace_float(
+            value["observation_count_weight"],
+            f"{label}.observation_count_weight",
+        )
+    return GlobalPositioningResidualLedgerLoss(
+        bucket=_require_str(_require_key(value, "bucket", label), f"{label}.bucket"),
+        type=_require_str(_require_key(value, "type", label), f"{label}.type"),
+        scale=_coerce_optional_trace_float(
+            _require_key(value, "scale", label), f"{label}.scale"
+        ),
+        weight=_coerce_optional_trace_float(
+            _require_key(value, "weight", label), f"{label}.weight"
+        ),
+        source=_require_str(_require_key(value, "source", label), f"{label}.source"),
+        observation_count_weight=observation_count_weight,
+    )
+
+
+def _parse_residual_ledger_block(
+    record: dict[str, Any], idx: int
+) -> GlobalPositioningResidualLedgerBlock | None:
+    label = f"residual_blocks[{idx}]"
+    attrs = _require_key(record, "attrs", label)
+    if not isinstance(attrs, dict):
+        raise TypeError(f"{label}.attrs must be an object")
+    if "replay_schema_version" not in attrs:
+        return None
+    replay_schema_version = _require_int(
+        attrs["replay_schema_version"], f"{label}.attrs.replay_schema_version"
+    )
+    if replay_schema_version != 1:
+        raise ValueError(
+            f"{label}.attrs.replay_schema_version: unsupported "
+            f"replay_schema_version {replay_schema_version}"
+        )
+
+    fixed_parameters_status = _require_str(
+        _require_key(attrs, "fixed_parameters_status", f"{label}.attrs"),
+        f"{label}.attrs.fixed_parameters_status",
+    )
+    if fixed_parameters_status != "serialized":
+        raise ValueError(
+            f"{label}.attrs.fixed_parameters_status must be 'serialized' for "
+            f"typed replay loading, got {fixed_parameters_status!r}"
+        )
+    fixed_parameters = _require_key(attrs, "fixed_parameters", f"{label}.attrs")
+    if not isinstance(fixed_parameters, dict):
+        raise TypeError(f"{label}.attrs.fixed_parameters must be an object")
+
+    event_type = _require_str(
+        _require_key(record, "event_type", label), f"{label}.event_type"
+    )
+    return GlobalPositioningResidualLedgerBlock(
+        residual_id=_require_str(
+            _require_key(attrs, "residual_id", f"{label}.attrs"),
+            f"{label}.attrs.residual_id",
+        ),
+        event_type=event_type,
+        replay_schema_version=replay_schema_version,
+        parameter_blocks=_parse_ledger_parameter_blocks(
+            _require_key(attrs, "parameter_blocks", f"{label}.attrs"),
+            f"{label}.attrs.parameter_blocks",
+        ),
+        loss=_parse_ledger_loss(
+            _require_key(attrs, "loss", f"{label}.attrs"),
+            f"{label}.attrs.loss",
+        ),
+        fixed_parameters_status=fixed_parameters_status,
+        fixed_parameters=fixed_parameters,
+        attrs=attrs,
+    )
+
+
+def _parse_trace_event_record(
+    record: dict[str, Any],
+    *,
+    path: Path,
+    idx: int,
+    expected_run_id: str | None,
+) -> GlobalPositioningTraceEvent:
+    label = f"{path}:{idx + 1}"
+    schema_version = _require_int(
+        _require_key(record, "schema_version", label),
+        f"{label}.schema_version",
+    )
+    if schema_version != 1:
+        raise ValueError(f"{label}: unsupported schema_version {schema_version}")
+    run_id = _require_str(_require_key(record, "run_id", label), f"{label}.run_id")
+    if expected_run_id is not None and run_id != expected_run_id:
+        raise ValueError(f"{label}: run_id {run_id!r}, expected {expected_run_id!r}")
+    seq = _require_int(_require_key(record, "seq", label), f"{label}.seq")
+    if seq < 0:
+        raise ValueError(f"{label}.seq must be non-negative")
+    timestamp_ns = _require_int(
+        _require_key(record, "timestamp_ns", label),
+        f"{label}.timestamp_ns",
+    )
+    if timestamp_ns < 0:
+        raise ValueError(f"{label}.timestamp_ns must be non-negative")
+    attrs = _require_key(record, "attrs", label)
+    if not isinstance(attrs, dict):
+        raise TypeError(f"{label}.attrs must be an object")
+    return GlobalPositioningTraceEvent(
+        schema_version=schema_version,
+        run_id=run_id,
+        seq=seq,
+        event_type=_require_str(
+            _require_key(record, "event_type", label),
+            f"{label}.event_type",
+        ),
+        stage=_require_str(_require_key(record, "stage", label), f"{label}.stage"),
+        iteration=_require_optional_iteration(
+            _require_key(record, "iteration", label),
+            f"{label}.iteration",
+        ),
+        timestamp_ns=timestamp_ns,
+        attrs=attrs,
+    )
+
+
+def _parse_iteration_metric_record(
+    record: dict[str, Any],
+    *,
+    path: Path,
+    idx: int,
+    expected_run_id: str | None,
+) -> GlobalPositioningIterationMetric:
+    event = _parse_trace_event_record(
+        record,
+        path=path,
+        idx=idx,
+        expected_run_id=expected_run_id,
+    )
+    label = f"{path}:{idx + 1}"
+    if event.event_type != "ceres_iteration":
+        raise ValueError(
+            f"{label}.event_type must be 'ceres_iteration', got {event.event_type!r}"
+        )
+    if event.iteration is None:
+        raise ValueError(f"{label}.iteration must not be null")
+    attrs = event.attrs
+    linear_solver_iterations = _require_int(
+        _require_key(attrs, "linear_solver_iterations", f"{label}.attrs"),
+        f"{label}.attrs.linear_solver_iterations",
+    )
+    if linear_solver_iterations < 0:
+        raise ValueError(f"{label}.attrs.linear_solver_iterations must be non-negative")
+    gradient_norm = None
+    if "gradient_norm" in attrs:
+        gradient_norm = _coerce_trace_float(
+            attrs["gradient_norm"], f"{label}.attrs.gradient_norm"
+        )
+    return GlobalPositioningIterationMetric(
+        schema_version=event.schema_version,
+        run_id=event.run_id,
+        seq=event.seq,
+        event_type=event.event_type,
+        stage=event.stage,
+        iteration=event.iteration,
+        timestamp_ns=event.timestamp_ns,
+        step_is_successful=_require_bool(
+            _require_key(attrs, "step_is_successful", f"{label}.attrs"),
+            f"{label}.attrs.step_is_successful",
+        ),
+        cost=_coerce_trace_float(
+            _require_key(attrs, "cost", f"{label}.attrs"), f"{label}.attrs.cost"
+        ),
+        cost_change=_coerce_trace_float(
+            _require_key(attrs, "cost_change", f"{label}.attrs"),
+            f"{label}.attrs.cost_change",
+        ),
+        gradient_norm=gradient_norm,
+        gradient_max_norm=_coerce_trace_float(
+            _require_key(attrs, "gradient_max_norm", f"{label}.attrs"),
+            f"{label}.attrs.gradient_max_norm",
+        ),
+        step_norm=_coerce_trace_float(
+            _require_key(attrs, "step_norm", f"{label}.attrs"),
+            f"{label}.attrs.step_norm",
+        ),
+        trust_region_radius=_coerce_trace_float(
+            _require_key(attrs, "trust_region_radius", f"{label}.attrs"),
+            f"{label}.attrs.trust_region_radius",
+        ),
+        linear_solver_iterations=linear_solver_iterations,
+        iteration_time_sec=_coerce_trace_float(
+            _require_key(attrs, "iteration_time_sec", f"{label}.attrs"),
+            f"{label}.attrs.iteration_time_sec",
+        ),
+        cumulative_time_sec=_coerce_trace_float(
+            _require_key(attrs, "cumulative_time_sec", f"{label}.attrs"),
+            f"{label}.attrs.cumulative_time_sec",
+        ),
+        attrs=attrs,
+    )
+
+
+def _read_optional_trace_events(
+    directory: Path,
+    filename: str,
+    *,
+    expected_run_id: str | None,
+) -> tuple[GlobalPositioningTraceEvent, ...]:
+    path = directory / filename
+    if not path.exists():
+        return ()
+    return tuple(
+        _parse_trace_event_record(
+            record,
+            path=path,
+            idx=idx,
+            expected_run_id=expected_run_id,
+        )
+        for idx, record in enumerate(_iter_jsonl(path))
+    )
+
+
+def _read_optional_iteration_metrics(
+    directory: Path,
+    filename: str,
+    *,
+    expected_run_id: str | None,
+) -> tuple[GlobalPositioningIterationMetric, ...]:
+    path = directory / filename
+    if not path.exists():
+        return ()
+    metrics = tuple(
+        _parse_iteration_metric_record(
+            record,
+            path=path,
+            idx=idx,
+            expected_run_id=expected_run_id,
+        )
+        for idx, record in enumerate(_iter_jsonl(path))
+    )
+    seen_iterations: set[int] = set()
+    for metric in metrics:
+        if metric.iteration in seen_iterations:
+            raise ValueError(f"{path}: duplicate iteration metric {metric.iteration}")
+        seen_iterations.add(metric.iteration)
+    return metrics
+
+
+def _require_float_vector(value: Any, label: str, size: int) -> np.ndarray:
+    if not isinstance(value, list):
+        raise TypeError(f"{label}: expected list")
+    if len(value) != size:
+        raise ValueError(f"{label}: expected length {size}, got {len(value)}")
+    return np.asarray(
+        [
+            _coerce_trace_float(item, f"{label}[{idx}]")
+            for idx, item in enumerate(value)
+        ],
+        dtype=np.float64,
+    )
+
+
+def _require_fixed_vector(
+    fixed_parameters: dict[str, Any], key: str, residual_id: str, size: int
+) -> np.ndarray:
+    return _require_float_vector(
+        _require_key(fixed_parameters, key, f"residual {residual_id} fixed_parameters"),
+        f"residual {residual_id} fixed_parameters.{key}",
+        size,
+    )
+
+
+def _require_fixed_float(
+    fixed_parameters: dict[str, Any], key: str, residual_id: str
+) -> float:
+    return _coerce_trace_float(
+        _require_key(fixed_parameters, key, f"residual {residual_id} fixed_parameters"),
+        f"residual {residual_id} fixed_parameters.{key}",
+    )
+
+
+def _require_fixed_bool(
+    fixed_parameters: dict[str, Any], key: str, residual_id: str
+) -> bool:
+    return _require_bool(
+        _require_key(fixed_parameters, key, f"residual {residual_id} fixed_parameters"),
+        f"residual {residual_id} fixed_parameters.{key}",
+    )
+
+
+def _snapshot_lookup(
+    array: GlobalPositioningSnapshotArray | None,
+    label: str,
+) -> dict[int, np.ndarray]:
+    if array is None:
+        return {}
+    if len(array.ids) != array.shape[0]:
+        raise ValueError(f"{label}: missing artifact ids for replay")
+    return {
+        item_id: np.atleast_1d(np.asarray(array.values[idx], dtype=np.float64))
+        for idx, item_id in enumerate(array.ids)
+    }
+
+
+def _rotation_matrix_from_quaternion_wxyz(value: np.ndarray, label: str) -> np.ndarray:
+    if value.shape != (4,):
+        raise ValueError(f"{label}: expected quaternion shape (4,), got {value.shape}")
+    norm = float(np.linalg.norm(value))
+    if not np.isfinite(norm) or norm <= 0.0:
+        raise ValueError(f"{label}: quaternion norm must be positive and finite")
+    w, x, y, z = value / norm
+    return np.array(
+        [
+            [
+                1.0 - 2.0 * (y * y + z * z),
+                2.0 * (x * y - z * w),
+                2.0 * (x * z + y * w),
+            ],
+            [
+                2.0 * (x * y + z * w),
+                1.0 - 2.0 * (x * x + z * z),
+                2.0 * (y * z - x * w),
+            ],
+            [
+                2.0 * (x * z - y * w),
+                2.0 * (y * z + x * w),
+                1.0 - 2.0 * (x * x + y * y),
+            ],
+        ],
+        dtype=np.float64,
+    )
+
+
+def _left_sqrt_information(covariance: np.ndarray, label: str) -> np.ndarray:
+    if covariance.shape != (3, 3):
+        raise ValueError(f"{label}: expected shape (3, 3), got {covariance.shape}")
+    try:
+        return np.linalg.cholesky(np.linalg.inv(covariance)).T
+    except np.linalg.LinAlgError as exc:
+        raise ValueError(f"{label}: covariance must be positive definite") from exc
+
+
+def _loss_rho(loss: GlobalPositioningResidualLedgerLoss, sq_norm: float) -> np.ndarray:
+    if sq_norm < 0.0 or not np.isfinite(sq_norm):
+        raise ValueError(f"loss input must be finite and non-negative, got {sq_norm}")
+    loss_type = loss.type
+    scale = 1.0 if loss.scale is None else loss.scale
+    weight = 1.0 if loss.weight is None else loss.weight
+    if scale <= 0.0:
+        raise ValueError(f"loss scale must be positive, got {scale}")
+    if weight < 0.0:
+        raise ValueError(f"loss weight must be non-negative, got {weight}")
+
+    if loss_type == "trivial":
+        rho = np.array([sq_norm, 1.0, 0.0], dtype=np.float64)
+    elif loss_type == "huber":
+        threshold = scale * scale
+        if sq_norm <= threshold:
+            rho = np.array([sq_norm, 1.0, 0.0], dtype=np.float64)
+        else:
+            root = math.sqrt(sq_norm)
+            rho = np.array(
+                [
+                    2.0 * scale * root - threshold,
+                    scale / root,
+                    -0.5 * scale / (sq_norm * root),
+                ],
+                dtype=np.float64,
+            )
+    elif loss_type == "soft_l1":
+        z = 1.0 + sq_norm / (scale * scale)
+        root = math.sqrt(z)
+        rho = np.array(
+            [
+                2.0 * scale * scale * (root - 1.0),
+                1.0 / root,
+                -0.5 / (scale * scale * z * root),
+            ],
+            dtype=np.float64,
+        )
+    elif loss_type == "cauchy":
+        z = 1.0 + sq_norm / (scale * scale)
+        rho = np.array(
+            [
+                scale * scale * math.log(z),
+                1.0 / z,
+                -1.0 / (scale * scale * z * z),
+            ],
+            dtype=np.float64,
+        )
+    else:
+        raise ValueError(f"unsupported loss type {loss_type!r}")
+    return weight * rho
+
+
+class _ReplaySnapshotValues:
+    def __init__(self, snapshot: GlobalPositioningParameterSnapshot):
+        self.by_kind = {
+            "frame_center": _snapshot_lookup(snapshot.frame_centers, "frame_centers"),
+            "point3D": _snapshot_lookup(snapshot.points3D, "points3D"),
+            "bata_scale": _snapshot_lookup(snapshot.scales, "scales"),
+            "dmap_scale": _snapshot_lookup(snapshot.dmap_scales, "dmap_scales"),
+            "cam_in_rig": _snapshot_lookup(snapshot.cams_in_rig, "cams_in_rig"),
+        }
+
+    def value(self, block: GlobalPositioningResidualLedgerParameterBlock) -> np.ndarray:
+        if block.kind not in self.by_kind:
+            raise ValueError(f"unsupported parameter block kind {block.kind!r}")
+        values = self.by_kind[block.kind]
+        if block.id not in values:
+            raise KeyError(
+                "snapshot is missing parameter block "
+                f"kind={block.kind!r}, id={block.id}"
+            )
+        value = np.asarray(values[block.id], dtype=np.float64)
+        if value.shape != (block.size,):
+            raise ValueError(
+                f"parameter block kind={block.kind!r}, id={block.id}: "
+                f"expected shape ({block.size},), got {value.shape}"
+            )
+        return value.copy()
+
+
+def _select_replay_ledger_blocks(
+    ledger_blocks: tuple[GlobalPositioningResidualLedgerBlock, ...],
+    residual_ids: str | list[str] | tuple[str, ...] | None,
+) -> tuple[GlobalPositioningResidualLedgerBlock, ...]:
+    if residual_ids is None:
+        return ledger_blocks
+    requested_ids = (
+        (residual_ids,) if isinstance(residual_ids, str) else tuple(residual_ids)
+    )
+    if not requested_ids:
+        raise ValueError("residual_ids must be non-empty when provided")
+    duplicate_ids = sorted(
+        {
+            residual_id
+            for residual_id in requested_ids
+            if requested_ids.count(residual_id) > 1
+        }
+    )
+    if duplicate_ids:
+        raise ValueError(f"residual_ids contains duplicates: {duplicate_ids}")
+
+    by_id = {block.residual_id: block for block in ledger_blocks}
+    missing_ids = [
+        residual_id for residual_id in requested_ids if residual_id not in by_id
+    ]
+    if missing_ids:
+        raise KeyError(f"trace is missing replay residual ids: {missing_ids}")
+    return tuple(by_id[residual_id] for residual_id in requested_ids)
+
+
+class GlobalPositioningTraceReplay:
+    def __init__(
+        self,
+        trace: GlobalPositioningTrace,
+        *,
+        iteration: int,
+        compute_jacobians: bool = False,
+        residual_ids: str | list[str] | tuple[str, ...] | None = None,
+    ):
+        self.trace = trace
+        self.iteration = iteration
+        self.compute_jacobians = compute_jacobians
+        ledger_blocks = trace.residual_ledger_blocks
+        if not ledger_blocks:
+            raise ValueError("trace has no typed residual_ledger_blocks for replay")
+        self.ledger_blocks = _select_replay_ledger_blocks(ledger_blocks, residual_ids)
+        self.snapshot = trace.snapshot(iteration)
+        self.snapshot_values = _ReplaySnapshotValues(self.snapshot)
+
+    def evaluate(self) -> GlobalPositioningReplayEvaluation:
+        raw_residual_blocks = []
+        raw_costs = []
+        robust_costs = []
+        loss_rhos = []
+        residual_ids = []
+        residual_dims = []
+        residual_offsets = []
+        evaluation_success = []
+        parameter_blocks = []
+        jacobian_blocks_by_residual = []
+        scalar_offset = 0
+        jacobian_offset = 0
+
+        for block in self.ledger_blocks:
+            residual = self._evaluate_block(block)
+            if residual.ndim != 1:
+                raise ValueError(
+                    f"residual {block.residual_id}: expected vector residual"
+                )
+            raw_residual_blocks.append(residual)
+            raw_cost = 0.5 * float(residual @ residual)
+            rho = _loss_rho(block.loss, 2.0 * raw_cost)
+
+            residual_ids.append(block.residual_id)
+            residual_dims.append(int(residual.size))
+            residual_offsets.append(scalar_offset)
+            evaluation_success.append(True)
+            raw_costs.append(raw_cost)
+            loss_rhos.append(rho)
+            robust_costs.append(0.5 * float(rho[0]))
+            parameter_blocks.append(block.parameter_blocks)
+            scalar_offset += int(residual.size)
+
+            residual_jacobian_blocks = ()
+            if self.compute_jacobians:
+                finite_diff_blocks = []
+                for parameter_block in block.parameter_blocks:
+                    jacobian = self._finite_difference_jacobian(block, parameter_block)
+                    finite_diff_blocks.append(
+                        GlobalPositioningReplayJacobianBlock(
+                            parameter_block=parameter_block,
+                            offset=jacobian_offset,
+                            residual_dim=int(residual.size),
+                            values=jacobian,
+                        )
+                    )
+                    jacobian_offset += int(residual.size) * parameter_block.size
+                residual_jacobian_blocks = tuple(finite_diff_blocks)
+            jacobian_blocks_by_residual.append(residual_jacobian_blocks)
+
+        raw_residuals = (
+            np.concatenate(raw_residual_blocks)
+            if raw_residual_blocks
+            else np.empty((0,), dtype=np.float64)
+        )
+        return GlobalPositioningReplayEvaluation(
+            iteration=self.iteration,
+            raw_residuals=raw_residuals,
+            raw_costs=np.asarray(raw_costs, dtype=np.float64),
+            loss_rho_values=np.asarray(loss_rhos, dtype=np.float64).reshape((-1, 3)),
+            robust_costs=np.asarray(robust_costs, dtype=np.float64),
+            evaluation_success=tuple(evaluation_success),
+            residual_ids=tuple(residual_ids),
+            residual_dims=tuple(residual_dims),
+            residual_offsets=tuple(residual_offsets),
+            parameter_blocks=tuple(parameter_blocks),
+            raw_jacobians=(
+                tuple(jacobian_blocks_by_residual) if self.compute_jacobians else ()
+            ),
+        )
+
+    def _parameter_values(
+        self,
+        block: GlobalPositioningResidualLedgerBlock,
+        overrides: dict[tuple[str, int], np.ndarray] | None = None,
+    ) -> dict[str, np.ndarray]:
+        values = {}
+        seen_roles = set()
+        overrides = overrides or {}
+        for parameter_block in block.parameter_blocks:
+            if parameter_block.role in seen_roles:
+                raise ValueError(
+                    f"residual {block.residual_id}: duplicate parameter role "
+                    f"{parameter_block.role!r}"
+                )
+            seen_roles.add(parameter_block.role)
+            key = (parameter_block.kind, parameter_block.id)
+            values[parameter_block.role] = (
+                np.asarray(overrides[key], dtype=np.float64).copy()
+                if key in overrides
+                else self.snapshot_values.value(parameter_block)
+            )
+        return values
+
+    def _evaluate_block(
+        self,
+        block: GlobalPositioningResidualLedgerBlock,
+        overrides: dict[tuple[str, int], np.ndarray] | None = None,
+    ) -> np.ndarray:
+        residual_type = _require_str(
+            _require_key(
+                block.attrs,
+                "residual_type",
+                f"residual {block.residual_id} attrs",
+            ),
+            f"residual {block.residual_id} attrs.residual_type",
+        )
+        values = self._parameter_values(block, overrides)
+        fixed = block.fixed_parameters
+
+        if residual_type == "bata_ref_frame":
+            residual = _require_fixed_vector(
+                fixed, "cam_from_point3D_dir", block.residual_id, 3
+            ) - values["bata_scale"][0] * (values["point3D"] - values["frame_center"])
+            if "keypoint_covariance_world_row_major" in fixed:
+                covariance = _require_fixed_vector(
+                    fixed,
+                    "keypoint_covariance_world_row_major",
+                    block.residual_id,
+                    9,
+                ).reshape((3, 3))
+                residual = (
+                    _left_sqrt_information(
+                        covariance,
+                        f"residual {block.residual_id} "
+                        "keypoint_covariance_world_row_major",
+                    )
+                    @ residual
+                )
+            return residual
+
+        if residual_type == "bata_constant_rig":
+            return _require_fixed_vector(
+                fixed, "cam_from_point3D_dir", block.residual_id, 3
+            ) - values["bata_scale"][0] * (
+                values["point3D"]
+                - values["frame_center"]
+                + _require_fixed_vector(fixed, "cam_from_rig_dir", block.residual_id, 3)
+            )
+
+        if residual_type == "bata_variable_rig":
+            world_from_rig = _rotation_matrix_from_quaternion_wxyz(
+                _require_fixed_vector(
+                    fixed, "world_from_rig_rotation_wxyz", block.residual_id, 4
+                ),
+                f"residual {block.residual_id} world_from_rig_rotation_wxyz",
+            )
+            cam_from_rig_translation = world_from_rig @ values["cam_in_rig"]
+            return _require_fixed_vector(
+                fixed, "cam_from_point3D_dir", block.residual_id, 3
+            ) - values["bata_scale"][0] * (
+                values["point3D"] - values["frame_center"] - cam_from_rig_translation
+            )
+
+        if residual_type == "metric_depth":
+            return self._evaluate_metric_depth(block, values)
+
+        if residual_type == "scale_prior":
+            stddev = _require_fixed_float(
+                fixed, "scale_prior_stddev", block.residual_id
+            )
+            if stddev <= 1e-9:
+                raise ValueError(
+                    f"residual {block.residual_id}: "
+                    "scale_prior_stddev must be positive"
+                )
+            target = _require_fixed_float(
+                fixed, "scale_prior_target", block.residual_id
+            )
+            return np.asarray(
+                [(values["dmap_scale"][0] - target) / stddev], dtype=np.float64
+            )
+
+        raise ValueError(f"unsupported residual_type {residual_type!r}")
+
+    def _evaluate_metric_depth(
+        self,
+        block: GlobalPositioningResidualLedgerBlock,
+        values: dict[str, np.ndarray],
+    ) -> np.ndarray:
+        fixed = block.fixed_parameters
+        rotation = _rotation_matrix_from_quaternion_wxyz(
+            _require_fixed_vector(fixed, "camera_rotation_wxyz", block.residual_id, 4),
+            f"residual {block.residual_id} camera_rotation_wxyz",
+        )
+        depth_prior = _coerce_trace_float(
+            _require_key(
+                block.attrs,
+                "depth_prior",
+                f"residual {block.residual_id} attrs",
+            ),
+            f"residual {block.residual_id} attrs.depth_prior",
+        )
+        sigma_depth = _coerce_trace_float(
+            _require_key(
+                block.attrs,
+                "depth_sigma",
+                f"residual {block.residual_id} attrs",
+            ),
+            f"residual {block.residual_id} attrs.depth_sigma",
+        )
+        if depth_prior <= 0.0:
+            raise ValueError(
+                f"residual {block.residual_id}: depth_prior must be positive"
+            )
+        if sigma_depth <= 1e-9:
+            raise ValueError(
+                f"residual {block.residual_id}: depth_sigma must be positive"
+            )
+
+        point_vec_cam = rotation @ (values["point3D"] - values["frame_center"])
+        z_est = float(point_vec_cam[2])
+        use_log_scale = _require_fixed_bool(
+            fixed, "metric_depth_use_log_scale", block.residual_id
+        )
+        dmap_value = float(values["dmap_scale"][0])
+        scale = math.exp(dmap_value) if use_log_scale else dmap_value
+        scaled_prior = scale * depth_prior
+        scaled_sigma = scale * sigma_depth
+
+        if (
+            _require_fixed_bool(
+                fixed, "metric_depth_zero_residual_behind", block.residual_id
+            )
+            and z_est <= 0.0
+        ):
+            return np.asarray([0.0], dtype=np.float64)
+
+        residual_type = _require_str(
+            _require_key(
+                fixed,
+                "metric_depth_residual_type",
+                f"residual {block.residual_id} fixed_parameters",
+            ),
+            f"residual {block.residual_id} "
+            "fixed_parameters.metric_depth_residual_type",
+        )
+        if residual_type != "linear":
+            depth_prior_safe = max(depth_prior, 1e-6)
+            sigma_log = sigma_depth / depth_prior_safe
+            weight_log = 1.0 / max(1e-6, sigma_log)
+            if residual_type == "log_linear":
+                threshold = _require_fixed_float(
+                    fixed,
+                    "metric_depth_log_linear_threshold",
+                    block.residual_id,
+                )
+                if threshold <= 0.0:
+                    raise ValueError(
+                        f"residual {block.residual_id}: "
+                        "metric_depth_log_linear_threshold must be positive"
+                    )
+                scaled_prior_safe = max(scaled_prior, 1e-6)
+                if z_est > threshold:
+                    r_depth = math.log(max(z_est, 1e-6) / scaled_prior_safe)
+                else:
+                    r_depth = (
+                        math.log(threshold / scaled_prior_safe)
+                        + (z_est - threshold) / threshold
+                    )
+                weight = weight_log
+            elif residual_type == "log":
+                if z_est > 0.0:
+                    r_depth = math.log(max(z_est, 1e-6) / max(scaled_prior, 1e-6))
+                    weight = weight_log
+                else:
+                    r_depth = z_est - scaled_prior
+                    weight = 1.0 / max(1e-6, scaled_sigma)
+            else:
+                raise ValueError(
+                    f"unsupported metric_depth_residual_type {residual_type!r}"
+                )
+        else:
+            r_depth = z_est - scaled_prior
+            weight = 1.0 / max(1e-6, scaled_sigma)
+        return np.asarray([weight * r_depth], dtype=np.float64)
+
+    def _finite_difference_jacobian(
+        self,
+        block: GlobalPositioningResidualLedgerBlock,
+        parameter_block: GlobalPositioningResidualLedgerParameterBlock,
+    ) -> np.ndarray:
+        key = (parameter_block.kind, parameter_block.id)
+        base_value = self.snapshot_values.value(parameter_block)
+        base_residual = self._evaluate_block(block)
+        jacobian = np.empty(
+            (base_residual.size, parameter_block.size), dtype=np.float64
+        )
+        for col in range(parameter_block.size):
+            step = 1e-6 * max(1.0, abs(float(base_value[col])))
+            plus = base_value.copy()
+            minus = base_value.copy()
+            plus[col] += step
+            minus[col] -= step
+            plus_residual = self._evaluate_block(block, {key: plus})
+            minus_residual = self._evaluate_block(block, {key: minus})
+            jacobian[:, col] = (plus_residual - minus_residual) / (2.0 * step)
+        return jacobian
+
+
+class _RawBinaryResidualBlock:
+    def __init__(self, residual_values: _RawBinaryResidualValues, index: int):
+        self._residual_values = residual_values
+        self.index = index
+
+    @property
+    def residual_id(self) -> str:
+        return self._residual_values.residual_ids[self.index]
+
+    @property
+    def residual_dim(self) -> int:
+        return self._residual_values.residual_dims[self.index]
+
+    @property
+    def residual_offset(self) -> int:
+        return self._residual_values.residual_offsets[self.index]
+
+    @property
+    def evaluation_success(self) -> bool:
+        return self._residual_values.evaluation_success[self.index]
+
+    @property
+    def raw_residuals(self) -> np.ndarray:
+        begin = self.residual_offset
+        end = begin + self.residual_dim
+        return self._residual_values.raw_residuals[begin:end]
+
+    @property
+    def raw_cost(self) -> float:
+        return float(self._residual_values.raw_costs[self.index])
+
+    @property
+    def robust_cost(self) -> float:
+        return float(self._residual_values.robust_costs[self.index])
+
+    @property
+    def loss_rho(self) -> np.ndarray:
+        return self._residual_values.loss_rho_values[self.index]
+
+    @property
+    def loss_rho0(self) -> float:
+        return float(self.loss_rho[0])
+
+    @property
+    def loss_rho1(self) -> float:
+        return float(self.loss_rho[1])
+
+    @property
+    def loss_rho2(self) -> float:
+        return float(self.loss_rho[2])
+
+    @property
+    def loss_derivative_scale(self) -> float:
+        return self.loss_rho1
+
+    @property
+    def parameter_blocks(self) -> tuple[GlobalPositioningParameterBlock, ...]:
+        if not self._residual_values.has_raw_jacobians:
+            return ()
+        return tuple(self._residual_values.parameter_blocks[self.index])
+
+    @property
+    def jacobian_blocks(self) -> tuple[GlobalPositioningJacobianBlock, ...]:
+        if not self._residual_values.has_raw_jacobians:
+            return ()
+        raw_jacobians = self._residual_values.raw_jacobians
+        if raw_jacobians is None:
+            return ()
+
+        blocks = []
+        for parameter_block, offset in zip(
+            self._residual_values.parameter_blocks[self.index],
+            self._residual_values.raw_jacobian_offsets[self.index],
+            strict=True,
+        ):
+            end = offset + self.residual_dim * parameter_block.size
+            values = raw_jacobians[offset:end].reshape(
+                (self.residual_dim, parameter_block.size)
+            )
+            blocks.append(
+                GlobalPositioningJacobianBlock(
+                    parameter_block, offset, self.residual_dim, values
+                )
+            )
+        return tuple(blocks)
+
+    def jacobian(self, block: int | str, *, id: int | None = None) -> np.ndarray:
+        jacobian_blocks = self.jacobian_blocks
+        if isinstance(block, int):
+            return jacobian_blocks[block].values
+        matches = [
+            item
+            for item in jacobian_blocks
+            if item.parameter_block.role == block
+            and (id is None or item.parameter_block.id == id)
+        ]
+        if len(matches) != 1:
+            raise KeyError(
+                f"Expected exactly one Jacobian block for role={block!r}, "
+                f"id={id!r}; found {len(matches)}"
+            )
+        return matches[0].values
+
+
+class _RawBinaryResidualValues:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        expected_iteration: int | None = None,
+        expected_residual_ids: tuple[str, ...] | None = None,
+    ):
+        self.path = Path(path)
+        self.metadata_path = self.path
+        self.metadata = {
+            "schema_version": 1,
+            "storage_format": _RAW_BINARY_STORAGE_FORMAT,
+            "artifacts": {
+                "residual_values": {
+                    "file": self.path.name,
+                    "dtype": "float64",
+                    "byte_order": "little_endian",
+                }
+            },
+        }
+        with self.path.open("rb") as stream:
+            _read_magic(stream, _RAW_RESIDUAL_VALUES_MAGIC, str(self.path))
+            (version,) = _read_struct(stream, "I", str(self.path))
+            if version == 1:
+                iteration, num_residuals, total_scalar_residuals, has_loss_rho = (
+                    _read_struct(stream, "qQQ?", str(self.path))
+                )
+                has_raw_jacobians = False
+            elif version == 2:
+                (
+                    iteration,
+                    num_residuals,
+                    total_scalar_residuals,
+                    has_loss_rho,
+                    has_raw_jacobians,
+                ) = _read_struct(stream, "qQQ??", str(self.path))
+            else:
+                raise ValueError(
+                    f"{self.path}: unsupported residual-values schema version {version}"
+                )
+            if expected_iteration is not None and iteration != expected_iteration:
+                raise ValueError(
+                    f"{self.path}: iteration {iteration}, expected {expected_iteration}"
+                )
+            self.iteration = int(iteration)
+            self.num_residual_blocks = int(num_residuals)
+            self.total_scalar_residuals = int(total_scalar_residuals)
+            self.has_raw_jacobians = bool(has_raw_jacobians)
+            self.has_loss_rho_values = bool(has_loss_rho)
+            self.residual_ids = []
+            self.residual_dims = []
+            self.residual_offsets = []
+            self.evaluation_success = []
+            for idx in range(self.num_residual_blocks):
+                label = f"{self.path}: residual_values[{idx}]"
+                self.residual_ids.append(
+                    _read_binary_string(stream, f"{label}.residual_id")
+                )
+                residual_dim, residual_offset, success = _read_struct(
+                    stream, "IQ?", label
+                )
+                self.residual_dims.append(int(residual_dim))
+                self.residual_offsets.append(int(residual_offset))
+                self.evaluation_success.append(bool(success))
+
+            self._validate_residual_structure()
+            if (
+                expected_residual_ids is not None
+                and tuple(self.residual_ids) != expected_residual_ids
+            ):
+                raise ValueError(
+                    "raw binary residual_values.residual_ids does not match residual ledger order"
+                )
+            self._residual_id_to_index = {
+                residual_id: idx for idx, residual_id in enumerate(self.residual_ids)
+            }
+
+            raw_residuals = np.frombuffer(
+                _read_exact(
+                    stream,
+                    self.total_scalar_residuals * 8,
+                    f"{self.path}: raw_residuals",
+                ),
+                dtype="<f8",
+            ).copy()
+            raw_costs = np.frombuffer(
+                _read_exact(
+                    stream, self.num_residual_blocks * 8, f"{self.path}: raw_costs"
+                ),
+                dtype="<f8",
+            ).copy()
+            robust_costs = np.frombuffer(
+                _read_exact(
+                    stream, self.num_residual_blocks * 8, f"{self.path}: robust_costs"
+                ),
+                dtype="<f8",
+            ).copy()
+            if self.has_loss_rho_values:
+                loss_rho_values = np.frombuffer(
+                    _read_exact(
+                        stream,
+                        self.num_residual_blocks * 3 * 8,
+                        f"{self.path}: loss_rho_values",
+                    ),
+                    dtype="<f8",
+                ).copy()
+                self._loss_rho_values = loss_rho_values.reshape(
+                    (self.num_residual_blocks, 3)
+                )
+            else:
+                self._loss_rho_values = np.full(
+                    (self.num_residual_blocks, 3), np.nan, dtype=np.float64
+                )
+            self.total_jacobian_scalars = 0
+            self.parameter_blocks: list[list[GlobalPositioningParameterBlock]] = []
+            self.raw_jacobian_offsets: list[list[int]] = []
+            raw_jacobians = None
+            if self.has_raw_jacobians:
+                (total_jacobian_scalars,) = _read_struct(
+                    stream, "Q", f"{self.path}: total_jacobian_scalars"
+                )
+                self.total_jacobian_scalars = int(total_jacobian_scalars)
+                expected_jacobian_offset = 0
+                for residual_idx in range(self.num_residual_blocks):
+                    label = f"{self.path}: residual_values[{residual_idx}].jacobians"
+                    (num_parameter_blocks,) = _read_struct(
+                        stream, "I", f"{label}.num_parameter_blocks"
+                    )
+                    residual_parameter_blocks = []
+                    residual_offsets = []
+                    for block_idx in range(int(num_parameter_blocks)):
+                        block_label = f"{label}.parameter_blocks[{block_idx}]"
+                        role = _read_binary_string(stream, f"{block_label}.role")
+                        kind = _read_binary_string(stream, f"{block_label}.kind")
+                        block_id, block_size, raw_jacobian_offset, is_constant = (
+                            _read_struct(stream, "QIQ?", block_label)
+                        )
+                        block_size = int(block_size)
+                        raw_jacobian_offset = int(raw_jacobian_offset)
+                        if not role:
+                            raise ValueError(f"{block_label}.role must be non-empty")
+                        if not kind:
+                            raise ValueError(f"{block_label}.kind must be non-empty")
+                        if block_size <= 0:
+                            raise ValueError(f"{block_label}.size must be positive")
+                        if raw_jacobian_offset != expected_jacobian_offset:
+                            raise ValueError(
+                                f"{block_label}.raw_jacobian_offset is "
+                                f"{raw_jacobian_offset}, expected "
+                                f"{expected_jacobian_offset}"
+                            )
+                        lower_bounds = np.frombuffer(
+                            _read_exact(
+                                stream,
+                                block_size * 8,
+                                f"{block_label}.lower_bounds",
+                            ),
+                            dtype="<f8",
+                        ).copy()
+                        residual_parameter_blocks.append(
+                            GlobalPositioningParameterBlock(
+                                role=role,
+                                kind=kind,
+                                id=int(block_id),
+                                size=block_size,
+                                is_constant=bool(is_constant),
+                                lower_bounds=tuple(
+                                    float(value) for value in lower_bounds.tolist()
+                                ),
+                            )
+                        )
+                        residual_offsets.append(raw_jacobian_offset)
+                        expected_jacobian_offset += (
+                            self.residual_dims[residual_idx] * block_size
+                        )
+                    self.parameter_blocks.append(residual_parameter_blocks)
+                    self.raw_jacobian_offsets.append(residual_offsets)
+                if expected_jacobian_offset != self.total_jacobian_scalars:
+                    raise ValueError(
+                        f"{self.path}: Jacobian offset sum is "
+                        f"{expected_jacobian_offset}, expected "
+                        f"total_jacobian_scalars {self.total_jacobian_scalars}"
+                    )
+                raw_jacobians = np.frombuffer(
+                    _read_exact(
+                        stream,
+                        self.total_jacobian_scalars * 8,
+                        f"{self.path}: raw_jacobians",
+                    ),
+                    dtype="<f8",
+                ).copy()
+            trailing = stream.read(1)
+            if trailing:
+                raise ValueError(f"{self.path}: unexpected trailing bytes")
+
+        self._raw_residuals = raw_residuals
+        self._raw_costs = raw_costs
+        self._robust_costs = robust_costs
+        self._raw_jacobians = raw_jacobians
+        self.metadata["has_raw_jacobians"] = self.has_raw_jacobians
+        if self.has_raw_jacobians:
+            self.metadata["total_jacobian_scalars"] = self.total_jacobian_scalars
+            self.metadata["parameter_block_sizes"] = [
+                [block.size for block in residual_blocks]
+                for residual_blocks in self.parameter_blocks
+            ]
+            self.metadata["raw_jacobian_offsets"] = self.raw_jacobian_offsets
+            self.metadata["raw_jacobian_layout"] = (
+                "residual_block_major/parameter_block_major/row_major"
+            )
+            self.metadata["jacobian_domain"] = "raw_cost_function_ambient_parameters"
+            self.metadata["loss_applied_to_jacobians"] = False
+            self.metadata["manifold_applied_to_jacobians"] = False
+            self.metadata["constant_parameter_blocks_included"] = True
+        if self.has_loss_rho_values:
+            self._validate_loss_rho_costs()
+
+    def _validate_residual_structure(self) -> None:
+        expected_offset = 0
+        for idx, (residual_id, residual_dim, residual_offset) in enumerate(
+            zip(
+                self.residual_ids,
+                self.residual_dims,
+                self.residual_offsets,
+                strict=True,
+            )
+        ):
+            if not residual_id:
+                raise ValueError(f"{self.path}: residual_ids[{idx}] must be non-empty")
+            if residual_dim < 0:
+                raise ValueError(
+                    f"{self.path}: residual_dims[{idx}] must be non-negative"
+                )
+            if residual_offset != expected_offset:
+                raise ValueError(
+                    f"{self.path}: residual_offsets[{idx}] is {residual_offset}, expected {expected_offset}"
+                )
+            expected_offset += residual_dim
+        if len(set(self.residual_ids)) != len(self.residual_ids):
+            raise ValueError(f"{self.path}: residual_ids must be unique")
+        if expected_offset != self.total_scalar_residuals:
+            raise ValueError(
+                f"{self.path}: sum(residual_dims) is {expected_offset}, "
+                f"expected total_scalar_residuals {self.total_scalar_residuals}"
+            )
+
+    def _validate_loss_rho_costs(self) -> None:
+        success_mask = np.asarray(self.evaluation_success, dtype=bool)
+        if not np.any(success_mask):
+            return
+        expected_robust_costs = 0.5 * self._loss_rho_values[:, 0]
+        matches = np.isclose(
+            self._robust_costs,
+            expected_robust_costs,
+            rtol=1e-10,
+            atol=1e-12,
+            equal_nan=False,
+        )
+        mismatch_mask = success_mask & ~matches
+        if np.any(mismatch_mask):
+            mismatch_idx = int(np.flatnonzero(mismatch_mask)[0])
+            raise ValueError(
+                "robust_costs must equal 0.5 * loss_rho_values[:, 0] "
+                "for successful residual evaluations; mismatch at "
+                f"residual {mismatch_idx} "
+                f"({self.residual_ids[mismatch_idx]!r})"
+            )
+
+    @property
+    def raw_residuals(self) -> np.ndarray:
+        return self._raw_residuals
+
+    @property
+    def raw_costs(self) -> np.ndarray:
+        return self._raw_costs
+
+    @property
+    def robust_costs(self) -> np.ndarray:
+        return self._robust_costs
+
+    @property
+    def loss_rho_values(self) -> np.ndarray:
+        if not self.has_loss_rho_values:
+            raise ValueError(
+                "loss_rho_values artifact is not present in this raw binary trace"
+            )
+        return self._loss_rho_values
+
+    @property
+    def raw_jacobians(self) -> np.ndarray | None:
+        return self._raw_jacobians
+
+    def residual(self, residual: int | str) -> _RawBinaryResidualBlock:
+        if isinstance(residual, str):
+            try:
+                residual = self._residual_id_to_index[residual]
+            except KeyError as exc:
+                raise KeyError(f"Unknown residual id {residual!r}") from exc
+        if residual < 0 or residual >= self.num_residual_blocks:
+            raise IndexError(f"Residual index {residual} out of range")
+        return _RawBinaryResidualBlock(self, residual)
+
+
+def _read_raw_snapshot_array(
+    path: Path,
+    *,
+    expected_name: str,
+    max_rows: int | None = None,
+) -> GlobalPositioningSnapshotArray:
+    with path.open("rb") as stream:
+        _read_magic(stream, _RAW_ARRAY_MAGIC, str(path))
+        version, rows, cols = _read_struct(stream, "IQQ", str(path))
+        if version != 1:
+            raise ValueError(f"{path}: unsupported array schema version {version}")
+        name = _read_binary_string(stream, f"{path}: name")
+        if name != expected_name:
+            raise ValueError(f"{path}: array name {name!r}, expected {expected_name!r}")
+        ids = np.frombuffer(
+            _read_exact(stream, rows * 8, f"{path}: ids"), dtype="<i8"
+        ).copy()
+        values = np.frombuffer(
+            _read_exact(stream, rows * cols * 8, f"{path}: values"), dtype="<f8"
+        ).copy()
+        trailing = stream.read(1)
+        if trailing:
+            raise ValueError(f"{path}: unexpected trailing bytes")
+    shape = (int(rows), int(cols)) if cols != 1 else (int(rows),)
+    values = values.reshape(shape)
+    ids_tuple = tuple(int(item) for item in ids.tolist())
+    if max_rows is not None:
+        row_count = min(max_rows, shape[0])
+        values = values[:row_count]
+        ids_tuple = ids_tuple[:row_count]
+        shape = (row_count, *shape[1:])
+    return GlobalPositioningSnapshotArray(ids=ids_tuple, shape=shape, values=values)
+
+
+class _RawBinaryGlobalPositioningTrace:
+    def __init__(self, path: Path, manifest: dict[str, Any]):
+        self.path = Path(path)
+        self.manifest = manifest
+        self._validate_manifest()
+        self._iterations = self._parse_iterations()
+        self._residual_blocks = self._read_residual_blocks()
+        self.residual_blocks = list(self._residual_blocks)
+        self.residual_skips: list[dict[str, Any]] = []
+        self._residual_ledger_blocks: (
+            tuple[GlobalPositioningResidualLedgerBlock, ...] | None
+        ) = None
+
+    def _validate_manifest(self) -> None:
+        schema_version = _require_int(
+            _require_key(
+                self.manifest, "schema_version", str(self.path / "manifest.json")
+            ),
+            "schema_version",
+        )
+        if schema_version != 1:
+            raise ValueError(
+                f"{self.path / 'manifest.json'}: unsupported schema_version {schema_version}"
+            )
+        storage_format = _require_str(
+            _require_key(
+                self.manifest, "storage_format", str(self.path / "manifest.json")
+            ),
+            "storage_format",
+        )
+        if storage_format != _RAW_BINARY_STORAGE_FORMAT:
+            raise ValueError(
+                f"{self.path / 'manifest.json'}: unsupported storage_format {storage_format!r}"
+            )
+        byte_order = _require_str(
+            _require_key(self.manifest, "byte_order", str(self.path / "manifest.json")),
+            "byte_order",
+        )
+        if byte_order != "little_endian":
+            raise ValueError(
+                f"{self.path / 'manifest.json'}: byte_order must be little_endian"
+            )
+        dtype = _require_str(
+            _require_key(self.manifest, "dtype", str(self.path / "manifest.json")),
+            "dtype",
+        )
+        if dtype != "float64":
+            raise ValueError(f"{self.path / 'manifest.json'}: dtype must be float64")
+
+    def _parse_iterations(self) -> dict[int, dict[str, Any]]:
+        iterations = _require_key(
+            self.manifest, "iterations", str(self.path / "manifest.json")
+        )
+        if not isinstance(iterations, list):
+            raise TypeError(f"{self.path / 'manifest.json'}: iterations must be a list")
+        parsed = {}
+        for idx, item in enumerate(iterations):
+            if not isinstance(item, dict):
+                raise TypeError(
+                    f"{self.path / 'manifest.json'}: iterations[{idx}] must be an object"
+                )
+            iteration = _require_int(
+                _require_key(item, "iteration", "iteration"), "iteration"
+            )
+            if iteration < 0:
+                raise ValueError(
+                    f"{self.path / 'manifest.json'}: iterations[{idx}].iteration must be non-negative"
+                )
+            if iteration in parsed:
+                raise ValueError(
+                    f"{self.path / 'manifest.json'}: duplicate iteration {iteration}"
+                )
+            directory = _require_str(
+                _require_key(item, "directory", "iteration"), "directory"
+            )
+            relative = Path(directory)
+            item = dict(item)
+            item["_directory_relative_path"] = relative
+            item["_directory_path"] = _resolve_raw_trace_path(
+                self.path,
+                relative,
+                f"{self.path / 'manifest.json'}: iterations[{idx}].directory",
+            )
+            parsed[iteration] = item
+        return parsed
+
+    def _read_residual_blocks(self) -> tuple[dict[str, Any], ...]:
+        static = _require_key(self.manifest, "static", str(self.path / "manifest.json"))
+        if not isinstance(static, dict):
+            raise TypeError(f"{self.path / 'manifest.json'}: static must be an object")
+        ledger_name = _require_str(
+            _require_key(static, "residual_ledger", "static"), "static.residual_ledger"
+        )
+        ledger_relative_path = Path(ledger_name)
+        ledger_path = _resolve_raw_trace_path(
+            self.path,
+            ledger_relative_path,
+            f"{self.path / 'manifest.json'}: static.residual_ledger",
+        )
+        with ledger_path.open("rb") as stream:
+            _read_magic(stream, _RAW_LEDGER_MAGIC, str(ledger_path))
+            version, count = _read_struct(stream, "IQ", str(ledger_path))
+            if version != 1:
+                raise ValueError(
+                    f"{ledger_path}: unsupported residual ledger schema version {version}"
+                )
+            records = []
+            for idx in range(count):
+                label = f"{ledger_path}: residual_ledger[{idx}]"
+                residual_id = _read_binary_string(stream, f"{label}.residual_id")
+                residual_type = _read_binary_string(stream, f"{label}.residual_type")
+                loss_bucket = _read_binary_string(stream, f"{label}.loss_bucket")
+                frame_id, image_id, point3D_id, is_lc_observation = _read_struct(
+                    stream, "qqq?", label
+                )
+                attrs = _read_binary_json(stream, f"{label}.attrs")
+                attrs.update(
+                    {
+                        "residual_id": residual_id,
+                        "residual_type": residual_type,
+                        "loss_bucket": loss_bucket,
+                        "frame_id": (
+                            None if frame_id == _RAW_NONE_ID else int(frame_id)
+                        ),
+                        "image_id": (
+                            None if image_id == _RAW_NONE_ID else int(image_id)
+                        ),
+                        "point3D_id": (
+                            None if point3D_id == _RAW_NONE_ID else int(point3D_id)
+                        ),
+                        "is_lc_observation": bool(is_lc_observation),
+                    }
+                )
+                records.append(
+                    {
+                        "event_type": "residual_added",
+                        "stage": "problem_build",
+                        "attrs": attrs,
+                    }
+                )
+            trailing = stream.read(1)
+            if trailing:
+                raise ValueError(f"{ledger_path}: unexpected trailing bytes")
+        return tuple(records)
+
+    def raw_binary_artifact_paths(self) -> tuple[Path, ...]:
+        paths = [_resolve_raw_trace_path(self.path, Path("manifest.json"), "manifest")]
+        static = self.manifest.get("static")
+        if isinstance(static, dict):
+            ledger_name = static.get("residual_ledger")
+            if isinstance(ledger_name, str):
+                paths.append(
+                    _resolve_raw_trace_path(
+                        self.path,
+                        Path(ledger_name),
+                        "static.residual_ledger",
+                    )
+                )
+        for iteration, metadata in sorted(self._iterations.items()):
+            directory = metadata["_directory_relative_path"]
+            for key in (
+                "frame_centers",
+                "point_xyz",
+                "scales",
+                "dmap_scales",
+                "cams_in_rig",
+                "residual_values",
+                "jacobians",
+            ):
+                filename = metadata.get(key)
+                if isinstance(filename, str):
+                    paths.append(
+                        _resolve_raw_trace_path(
+                            self.path,
+                            directory / filename,
+                            f"iterations[{iteration}].{key}",
+                        )
+                    )
+        return tuple(paths)
+
+    @property
+    def status(self) -> str:
+        return _require_str(
+            _require_key(self.manifest, "status", str(self.path / "manifest.json")),
+            "status",
+        )
+
+    @property
+    def trace_level(self) -> str:
+        return _require_str(
+            _require_key(
+                self.manifest, "trace_level", str(self.path / "manifest.json")
+            ),
+            "trace_level",
+        )
+
+    @property
+    def residual_value_iterations(self) -> tuple[int, ...]:
+        return tuple(
+            sorted(
+                iteration
+                for iteration, metadata in self._iterations.items()
+                if "residual_values" in metadata
+            )
+        )
+
+    @property
+    def snapshot_iterations(self) -> tuple[int, ...]:
+        return tuple(
+            sorted(
+                iteration
+                for iteration, metadata in self._iterations.items()
+                if "frame_centers" in metadata and "point_xyz" in metadata
+            )
+        )
+
+    @property
+    def events(self) -> tuple[GlobalPositioningTraceEvent, ...]:
+        return ()
+
+    @property
+    def solver_events(self) -> tuple[GlobalPositioningTraceEvent, ...]:
+        return ()
+
+    @property
+    def iteration_metrics(self) -> tuple[GlobalPositioningIterationMetric, ...]:
+        return ()
+
+    @property
+    def iteration_metrics_by_iteration(
+        self,
+    ) -> dict[int, GlobalPositioningIterationMetric]:
+        return {}
+
+    @property
+    def residual_ledger_blocks(
+        self,
+    ) -> tuple[GlobalPositioningResidualLedgerBlock, ...]:
+        if self._residual_ledger_blocks is None:
+            blocks = []
+            for idx, record in enumerate(self.residual_blocks):
+                block = _parse_residual_ledger_block(record, idx)
+                if block is not None:
+                    blocks.append(block)
+            self._residual_ledger_blocks = tuple(blocks)
+        return self._residual_ledger_blocks
+
+    def _iteration_file(self, iteration: int, key: str) -> Path:
+        if iteration not in self._iterations:
+            raise KeyError(f"Trace has no iteration {iteration}")
+        metadata = self._iterations[iteration]
+        if key not in metadata:
+            raise KeyError(f"Trace iteration {iteration} has no {key}")
+        filename = _require_str(metadata[key], f"iterations[{iteration}].{key}")
+        relative = Path(filename)
+        if (
+            relative.is_absolute()
+            or relative.name != filename
+            or ".." in relative.parts
+        ):
+            raise ValueError(f"iterations[{iteration}].{key}: expected bare filename")
+        return _resolve_raw_trace_path(
+            self.path,
+            metadata["_directory_relative_path"] / relative,
+            f"iterations[{iteration}].{key}",
+        )
+
+    def residual_values(self, iteration: int | None = None) -> _RawBinaryResidualValues:
+        if iteration is None:
+            iterations = self.residual_value_iterations
+            if len(iterations) != 1:
+                raise ValueError(
+                    f"Trace has {len(iterations)} residual-value iterations; pass iteration explicitly"
+                )
+            iteration = iterations[0]
+        return _RawBinaryResidualValues(
+            self._iteration_file(iteration, "residual_values"),
+            expected_iteration=iteration,
+            expected_residual_ids=self._ledger_residual_ids(),
+        )
+
+    def _ledger_residual_ids(self) -> tuple[str, ...] | None:
+        if not self.residual_blocks:
+            return None
+        return tuple(
+            _require_str(
+                _require_key(
+                    _require_key(record, "attrs", f"residual_blocks[{idx}]"),
+                    "residual_id",
+                    f"residual_blocks[{idx}].attrs",
+                ),
+                f"residual_blocks[{idx}].attrs.residual_id",
+            )
+            for idx, record in enumerate(self.residual_blocks)
+        )
+
+    def snapshot(
+        self, iteration: int, max_points: int | None = None
+    ) -> GlobalPositioningParameterSnapshot:
+        max_points = _normalize_max_points(max_points)
+        metadata = self._iterations[iteration]
+        frame_centers = _read_raw_snapshot_array(
+            self._iteration_file(iteration, "frame_centers"),
+            expected_name="frame_centers",
+        )
+        points3D = _read_raw_snapshot_array(
+            self._iteration_file(iteration, "point_xyz"),
+            expected_name="point_xyz",
+            max_rows=max_points,
+        )
+        scales = (
+            _read_raw_snapshot_array(
+                self._iteration_file(iteration, "scales"), expected_name="scales"
+            )
+            if "scales" in metadata
+            else _empty_snapshot_array()
+        )
+        dmap_scales = (
+            _read_raw_snapshot_array(
+                self._iteration_file(iteration, "dmap_scales"),
+                expected_name="dmap_scales",
+            )
+            if "dmap_scales" in metadata
+            else None
+        )
+        cams_in_rig = (
+            _read_raw_snapshot_array(
+                self._iteration_file(iteration, "cams_in_rig"),
+                expected_name="cams_in_rig",
+            )
+            if "cams_in_rig" in metadata
+            else None
+        )
+        return GlobalPositioningParameterSnapshot(
+            metadata_path=self.path / "manifest.json",
+            metadata=self.manifest,
+            iteration=iteration,
+            frame_centers=frame_centers,
+            points3D=points3D,
+            scales=scales,
+            dmap_scales=dmap_scales,
+            cams_in_rig=cams_in_rig,
+        )
+
+    def replay(
+        self,
+        iteration: int,
+        *,
+        compute_jacobians: bool = False,
+        residual_ids: str | list[str] | tuple[str, ...] | None = None,
+    ) -> GlobalPositioningReplayEvaluation:
+        return GlobalPositioningTraceReplay(
+            self,
+            iteration=iteration,
+            compute_jacobians=compute_jacobians,
+            residual_ids=residual_ids,
+        ).evaluate()
+
+
 class GlobalPositioningTrace:
     def __init__(self, path: Path):
         self.path = Path(path)
         self.manifest = _load_json(self.path / "manifest.json")
-        self.residual_blocks = self._read_optional_jsonl(
-            "residual_blocks.jsonl"
+        expected_run_id = self._manifest_run_id()
+        self._events = _read_optional_trace_events(
+            self.path,
+            "events.jsonl",
+            expected_run_id=expected_run_id,
         )
+        self._iteration_metrics = _read_optional_iteration_metrics(
+            self.path,
+            "iteration_metrics.jsonl",
+            expected_run_id=expected_run_id,
+        )
+        self._iteration_metrics_by_iteration = {
+            metric.iteration: metric for metric in self._iteration_metrics
+        }
+        self.residual_blocks = self._read_optional_jsonl("residual_blocks.jsonl")
         self.residual_skips = self._read_optional_jsonl("residual_skips.jsonl")
         self._residual_values_by_iteration = _discover_iteration_metadata(
             self.path / "residual_values"
@@ -1218,10 +3003,19 @@ class GlobalPositioningTrace:
         self._snapshots_by_iteration = _discover_iteration_metadata(
             self.path / "snapshots"
         )
+        self._residual_ledger_blocks: (
+            tuple[GlobalPositioningResidualLedgerBlock, ...] | None
+        ) = None
 
     @classmethod
-    def load(cls, path: str | Path) -> GlobalPositioningTrace:
-        return cls(Path(path))
+    def load(
+        cls, path: str | Path
+    ) -> GlobalPositioningTrace | _RawBinaryGlobalPositioningTrace:
+        path = Path(path)
+        manifest = _load_json(path / "manifest.json")
+        if manifest.get("storage_format") == _RAW_BINARY_STORAGE_FORMAT:
+            return _RawBinaryGlobalPositioningTrace(path, manifest)
+        return cls(path)
 
     def _read_optional_jsonl(self, filename: str) -> list[dict[str, Any]]:
         path = self.path / filename
@@ -1236,14 +3030,10 @@ class GlobalPositioningTrace:
         for idx, record in enumerate(self.residual_blocks):
             attrs = _require_key(record, "attrs", f"residual_blocks[{idx}]")
             if not isinstance(attrs, dict):
-                raise TypeError(
-                    f"residual_blocks[{idx}].attrs must be an object"
-                )
+                raise TypeError(f"residual_blocks[{idx}].attrs must be an object")
             residual_ids.append(
                 _require_str(
-                    _require_key(
-                        attrs, "residual_id", f"residual_blocks[{idx}].attrs"
-                    ),
+                    _require_key(attrs, "residual_id", f"residual_blocks[{idx}].attrs"),
                     f"residual_blocks[{idx}].attrs.residual_id",
                 )
             )
@@ -1252,16 +3042,12 @@ class GlobalPositioningTrace:
     def _manifest_run_id(self) -> str | None:
         if "run_id" not in self.manifest:
             return None
-        return _require_str(
-            self.manifest["run_id"], str(self.path / "manifest.json")
-        )
+        return _require_str(self.manifest["run_id"], str(self.path / "manifest.json"))
 
     @property
     def status(self) -> str:
         return _require_str(
-            _require_key(
-                self.manifest, "status", str(self.path / "manifest.json")
-            ),
+            _require_key(self.manifest, "status", str(self.path / "manifest.json")),
             "status",
         )
 
@@ -1282,6 +3068,39 @@ class GlobalPositioningTrace:
     def snapshot_iterations(self) -> tuple[int, ...]:
         return tuple(sorted(self._snapshots_by_iteration))
 
+    @property
+    def events(self) -> tuple[GlobalPositioningTraceEvent, ...]:
+        return self._events
+
+    @property
+    def solver_events(self) -> tuple[GlobalPositioningTraceEvent, ...]:
+        return tuple(event for event in self._events if event.stage == "ceres_solve")
+
+    @property
+    def iteration_metrics(
+        self,
+    ) -> tuple[GlobalPositioningIterationMetric, ...]:
+        return self._iteration_metrics
+
+    @property
+    def iteration_metrics_by_iteration(
+        self,
+    ) -> dict[int, GlobalPositioningIterationMetric]:
+        return dict(self._iteration_metrics_by_iteration)
+
+    @property
+    def residual_ledger_blocks(
+        self,
+    ) -> tuple[GlobalPositioningResidualLedgerBlock, ...]:
+        if self._residual_ledger_blocks is None:
+            blocks = []
+            for idx, record in enumerate(self.residual_blocks):
+                block = _parse_residual_ledger_block(record, idx)
+                if block is not None:
+                    blocks.append(block)
+            self._residual_ledger_blocks = tuple(blocks)
+        return self._residual_ledger_blocks
+
     def residual_values(
         self, iteration: int | None = None
     ) -> GlobalPositioningResidualValues:
@@ -1294,9 +3113,7 @@ class GlobalPositioningTrace:
                 )
             iteration = iterations[0]
         if iteration not in self._residual_values_by_iteration:
-            raise KeyError(
-                f"Trace has no residual values for iteration {iteration}"
-            )
+            raise KeyError(f"Trace has no residual values for iteration {iteration}")
         return GlobalPositioningResidualValues(
             self._residual_values_by_iteration[iteration],
             expected_iteration=iteration,
@@ -1308,12 +3125,24 @@ class GlobalPositioningTrace:
         self, iteration: int, max_points: int | None = None
     ) -> GlobalPositioningParameterSnapshot:
         if iteration not in self._snapshots_by_iteration:
-            raise KeyError(
-                f"Trace has no parameter snapshot for iteration {iteration}"
-            )
+            raise KeyError(f"Trace has no parameter snapshot for iteration {iteration}")
         return GlobalPositioningParameterSnapshotLoader(
             self._snapshots_by_iteration[iteration],
             expected_iteration=iteration,
             expected_run_id=self._manifest_run_id(),
             max_points=max_points,
         ).load()
+
+    def replay(
+        self,
+        iteration: int,
+        *,
+        compute_jacobians: bool = False,
+        residual_ids: str | list[str] | tuple[str, ...] | None = None,
+    ) -> GlobalPositioningReplayEvaluation:
+        return GlobalPositioningTraceReplay(
+            self,
+            iteration=iteration,
+            compute_jacobians=compute_jacobians,
+            residual_ids=residual_ids,
+        ).evaluate()

--- a/python/pycolmap/global_positioning_trace.py
+++ b/python/pycolmap/global_positioning_trace.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import struct
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +16,22 @@ _RAW_ARRAY_MAGIC = b"GPTRARR1"
 _RAW_RESIDUAL_VALUES_MAGIC = b"GPTRRSV1"
 _RAW_ENDIAN = "<"
 _RAW_NONE_ID = -1
+_HEAVY_RAW_LOAD_ENV = "PYCOLMAP_GP_TRACE_ALLOW_HEAVY_LOAD"
+_RAW_LOAD_MAX_RECORDS_ENV = "PYCOLMAP_GP_TRACE_MAX_EAGER_RAW_RECORDS"
+_DEFAULT_MAX_EAGER_RAW_RECORDS = 250_000
+
+
+def _max_eager_raw_records() -> int:
+    value = os.environ.get(_RAW_LOAD_MAX_RECORDS_ENV)
+    if value is None:
+        return _DEFAULT_MAX_EAGER_RAW_RECORDS
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{_RAW_LOAD_MAX_RECORDS_ENV} must be an integer") from exc
+    if parsed < 0:
+        raise ValueError(f"{_RAW_LOAD_MAX_RECORDS_ENV} must be non-negative")
+    return parsed
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -49,6 +66,138 @@ def _read_binary_json(stream: Any, label: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"{label}: expected encoded JSON object")
     return value
+
+
+def _read_binary_optional_double(stream: Any, label: str) -> float | None:
+    (has_value,) = _read_struct(stream, "?", label)
+    if not has_value:
+        return None
+    (value,) = _read_struct(stream, "d", label)
+    return float(value)
+
+
+def _read_binary_optional_bool(stream: Any, label: str) -> bool | None:
+    (has_value,) = _read_struct(stream, "?", label)
+    if not has_value:
+        return None
+    (value,) = _read_struct(stream, "?", label)
+    return bool(value)
+
+
+def _read_binary_optional_string(stream: Any, label: str) -> str | None:
+    (has_value,) = _read_struct(stream, "?", label)
+    if not has_value:
+        return None
+    return _read_binary_string(stream, label)
+
+
+def _read_binary_optional_double_array(stream: Any, label: str) -> list[float] | None:
+    (has_value,) = _read_struct(stream, "?", label)
+    if not has_value:
+        return None
+    (count,) = _read_struct(stream, "I", f"{label}.count")
+    return [float(_read_struct(stream, "d", f"{label}[{idx}]")[0]) for idx in range(count)]
+
+
+def _read_binary_parameter_block(stream: Any, label: str) -> dict[str, Any]:
+    role = _read_binary_string(stream, f"{label}.role")
+    kind = _read_binary_string(stream, f"{label}.kind")
+    (block_id,) = _read_struct(stream, "Q", f"{label}.id")
+    (has_size,) = _read_struct(stream, "?", f"{label}.has_size")
+    descriptor = {"role": role, "kind": kind, "id": int(block_id)}
+    if has_size:
+        (size,) = _read_struct(stream, "Q", f"{label}.size")
+        descriptor["size"] = int(size)
+    return descriptor
+
+
+def _read_binary_loss_config(stream: Any, label: str) -> dict[str, Any]:
+    loss = {
+        "bucket": _read_binary_string(stream, f"{label}.bucket"),
+        "type": _read_binary_string(stream, f"{label}.type"),
+        "scale": _read_binary_optional_double(stream, f"{label}.scale"),
+        "weight": _read_binary_optional_double(stream, f"{label}.weight"),
+        "source": _read_binary_string(stream, f"{label}.source"),
+    }
+    observation_count_weight = _read_binary_optional_double(stream, f"{label}.observation_count_weight")
+    if observation_count_weight is not None:
+        loss["observation_count_weight"] = observation_count_weight
+    return loss
+
+
+def _read_binary_fixed_parameters(stream: Any, label: str) -> dict[str, Any]:
+    fixed_parameters: dict[str, Any] = {}
+    for key in (
+        "cam_from_point3D_dir",
+        "keypoint_covariance_world_row_major",
+        "cam_from_rig_dir",
+        "rig_from_world_rotation_wxyz",
+        "world_from_rig_rotation_wxyz",
+        "camera_rotation_wxyz",
+    ):
+        value = _read_binary_optional_double_array(stream, f"{label}.{key}")
+        if value is not None:
+            fixed_parameters[key] = value
+    value = _read_binary_optional_bool(stream, f"{label}.metric_depth_use_log_scale")
+    if value is not None:
+        fixed_parameters["metric_depth_use_log_scale"] = value
+    value = _read_binary_optional_string(stream, f"{label}.metric_depth_residual_type")
+    if value is not None:
+        fixed_parameters["metric_depth_residual_type"] = value
+    value = _read_binary_optional_bool(stream, f"{label}.metric_depth_zero_residual_behind")
+    if value is not None:
+        fixed_parameters["metric_depth_zero_residual_behind"] = value
+    for key in (
+        "metric_depth_log_linear_threshold",
+        "scale_prior_target",
+        "scale_prior_stddev",
+    ):
+        value = _read_binary_optional_double(stream, f"{label}.{key}")
+        if value is not None:
+            fixed_parameters[key] = value
+    return fixed_parameters
+
+
+def _read_binary_trace_value(stream: Any, label: str) -> Any:
+    (value_type,) = _read_struct(stream, "B", f"{label}.type")
+    if value_type == 0:
+        return None
+    if value_type == 1:
+        (value,) = _read_struct(stream, "?", label)
+        return bool(value)
+    if value_type == 2:
+        (value,) = _read_struct(stream, "q", label)
+        return int(value)
+    if value_type == 3:
+        (value,) = _read_struct(stream, "Q", label)
+        return int(value)
+    if value_type == 4:
+        (value,) = _read_struct(stream, "d", label)
+        return float(value)
+    if value_type == 5:
+        return _read_binary_string(stream, label)
+    if value_type == 6:
+        (count,) = _read_struct(stream, "I", f"{label}.count")
+        return [_read_binary_string(stream, f"{label}[{idx}]") for idx in range(count)]
+    if value_type == 7:
+        (count,) = _read_struct(stream, "I", f"{label}.count")
+        return [_read_binary_parameter_block(stream, f"{label}[{idx}]") for idx in range(count)]
+    if value_type == 8:
+        return _read_binary_loss_config(stream, label)
+    if value_type == 9:
+        return _read_binary_fixed_parameters(stream, label)
+    raise ValueError(f"{label}: unsupported trace value type {value_type}")
+
+
+def _read_binary_trace_attrs(stream: Any, label: str) -> dict[str, Any]:
+    (count,) = _read_struct(stream, "I", f"{label}.count")
+    attrs = {}
+    for idx in range(count):
+        key = _read_binary_string(stream, f"{label}[{idx}].key")
+        if key in attrs:
+            raise ValueError(f"{label}: duplicate attr key {key!r}")
+        attrs[key] = _read_binary_trace_value(stream, f"{label}.{key}")
+    return attrs
 
 
 def _read_magic(stream: Any, expected: bytes, label: str) -> None:
@@ -137,17 +286,13 @@ def _require_str_list(value: Any, label: str) -> list[str]:
 def _require_nested_int_list(value: Any, label: str) -> list[list[int]]:
     if not isinstance(value, list):
         raise TypeError(f"{label}: expected list")
-    return [
-        _require_int_list(item, f"{label}[{idx}]") for idx, item in enumerate(value)
-    ]
+    return [_require_int_list(item, f"{label}[{idx}]") for idx, item in enumerate(value)]
 
 
 def _require_nested_bool_list(value: Any, label: str) -> list[list[bool]]:
     if not isinstance(value, list):
         raise TypeError(f"{label}: expected list")
-    return [
-        _require_bool_list(item, f"{label}[{idx}]") for idx, item in enumerate(value)
-    ]
+    return [_require_bool_list(item, f"{label}[{idx}]") for idx, item in enumerate(value)]
 
 
 def _coerce_trace_float(value: Any, label: str) -> float:
@@ -222,18 +367,14 @@ def _validate_trace_metadata(
         f"{metadata_path}: schema_version",
     )
     if schema_version != 1:
-        raise ValueError(
-            f"{metadata_path}: unsupported schema_version {schema_version}"
-        )
+        raise ValueError(f"{metadata_path}: unsupported schema_version {schema_version}")
 
     run_id = _require_str(
         _require_key(metadata, "run_id", str(metadata_path)),
         f"{metadata_path}: run_id",
     )
     if expected_run_id is not None and run_id != expected_run_id:
-        raise ValueError(
-            f"{metadata_path}: run_id {run_id!r}, expected {expected_run_id!r}"
-        )
+        raise ValueError(f"{metadata_path}: run_id {run_id!r}, expected {expected_run_id!r}")
 
     iteration = _require_int(
         _require_key(metadata, "iteration", str(metadata_path)),
@@ -242,9 +383,7 @@ def _validate_trace_metadata(
     if iteration < 0:
         raise ValueError(f"{metadata_path}: iteration must be non-negative")
     if expected_iteration is not None and iteration != expected_iteration:
-        raise ValueError(
-            f"{metadata_path}: iteration {iteration}, " f"expected {expected_iteration}"
-        )
+        raise ValueError(f"{metadata_path}: iteration {iteration}, " f"expected {expected_iteration}")
 
     dtype = _require_str(
         _require_key(metadata, "dtype", str(metadata_path)),
@@ -312,10 +451,7 @@ def _resolve_float64_artifact(
         or "/" in filename
         or "\\" in filename
     ):
-        raise ValueError(
-            f"{metadata_path}: artifacts.{name}.file must be a bare relative "
-            "filename"
-        )
+        raise ValueError(f"{metadata_path}: artifacts.{name}.file must be a bare relative " "filename")
     dtype = _require_str(
         _require_key(artifact, "dtype", f"{metadata_path}: artifacts.{name}"),
         f"{metadata_path}: artifacts.{name}.dtype",
@@ -327,18 +463,13 @@ def _resolve_float64_artifact(
     if dtype != "float64":
         raise ValueError(f"{metadata_path}: artifacts.{name}.dtype must be float64")
     if byte_order != "little_endian":
-        raise ValueError(
-            f"{metadata_path}: artifacts.{name}.byte_order must be " "little_endian"
-        )
+        raise ValueError(f"{metadata_path}: artifacts.{name}.byte_order must be " "little_endian")
     shape = _require_shape(
         _require_key(artifact, "shape", f"{metadata_path}: artifacts.{name}"),
         f"{metadata_path}: artifacts.{name}.shape",
     )
     if expected_shape is not None and shape != expected_shape:
-        raise ValueError(
-            f"{metadata_path}: artifacts.{name}.shape is {shape}, "
-            f"expected {expected_shape}"
-        )
+        raise ValueError(f"{metadata_path}: artifacts.{name}.shape is {shape}, " f"expected {expected_shape}")
 
     ids = None
     if expected_ids is not None or "ids" in artifact:
@@ -349,13 +480,10 @@ def _resolve_float64_artifact(
             )
         )
         if expected_ids is not None and ids != expected_ids:
-            raise ValueError(
-                f"{metadata_path}: artifacts.{name}.ids does not match " "top-level IDs"
-            )
+            raise ValueError(f"{metadata_path}: artifacts.{name}.ids does not match " "top-level IDs")
         if shape[0] != len(ids):
             raise ValueError(
-                f"{metadata_path}: artifacts.{name}.shape has {shape[0]} "
-                f"rows, expected {len(ids)} artifact IDs"
+                f"{metadata_path}: artifacts.{name}.shape has {shape[0]} " f"rows, expected {len(ids)} artifact IDs"
             )
 
     element_count = _shape_element_count(shape)
@@ -365,9 +493,7 @@ def _resolve_float64_artifact(
     try:
         resolved_path.relative_to(metadata_dir)
     except ValueError as exc:
-        raise ValueError(
-            f"{metadata_path}: artifacts.{name}.file escapes metadata directory"
-        ) from exc
+        raise ValueError(f"{metadata_path}: artifacts.{name}.file escapes metadata directory") from exc
     expected_size = element_count * 8
     actual_size = path.stat().st_size
     if actual_size != expected_size:
@@ -395,15 +521,11 @@ def _discover_iteration_metadata(directory: Path) -> dict[int, Path]:
         expected_name = f"iter_{iteration:06d}.json"
         if metadata_path.name != expected_name:
             raise ValueError(
-                f"{metadata_path}: filename does not match metadata "
-                f"iteration; expected {expected_name}"
+                f"{metadata_path}: filename does not match metadata " f"iteration; expected {expected_name}"
             )
         if iteration in metadata_by_iteration:
             previous = metadata_by_iteration[iteration]
-            raise ValueError(
-                f"Duplicate trace iteration {iteration}: "
-                f"{previous} and {metadata_path}"
-            )
+            raise ValueError(f"Duplicate trace iteration {iteration}: " f"{previous} and {metadata_path}")
         metadata_by_iteration[iteration] = metadata_path
     return metadata_by_iteration
 
@@ -558,9 +680,7 @@ class GlobalPositioningReplayEvaluation:
     residual_ids: tuple[str, ...]
     residual_dims: tuple[int, ...]
     residual_offsets: tuple[int, ...]
-    parameter_blocks: tuple[
-        tuple[GlobalPositioningResidualLedgerParameterBlock, ...], ...
-    ]
+    parameter_blocks: tuple[tuple[GlobalPositioningResidualLedgerParameterBlock, ...], ...]
     raw_jacobians: tuple[tuple[GlobalPositioningReplayJacobianBlock, ...], ...] = ()
 
     @property
@@ -672,14 +792,8 @@ class GlobalPositioningResidualBlock:
             strict=True,
         ):
             end = offset + self.residual_dim * parameter_block.size
-            values = raw_jacobians[offset:end].reshape(
-                (self.residual_dim, parameter_block.size)
-            )
-            blocks.append(
-                GlobalPositioningJacobianBlock(
-                    parameter_block, offset, self.residual_dim, values
-                )
-            )
+            values = raw_jacobians[offset:end].reshape((self.residual_dim, parameter_block.size))
+            blocks.append(GlobalPositioningJacobianBlock(parameter_block, offset, self.residual_dim, values))
         return tuple(blocks)
 
     def jacobian(self, block: int | str, *, id: int | None = None) -> np.ndarray:
@@ -689,13 +803,11 @@ class GlobalPositioningResidualBlock:
         matches = [
             item
             for item in jacobian_blocks
-            if item.parameter_block.role == block
-            and (id is None or item.parameter_block.id == id)
+            if item.parameter_block.role == block and (id is None or item.parameter_block.id == id)
         ]
         if len(matches) != 1:
             raise KeyError(
-                f"Expected exactly one Jacobian block for role={block!r}, "
-                f"id={id!r}; found {len(matches)}"
+                f"Expected exactly one Jacobian block for role={block!r}, " f"id={id!r}; found {len(matches)}"
             )
         return matches[0].values
 
@@ -722,9 +834,7 @@ class GlobalPositioningResidualValues:
             "num_residual_blocks",
         )
         self.total_scalar_residuals = _require_int(
-            _require_key(
-                self.metadata, "total_scalar_residuals", str(self.metadata_path)
-            ),
+            _require_key(self.metadata, "total_scalar_residuals", str(self.metadata_path)),
             "total_scalar_residuals",
         )
         self.residual_ids = _require_str_list(
@@ -744,21 +854,13 @@ class GlobalPositioningResidualValues:
             "evaluation_success",
         )
         self._validate_residual_structure()
-        if (
-            expected_residual_ids is not None
-            and tuple(self.residual_ids) != expected_residual_ids
-        ):
-            raise ValueError(
-                "residual_values.residual_ids does not match "
-                "residual_blocks.jsonl order"
-            )
+        if expected_residual_ids is not None and tuple(self.residual_ids) != expected_residual_ids:
+            raise ValueError("residual_values.residual_ids does not match " "residual_blocks.jsonl order")
         self.has_raw_jacobians = _require_bool(
             _require_key(self.metadata, "has_raw_jacobians", str(self.metadata_path)),
             "has_raw_jacobians",
         )
-        self._residual_id_to_index = {
-            residual_id: idx for idx, residual_id in enumerate(self.residual_ids)
-        }
+        self._residual_id_to_index = {residual_id: idx for idx, residual_id in enumerate(self.residual_ids)}
 
         raw_residuals_artifact = _resolve_float64_artifact(
             self.metadata_path,
@@ -824,9 +926,7 @@ class GlobalPositioningResidualValues:
                 ),
                 "raw_jacobian_offsets",
             )
-            parameter_block_descriptors = _require_key(
-                self.metadata, "parameter_blocks", str(self.metadata_path)
-            )
+            parameter_block_descriptors = _require_key(self.metadata, "parameter_blocks", str(self.metadata_path))
             parameter_block_is_constant = _require_nested_bool_list(
                 _require_key(
                     self.metadata,
@@ -878,9 +978,7 @@ class GlobalPositioningResidualValues:
             "loss_rho_layout",
         )
         if loss_rho_layout != "residual_block_major/rho0_rho1_rho2":
-            raise ValueError(
-                "loss_rho_layout must be 'residual_block_major/rho0_rho1_rho2'"
-            )
+            raise ValueError("loss_rho_layout must be 'residual_block_major/rho0_rho1_rho2'")
 
     def _validate_loss_rho_costs(self) -> None:
         if self._loss_rho_costs_validated:
@@ -930,22 +1028,14 @@ class GlobalPositioningResidualValues:
             ),
             "raw_jacobian_layout",
         )
-        if (
-            raw_jacobian_layout
-            != "residual_block_major/parameter_block_major/row_major"
-        ):
-            raise ValueError(
-                "raw_jacobian_layout must be "
-                "'residual_block_major/parameter_block_major/row_major'"
-            )
+        if raw_jacobian_layout != "residual_block_major/parameter_block_major/row_major":
+            raise ValueError("raw_jacobian_layout must be " "'residual_block_major/parameter_block_major/row_major'")
         jacobian_domain = _require_str(
             _require_key(self.metadata, "jacobian_domain", str(self.metadata_path)),
             "jacobian_domain",
         )
         if jacobian_domain != "raw_cost_function_ambient_parameters":
-            raise ValueError(
-                "jacobian_domain must be 'raw_cost_function_ambient_parameters'"
-            )
+            raise ValueError("jacobian_domain must be 'raw_cost_function_ambient_parameters'")
         for field_name in [
             "loss_applied_to_jacobians",
             "manifold_applied_to_jacobians",
@@ -974,10 +1064,7 @@ class GlobalPositioningResidualValues:
             ("evaluation_success", self.evaluation_success),
         ]:
             if len(values) != self.num_residual_blocks:
-                raise ValueError(
-                    f"{name}: length {len(values)}, "
-                    f"expected {self.num_residual_blocks}"
-                )
+                raise ValueError(f"{name}: length {len(values)}, " f"expected {self.num_residual_blocks}")
         if len(set(self.residual_ids)) != len(self.residual_ids):
             raise ValueError("residual_ids must be unique")
 
@@ -989,8 +1076,7 @@ class GlobalPositioningResidualValues:
                 raise ValueError(f"residual_dims[{residual_idx}] must be non-negative")
             if residual_offset != expected_offset:
                 raise ValueError(
-                    f"residual_offsets[{residual_idx}] is {residual_offset}, "
-                    f"expected {expected_offset}"
+                    f"residual_offsets[{residual_idx}] is {residual_offset}, " f"expected {expected_offset}"
                 )
             expected_offset += residual_dim
         if expected_offset != self.total_scalar_residuals:
@@ -1019,10 +1105,7 @@ class GlobalPositioningResidualValues:
             ("parameter_blocks", descriptors),
         ]:
             if len(values) != self.num_residual_blocks:
-                raise ValueError(
-                    f"{name}: outer length {len(values)}, "
-                    f"expected {self.num_residual_blocks}"
-                )
+                raise ValueError(f"{name}: outer length {len(values)}, " f"expected {self.num_residual_blocks}")
 
         expected_offset = 0
         for residual_idx in range(self.num_residual_blocks):
@@ -1035,15 +1118,11 @@ class GlobalPositioningResidualValues:
             ]:
                 if len(values[residual_idx]) != block_count:
                     raise ValueError(
-                        f"{name}[{residual_idx}]: length "
-                        f"{len(values[residual_idx])}, expected {block_count}"
+                        f"{name}[{residual_idx}]: length " f"{len(values[residual_idx])}, expected {block_count}"
                     )
             for block_idx, block_size in enumerate(sizes[residual_idx]):
                 if block_size <= 0:
-                    raise ValueError(
-                        f"parameter_block_sizes[{residual_idx}][{block_idx}] "
-                        "must be positive"
-                    )
+                    raise ValueError(f"parameter_block_sizes[{residual_idx}][{block_idx}] " "must be positive")
                 if len(lower_bounds[residual_idx][block_idx]) != block_size:
                     raise ValueError(
                         f"parameter_block_lower_bounds[{residual_idx}]"
@@ -1080,19 +1159,10 @@ class GlobalPositioningResidualValues:
             residual_blocks = []
             for block_idx, descriptor in enumerate(residual_descriptors):
                 if not isinstance(descriptor, dict):
-                    raise TypeError(
-                        f"parameter_blocks[{residual_idx}][{block_idx}]: "
-                        "expected object"
-                    )
-                role = _require_str(
-                    _require_key(descriptor, "role", "parameter_block"), "role"
-                )
-                kind = _require_str(
-                    _require_key(descriptor, "kind", "parameter_block"), "kind"
-                )
-                block_id = _require_int(
-                    _require_key(descriptor, "id", "parameter_block"), "id"
-                )
+                    raise TypeError(f"parameter_blocks[{residual_idx}][{block_idx}]: " "expected object")
+                role = _require_str(_require_key(descriptor, "role", "parameter_block"), "role")
+                kind = _require_str(_require_key(descriptor, "kind", "parameter_block"), "kind")
+                block_id = _require_int(_require_key(descriptor, "id", "parameter_block"), "id")
                 residual_blocks.append(
                     GlobalPositioningParameterBlock(
                         role=role,
@@ -1175,10 +1245,7 @@ def _require_top_level_ids_and_shape(
         f"{metadata_path}: {shape_key}",
     )
     if shape[0] != len(ids):
-        raise ValueError(
-            f"{metadata_path}: {shape_key} has {shape[0]} rows, "
-            f"expected {len(ids)} {ids_key}"
-        )
+        raise ValueError(f"{metadata_path}: {shape_key} has {shape[0]} rows, " f"expected {len(ids)} {ids_key}")
     return ids, shape
 
 
@@ -1197,10 +1264,7 @@ def _normalize_max_points(max_points: int | None) -> int | None:
     if max_points is None or max_points == -1:
         return None
     if not isinstance(max_points, int) or isinstance(max_points, bool):
-        raise TypeError(
-            f"max_points: expected int, None, or -1; "
-            f"got {type(max_points).__name__}"
-        )
+        raise TypeError(f"max_points: expected int, None, or -1; " f"got {type(max_points).__name__}")
     if max_points < -1:
         raise ValueError(f"max_points must be >= -1 or None, got {max_points}")
     return max_points
@@ -1415,33 +1479,24 @@ def _parse_ledger_loss(value: Any, label: str) -> GlobalPositioningResidualLedge
     return GlobalPositioningResidualLedgerLoss(
         bucket=_require_str(_require_key(value, "bucket", label), f"{label}.bucket"),
         type=_require_str(_require_key(value, "type", label), f"{label}.type"),
-        scale=_coerce_optional_trace_float(
-            _require_key(value, "scale", label), f"{label}.scale"
-        ),
-        weight=_coerce_optional_trace_float(
-            _require_key(value, "weight", label), f"{label}.weight"
-        ),
+        scale=_coerce_optional_trace_float(_require_key(value, "scale", label), f"{label}.scale"),
+        weight=_coerce_optional_trace_float(_require_key(value, "weight", label), f"{label}.weight"),
         source=_require_str(_require_key(value, "source", label), f"{label}.source"),
         observation_count_weight=observation_count_weight,
     )
 
 
-def _parse_residual_ledger_block(
-    record: dict[str, Any], idx: int
-) -> GlobalPositioningResidualLedgerBlock | None:
+def _parse_residual_ledger_block(record: dict[str, Any], idx: int) -> GlobalPositioningResidualLedgerBlock | None:
     label = f"residual_blocks[{idx}]"
     attrs = _require_key(record, "attrs", label)
     if not isinstance(attrs, dict):
         raise TypeError(f"{label}.attrs must be an object")
     if "replay_schema_version" not in attrs:
         return None
-    replay_schema_version = _require_int(
-        attrs["replay_schema_version"], f"{label}.attrs.replay_schema_version"
-    )
+    replay_schema_version = _require_int(attrs["replay_schema_version"], f"{label}.attrs.replay_schema_version")
     if replay_schema_version != 1:
         raise ValueError(
-            f"{label}.attrs.replay_schema_version: unsupported "
-            f"replay_schema_version {replay_schema_version}"
+            f"{label}.attrs.replay_schema_version: unsupported " f"replay_schema_version {replay_schema_version}"
         )
 
     fixed_parameters_status = _require_str(
@@ -1457,9 +1512,7 @@ def _parse_residual_ledger_block(
     if not isinstance(fixed_parameters, dict):
         raise TypeError(f"{label}.attrs.fixed_parameters must be an object")
 
-    event_type = _require_str(
-        _require_key(record, "event_type", label), f"{label}.event_type"
-    )
+    event_type = _require_str(_require_key(record, "event_type", label), f"{label}.event_type")
     return GlobalPositioningResidualLedgerBlock(
         residual_id=_require_str(
             _require_key(attrs, "residual_id", f"{label}.attrs"),
@@ -1543,9 +1596,7 @@ def _parse_iteration_metric_record(
     )
     label = f"{path}:{idx + 1}"
     if event.event_type != "ceres_iteration":
-        raise ValueError(
-            f"{label}.event_type must be 'ceres_iteration', got {event.event_type!r}"
-        )
+        raise ValueError(f"{label}.event_type must be 'ceres_iteration', got {event.event_type!r}")
     if event.iteration is None:
         raise ValueError(f"{label}.iteration must not be null")
     attrs = event.attrs
@@ -1557,9 +1608,7 @@ def _parse_iteration_metric_record(
         raise ValueError(f"{label}.attrs.linear_solver_iterations must be non-negative")
     gradient_norm = None
     if "gradient_norm" in attrs:
-        gradient_norm = _coerce_trace_float(
-            attrs["gradient_norm"], f"{label}.attrs.gradient_norm"
-        )
+        gradient_norm = _coerce_trace_float(attrs["gradient_norm"], f"{label}.attrs.gradient_norm")
     return GlobalPositioningIterationMetric(
         schema_version=event.schema_version,
         run_id=event.run_id,
@@ -1572,9 +1621,7 @@ def _parse_iteration_metric_record(
             _require_key(attrs, "step_is_successful", f"{label}.attrs"),
             f"{label}.attrs.step_is_successful",
         ),
-        cost=_coerce_trace_float(
-            _require_key(attrs, "cost", f"{label}.attrs"), f"{label}.attrs.cost"
-        ),
+        cost=_coerce_trace_float(_require_key(attrs, "cost", f"{label}.attrs"), f"{label}.attrs.cost"),
         cost_change=_coerce_trace_float(
             _require_key(attrs, "cost_change", f"{label}.attrs"),
             f"{label}.attrs.cost_change",
@@ -1657,17 +1704,12 @@ def _require_float_vector(value: Any, label: str, size: int) -> np.ndarray:
     if len(value) != size:
         raise ValueError(f"{label}: expected length {size}, got {len(value)}")
     return np.asarray(
-        [
-            _coerce_trace_float(item, f"{label}[{idx}]")
-            for idx, item in enumerate(value)
-        ],
+        [_coerce_trace_float(item, f"{label}[{idx}]") for idx, item in enumerate(value)],
         dtype=np.float64,
     )
 
 
-def _require_fixed_vector(
-    fixed_parameters: dict[str, Any], key: str, residual_id: str, size: int
-) -> np.ndarray:
+def _require_fixed_vector(fixed_parameters: dict[str, Any], key: str, residual_id: str, size: int) -> np.ndarray:
     return _require_float_vector(
         _require_key(fixed_parameters, key, f"residual {residual_id} fixed_parameters"),
         f"residual {residual_id} fixed_parameters.{key}",
@@ -1675,18 +1717,14 @@ def _require_fixed_vector(
     )
 
 
-def _require_fixed_float(
-    fixed_parameters: dict[str, Any], key: str, residual_id: str
-) -> float:
+def _require_fixed_float(fixed_parameters: dict[str, Any], key: str, residual_id: str) -> float:
     return _coerce_trace_float(
         _require_key(fixed_parameters, key, f"residual {residual_id} fixed_parameters"),
         f"residual {residual_id} fixed_parameters.{key}",
     )
 
 
-def _require_fixed_bool(
-    fixed_parameters: dict[str, Any], key: str, residual_id: str
-) -> bool:
+def _require_fixed_bool(fixed_parameters: dict[str, Any], key: str, residual_id: str) -> bool:
     return _require_bool(
         _require_key(fixed_parameters, key, f"residual {residual_id} fixed_parameters"),
         f"residual {residual_id} fixed_parameters.{key}",
@@ -1813,10 +1851,7 @@ class _ReplaySnapshotValues:
             raise ValueError(f"unsupported parameter block kind {block.kind!r}")
         values = self.by_kind[block.kind]
         if block.id not in values:
-            raise KeyError(
-                "snapshot is missing parameter block "
-                f"kind={block.kind!r}, id={block.id}"
-            )
+            raise KeyError("snapshot is missing parameter block " f"kind={block.kind!r}, id={block.id}")
         value = np.asarray(values[block.id], dtype=np.float64)
         if value.shape != (block.size,):
             raise ValueError(
@@ -1832,25 +1867,15 @@ def _select_replay_ledger_blocks(
 ) -> tuple[GlobalPositioningResidualLedgerBlock, ...]:
     if residual_ids is None:
         return ledger_blocks
-    requested_ids = (
-        (residual_ids,) if isinstance(residual_ids, str) else tuple(residual_ids)
-    )
+    requested_ids = (residual_ids,) if isinstance(residual_ids, str) else tuple(residual_ids)
     if not requested_ids:
         raise ValueError("residual_ids must be non-empty when provided")
-    duplicate_ids = sorted(
-        {
-            residual_id
-            for residual_id in requested_ids
-            if requested_ids.count(residual_id) > 1
-        }
-    )
+    duplicate_ids = sorted({residual_id for residual_id in requested_ids if requested_ids.count(residual_id) > 1})
     if duplicate_ids:
         raise ValueError(f"residual_ids contains duplicates: {duplicate_ids}")
 
     by_id = {block.residual_id: block for block in ledger_blocks}
-    missing_ids = [
-        residual_id for residual_id in requested_ids if residual_id not in by_id
-    ]
+    missing_ids = [residual_id for residual_id in requested_ids if residual_id not in by_id]
     if missing_ids:
         raise KeyError(f"trace is missing replay residual ids: {missing_ids}")
     return tuple(by_id[residual_id] for residual_id in requested_ids)
@@ -1892,9 +1917,7 @@ class GlobalPositioningTraceReplay:
         for block in self.ledger_blocks:
             residual = self._evaluate_block(block)
             if residual.ndim != 1:
-                raise ValueError(
-                    f"residual {block.residual_id}: expected vector residual"
-                )
+                raise ValueError(f"residual {block.residual_id}: expected vector residual")
             raw_residual_blocks.append(residual)
             raw_cost = 0.5 * float(residual @ residual)
             rho = _loss_rho(block.loss, 2.0 * raw_cost)
@@ -1927,9 +1950,7 @@ class GlobalPositioningTraceReplay:
             jacobian_blocks_by_residual.append(residual_jacobian_blocks)
 
         raw_residuals = (
-            np.concatenate(raw_residual_blocks)
-            if raw_residual_blocks
-            else np.empty((0,), dtype=np.float64)
+            np.concatenate(raw_residual_blocks) if raw_residual_blocks else np.empty((0,), dtype=np.float64)
         )
         return GlobalPositioningReplayEvaluation(
             iteration=self.iteration,
@@ -1942,9 +1963,7 @@ class GlobalPositioningTraceReplay:
             residual_dims=tuple(residual_dims),
             residual_offsets=tuple(residual_offsets),
             parameter_blocks=tuple(parameter_blocks),
-            raw_jacobians=(
-                tuple(jacobian_blocks_by_residual) if self.compute_jacobians else ()
-            ),
+            raw_jacobians=(tuple(jacobian_blocks_by_residual) if self.compute_jacobians else ()),
         )
 
     def _parameter_values(
@@ -1958,8 +1977,7 @@ class GlobalPositioningTraceReplay:
         for parameter_block in block.parameter_blocks:
             if parameter_block.role in seen_roles:
                 raise ValueError(
-                    f"residual {block.residual_id}: duplicate parameter role "
-                    f"{parameter_block.role!r}"
+                    f"residual {block.residual_id}: duplicate parameter role " f"{parameter_block.role!r}"
                 )
             seen_roles.add(parameter_block.role)
             key = (parameter_block.kind, parameter_block.id)
@@ -1987,9 +2005,9 @@ class GlobalPositioningTraceReplay:
         fixed = block.fixed_parameters
 
         if residual_type == "bata_ref_frame":
-            residual = _require_fixed_vector(
-                fixed, "cam_from_point3D_dir", block.residual_id, 3
-            ) - values["bata_scale"][0] * (values["point3D"] - values["frame_center"])
+            residual = _require_fixed_vector(fixed, "cam_from_point3D_dir", block.residual_id, 3) - values[
+                "bata_scale"
+            ][0] * (values["point3D"] - values["frame_center"])
             if "keypoint_covariance_world_row_major" in fixed:
                 covariance = _require_fixed_vector(
                     fixed,
@@ -2000,17 +2018,16 @@ class GlobalPositioningTraceReplay:
                 residual = (
                     _left_sqrt_information(
                         covariance,
-                        f"residual {block.residual_id} "
-                        "keypoint_covariance_world_row_major",
+                        f"residual {block.residual_id} " "keypoint_covariance_world_row_major",
                     )
                     @ residual
                 )
             return residual
 
         if residual_type == "bata_constant_rig":
-            return _require_fixed_vector(
-                fixed, "cam_from_point3D_dir", block.residual_id, 3
-            ) - values["bata_scale"][0] * (
+            return _require_fixed_vector(fixed, "cam_from_point3D_dir", block.residual_id, 3) - values["bata_scale"][
+                0
+            ] * (
                 values["point3D"]
                 - values["frame_center"]
                 + _require_fixed_vector(fixed, "cam_from_rig_dir", block.residual_id, 3)
@@ -2018,36 +2035,23 @@ class GlobalPositioningTraceReplay:
 
         if residual_type == "bata_variable_rig":
             world_from_rig = _rotation_matrix_from_quaternion_wxyz(
-                _require_fixed_vector(
-                    fixed, "world_from_rig_rotation_wxyz", block.residual_id, 4
-                ),
+                _require_fixed_vector(fixed, "world_from_rig_rotation_wxyz", block.residual_id, 4),
                 f"residual {block.residual_id} world_from_rig_rotation_wxyz",
             )
             cam_from_rig_translation = world_from_rig @ values["cam_in_rig"]
-            return _require_fixed_vector(
-                fixed, "cam_from_point3D_dir", block.residual_id, 3
-            ) - values["bata_scale"][0] * (
-                values["point3D"] - values["frame_center"] - cam_from_rig_translation
-            )
+            return _require_fixed_vector(fixed, "cam_from_point3D_dir", block.residual_id, 3) - values["bata_scale"][
+                0
+            ] * (values["point3D"] - values["frame_center"] - cam_from_rig_translation)
 
         if residual_type == "metric_depth":
             return self._evaluate_metric_depth(block, values)
 
         if residual_type == "scale_prior":
-            stddev = _require_fixed_float(
-                fixed, "scale_prior_stddev", block.residual_id
-            )
+            stddev = _require_fixed_float(fixed, "scale_prior_stddev", block.residual_id)
             if stddev <= 1e-9:
-                raise ValueError(
-                    f"residual {block.residual_id}: "
-                    "scale_prior_stddev must be positive"
-                )
-            target = _require_fixed_float(
-                fixed, "scale_prior_target", block.residual_id
-            )
-            return np.asarray(
-                [(values["dmap_scale"][0] - target) / stddev], dtype=np.float64
-            )
+                raise ValueError(f"residual {block.residual_id}: " "scale_prior_stddev must be positive")
+            target = _require_fixed_float(fixed, "scale_prior_target", block.residual_id)
+            return np.asarray([(values["dmap_scale"][0] - target) / stddev], dtype=np.float64)
 
         raise ValueError(f"unsupported residual_type {residual_type!r}")
 
@@ -2078,30 +2082,19 @@ class GlobalPositioningTraceReplay:
             f"residual {block.residual_id} attrs.depth_sigma",
         )
         if depth_prior <= 0.0:
-            raise ValueError(
-                f"residual {block.residual_id}: depth_prior must be positive"
-            )
+            raise ValueError(f"residual {block.residual_id}: depth_prior must be positive")
         if sigma_depth <= 1e-9:
-            raise ValueError(
-                f"residual {block.residual_id}: depth_sigma must be positive"
-            )
+            raise ValueError(f"residual {block.residual_id}: depth_sigma must be positive")
 
         point_vec_cam = rotation @ (values["point3D"] - values["frame_center"])
         z_est = float(point_vec_cam[2])
-        use_log_scale = _require_fixed_bool(
-            fixed, "metric_depth_use_log_scale", block.residual_id
-        )
+        use_log_scale = _require_fixed_bool(fixed, "metric_depth_use_log_scale", block.residual_id)
         dmap_value = float(values["dmap_scale"][0])
         scale = math.exp(dmap_value) if use_log_scale else dmap_value
         scaled_prior = scale * depth_prior
         scaled_sigma = scale * sigma_depth
 
-        if (
-            _require_fixed_bool(
-                fixed, "metric_depth_zero_residual_behind", block.residual_id
-            )
-            and z_est <= 0.0
-        ):
+        if _require_fixed_bool(fixed, "metric_depth_zero_residual_behind", block.residual_id) and z_est <= 0.0:
             return np.asarray([0.0], dtype=np.float64)
 
         residual_type = _require_str(
@@ -2110,8 +2103,7 @@ class GlobalPositioningTraceReplay:
                 "metric_depth_residual_type",
                 f"residual {block.residual_id} fixed_parameters",
             ),
-            f"residual {block.residual_id} "
-            "fixed_parameters.metric_depth_residual_type",
+            f"residual {block.residual_id} " "fixed_parameters.metric_depth_residual_type",
         )
         if residual_type != "linear":
             depth_prior_safe = max(depth_prior, 1e-6)
@@ -2125,17 +2117,13 @@ class GlobalPositioningTraceReplay:
                 )
                 if threshold <= 0.0:
                     raise ValueError(
-                        f"residual {block.residual_id}: "
-                        "metric_depth_log_linear_threshold must be positive"
+                        f"residual {block.residual_id}: " "metric_depth_log_linear_threshold must be positive"
                     )
                 scaled_prior_safe = max(scaled_prior, 1e-6)
                 if z_est > threshold:
                     r_depth = math.log(max(z_est, 1e-6) / scaled_prior_safe)
                 else:
-                    r_depth = (
-                        math.log(threshold / scaled_prior_safe)
-                        + (z_est - threshold) / threshold
-                    )
+                    r_depth = math.log(threshold / scaled_prior_safe) + (z_est - threshold) / threshold
                 weight = weight_log
             elif residual_type == "log":
                 if z_est > 0.0:
@@ -2145,9 +2133,7 @@ class GlobalPositioningTraceReplay:
                     r_depth = z_est - scaled_prior
                     weight = 1.0 / max(1e-6, scaled_sigma)
             else:
-                raise ValueError(
-                    f"unsupported metric_depth_residual_type {residual_type!r}"
-                )
+                raise ValueError(f"unsupported metric_depth_residual_type {residual_type!r}")
         else:
             r_depth = z_est - scaled_prior
             weight = 1.0 / max(1e-6, scaled_sigma)
@@ -2161,9 +2147,7 @@ class GlobalPositioningTraceReplay:
         key = (parameter_block.kind, parameter_block.id)
         base_value = self.snapshot_values.value(parameter_block)
         base_residual = self._evaluate_block(block)
-        jacobian = np.empty(
-            (base_residual.size, parameter_block.size), dtype=np.float64
-        )
+        jacobian = np.empty((base_residual.size, parameter_block.size), dtype=np.float64)
         for col in range(parameter_block.size):
             step = 1e-6 * max(1.0, abs(float(base_value[col])))
             plus = base_value.copy()
@@ -2252,14 +2236,8 @@ class _RawBinaryResidualBlock:
             strict=True,
         ):
             end = offset + self.residual_dim * parameter_block.size
-            values = raw_jacobians[offset:end].reshape(
-                (self.residual_dim, parameter_block.size)
-            )
-            blocks.append(
-                GlobalPositioningJacobianBlock(
-                    parameter_block, offset, self.residual_dim, values
-                )
-            )
+            values = raw_jacobians[offset:end].reshape((self.residual_dim, parameter_block.size))
+            blocks.append(GlobalPositioningJacobianBlock(parameter_block, offset, self.residual_dim, values))
         return tuple(blocks)
 
     def jacobian(self, block: int | str, *, id: int | None = None) -> np.ndarray:
@@ -2269,13 +2247,11 @@ class _RawBinaryResidualBlock:
         matches = [
             item
             for item in jacobian_blocks
-            if item.parameter_block.role == block
-            and (id is None or item.parameter_block.id == id)
+            if item.parameter_block.role == block and (id is None or item.parameter_block.id == id)
         ]
         if len(matches) != 1:
             raise KeyError(
-                f"Expected exactly one Jacobian block for role={block!r}, "
-                f"id={id!r}; found {len(matches)}"
+                f"Expected exactly one Jacobian block for role={block!r}, " f"id={id!r}; found {len(matches)}"
             )
         return matches[0].values
 
@@ -2305,8 +2281,8 @@ class _RawBinaryResidualValues:
             _read_magic(stream, _RAW_RESIDUAL_VALUES_MAGIC, str(self.path))
             (version,) = _read_struct(stream, "I", str(self.path))
             if version == 1:
-                iteration, num_residuals, total_scalar_residuals, has_loss_rho = (
-                    _read_struct(stream, "qQQ?", str(self.path))
+                iteration, num_residuals, total_scalar_residuals, has_loss_rho = _read_struct(
+                    stream, "qQQ?", str(self.path)
                 )
                 has_raw_jacobians = False
             elif version == 2:
@@ -2318,13 +2294,9 @@ class _RawBinaryResidualValues:
                     has_raw_jacobians,
                 ) = _read_struct(stream, "qQQ??", str(self.path))
             else:
-                raise ValueError(
-                    f"{self.path}: unsupported residual-values schema version {version}"
-                )
+                raise ValueError(f"{self.path}: unsupported residual-values schema version {version}")
             if expected_iteration is not None and iteration != expected_iteration:
-                raise ValueError(
-                    f"{self.path}: iteration {iteration}, expected {expected_iteration}"
-                )
+                raise ValueError(f"{self.path}: iteration {iteration}, expected {expected_iteration}")
             self.iteration = int(iteration)
             self.num_residual_blocks = int(num_residuals)
             self.total_scalar_residuals = int(total_scalar_residuals)
@@ -2336,27 +2308,16 @@ class _RawBinaryResidualValues:
             self.evaluation_success = []
             for idx in range(self.num_residual_blocks):
                 label = f"{self.path}: residual_values[{idx}]"
-                self.residual_ids.append(
-                    _read_binary_string(stream, f"{label}.residual_id")
-                )
-                residual_dim, residual_offset, success = _read_struct(
-                    stream, "IQ?", label
-                )
+                self.residual_ids.append(_read_binary_string(stream, f"{label}.residual_id"))
+                residual_dim, residual_offset, success = _read_struct(stream, "IQ?", label)
                 self.residual_dims.append(int(residual_dim))
                 self.residual_offsets.append(int(residual_offset))
                 self.evaluation_success.append(bool(success))
 
             self._validate_residual_structure()
-            if (
-                expected_residual_ids is not None
-                and tuple(self.residual_ids) != expected_residual_ids
-            ):
-                raise ValueError(
-                    "raw binary residual_values.residual_ids does not match residual ledger order"
-                )
-            self._residual_id_to_index = {
-                residual_id: idx for idx, residual_id in enumerate(self.residual_ids)
-            }
+            if expected_residual_ids is not None and tuple(self.residual_ids) != expected_residual_ids:
+                raise ValueError("raw binary residual_values.residual_ids does not match residual ledger order")
+            self._residual_id_to_index = {residual_id: idx for idx, residual_id in enumerate(self.residual_ids)}
 
             raw_residuals = np.frombuffer(
                 _read_exact(
@@ -2367,15 +2328,11 @@ class _RawBinaryResidualValues:
                 dtype="<f8",
             ).copy()
             raw_costs = np.frombuffer(
-                _read_exact(
-                    stream, self.num_residual_blocks * 8, f"{self.path}: raw_costs"
-                ),
+                _read_exact(stream, self.num_residual_blocks * 8, f"{self.path}: raw_costs"),
                 dtype="<f8",
             ).copy()
             robust_costs = np.frombuffer(
-                _read_exact(
-                    stream, self.num_residual_blocks * 8, f"{self.path}: robust_costs"
-                ),
+                _read_exact(stream, self.num_residual_blocks * 8, f"{self.path}: robust_costs"),
                 dtype="<f8",
             ).copy()
             if self.has_loss_rho_values:
@@ -2387,36 +2344,28 @@ class _RawBinaryResidualValues:
                     ),
                     dtype="<f8",
                 ).copy()
-                self._loss_rho_values = loss_rho_values.reshape(
-                    (self.num_residual_blocks, 3)
-                )
+                self._loss_rho_values = loss_rho_values.reshape((self.num_residual_blocks, 3))
             else:
-                self._loss_rho_values = np.full(
-                    (self.num_residual_blocks, 3), np.nan, dtype=np.float64
-                )
+                self._loss_rho_values = np.full((self.num_residual_blocks, 3), np.nan, dtype=np.float64)
             self.total_jacobian_scalars = 0
             self.parameter_blocks: list[list[GlobalPositioningParameterBlock]] = []
             self.raw_jacobian_offsets: list[list[int]] = []
             raw_jacobians = None
             if self.has_raw_jacobians:
-                (total_jacobian_scalars,) = _read_struct(
-                    stream, "Q", f"{self.path}: total_jacobian_scalars"
-                )
+                (total_jacobian_scalars,) = _read_struct(stream, "Q", f"{self.path}: total_jacobian_scalars")
                 self.total_jacobian_scalars = int(total_jacobian_scalars)
                 expected_jacobian_offset = 0
                 for residual_idx in range(self.num_residual_blocks):
                     label = f"{self.path}: residual_values[{residual_idx}].jacobians"
-                    (num_parameter_blocks,) = _read_struct(
-                        stream, "I", f"{label}.num_parameter_blocks"
-                    )
+                    (num_parameter_blocks,) = _read_struct(stream, "I", f"{label}.num_parameter_blocks")
                     residual_parameter_blocks = []
                     residual_offsets = []
                     for block_idx in range(int(num_parameter_blocks)):
                         block_label = f"{label}.parameter_blocks[{block_idx}]"
                         role = _read_binary_string(stream, f"{block_label}.role")
                         kind = _read_binary_string(stream, f"{block_label}.kind")
-                        block_id, block_size, raw_jacobian_offset, is_constant = (
-                            _read_struct(stream, "QIQ?", block_label)
+                        block_id, block_size, raw_jacobian_offset, is_constant = _read_struct(
+                            stream, "QIQ?", block_label
                         )
                         block_size = int(block_size)
                         raw_jacobian_offset = int(raw_jacobian_offset)
@@ -2447,15 +2396,11 @@ class _RawBinaryResidualValues:
                                 id=int(block_id),
                                 size=block_size,
                                 is_constant=bool(is_constant),
-                                lower_bounds=tuple(
-                                    float(value) for value in lower_bounds.tolist()
-                                ),
+                                lower_bounds=tuple(float(value) for value in lower_bounds.tolist()),
                             )
                         )
                         residual_offsets.append(raw_jacobian_offset)
-                        expected_jacobian_offset += (
-                            self.residual_dims[residual_idx] * block_size
-                        )
+                        expected_jacobian_offset += self.residual_dims[residual_idx] * block_size
                     self.parameter_blocks.append(residual_parameter_blocks)
                     self.raw_jacobian_offsets.append(residual_offsets)
                 if expected_jacobian_offset != self.total_jacobian_scalars:
@@ -2484,13 +2429,10 @@ class _RawBinaryResidualValues:
         if self.has_raw_jacobians:
             self.metadata["total_jacobian_scalars"] = self.total_jacobian_scalars
             self.metadata["parameter_block_sizes"] = [
-                [block.size for block in residual_blocks]
-                for residual_blocks in self.parameter_blocks
+                [block.size for block in residual_blocks] for residual_blocks in self.parameter_blocks
             ]
             self.metadata["raw_jacobian_offsets"] = self.raw_jacobian_offsets
-            self.metadata["raw_jacobian_layout"] = (
-                "residual_block_major/parameter_block_major/row_major"
-            )
+            self.metadata["raw_jacobian_layout"] = "residual_block_major/parameter_block_major/row_major"
             self.metadata["jacobian_domain"] = "raw_cost_function_ambient_parameters"
             self.metadata["loss_applied_to_jacobians"] = False
             self.metadata["manifold_applied_to_jacobians"] = False
@@ -2511,9 +2453,7 @@ class _RawBinaryResidualValues:
             if not residual_id:
                 raise ValueError(f"{self.path}: residual_ids[{idx}] must be non-empty")
             if residual_dim < 0:
-                raise ValueError(
-                    f"{self.path}: residual_dims[{idx}] must be non-negative"
-                )
+                raise ValueError(f"{self.path}: residual_dims[{idx}] must be non-negative")
             if residual_offset != expected_offset:
                 raise ValueError(
                     f"{self.path}: residual_offsets[{idx}] is {residual_offset}, expected {expected_offset}"
@@ -2564,9 +2504,7 @@ class _RawBinaryResidualValues:
     @property
     def loss_rho_values(self) -> np.ndarray:
         if not self.has_loss_rho_values:
-            raise ValueError(
-                "loss_rho_values artifact is not present in this raw binary trace"
-            )
+            raise ValueError("loss_rho_values artifact is not present in this raw binary trace")
         return self._loss_rho_values
 
     @property
@@ -2598,12 +2536,8 @@ def _read_raw_snapshot_array(
         name = _read_binary_string(stream, f"{path}: name")
         if name != expected_name:
             raise ValueError(f"{path}: array name {name!r}, expected {expected_name!r}")
-        ids = np.frombuffer(
-            _read_exact(stream, rows * 8, f"{path}: ids"), dtype="<i8"
-        ).copy()
-        values = np.frombuffer(
-            _read_exact(stream, rows * cols * 8, f"{path}: values"), dtype="<f8"
-        ).copy()
+        ids = np.frombuffer(_read_exact(stream, rows * 8, f"{path}: ids"), dtype="<i8").copy()
+        values = np.frombuffer(_read_exact(stream, rows * cols * 8, f"{path}: values"), dtype="<f8").copy()
         trailing = stream.read(1)
         if trailing:
             raise ValueError(f"{path}: unexpected trailing bytes")
@@ -2623,43 +2557,32 @@ class _RawBinaryGlobalPositioningTrace:
         self.path = Path(path)
         self.manifest = manifest
         self._validate_manifest()
+        self._guard_eager_residual_load()
         self._iterations = self._parse_iterations()
         self._residual_blocks = self._read_residual_blocks()
         self.residual_blocks = list(self._residual_blocks)
         self.residual_skips: list[dict[str, Any]] = []
-        self._residual_ledger_blocks: (
-            tuple[GlobalPositioningResidualLedgerBlock, ...] | None
-        ) = None
+        self._residual_ledger_blocks: tuple[GlobalPositioningResidualLedgerBlock, ...] | None = None
 
     def _validate_manifest(self) -> None:
         schema_version = _require_int(
-            _require_key(
-                self.manifest, "schema_version", str(self.path / "manifest.json")
-            ),
+            _require_key(self.manifest, "schema_version", str(self.path / "manifest.json")),
             "schema_version",
         )
         if schema_version != 1:
-            raise ValueError(
-                f"{self.path / 'manifest.json'}: unsupported schema_version {schema_version}"
-            )
+            raise ValueError(f"{self.path / 'manifest.json'}: unsupported schema_version {schema_version}")
         storage_format = _require_str(
-            _require_key(
-                self.manifest, "storage_format", str(self.path / "manifest.json")
-            ),
+            _require_key(self.manifest, "storage_format", str(self.path / "manifest.json")),
             "storage_format",
         )
         if storage_format != _RAW_BINARY_STORAGE_FORMAT:
-            raise ValueError(
-                f"{self.path / 'manifest.json'}: unsupported storage_format {storage_format!r}"
-            )
+            raise ValueError(f"{self.path / 'manifest.json'}: unsupported storage_format {storage_format!r}")
         byte_order = _require_str(
             _require_key(self.manifest, "byte_order", str(self.path / "manifest.json")),
             "byte_order",
         )
         if byte_order != "little_endian":
-            raise ValueError(
-                f"{self.path / 'manifest.json'}: byte_order must be little_endian"
-            )
+            raise ValueError(f"{self.path / 'manifest.json'}: byte_order must be little_endian")
         dtype = _require_str(
             _require_key(self.manifest, "dtype", str(self.path / "manifest.json")),
             "dtype",
@@ -2667,32 +2590,51 @@ class _RawBinaryGlobalPositioningTrace:
         if dtype != "float64":
             raise ValueError(f"{self.path / 'manifest.json'}: dtype must be float64")
 
-    def _parse_iterations(self) -> dict[int, dict[str, Any]]:
-        iterations = _require_key(
-            self.manifest, "iterations", str(self.path / "manifest.json")
+    def _guard_eager_residual_load(self) -> None:
+        if os.environ.get(_HEAVY_RAW_LOAD_ENV) == "1":
+            return
+        max_records = _max_eager_raw_records()
+        ledger_count = self._raw_residual_ledger_count()
+        if ledger_count <= max_records:
+            return
+        raise RuntimeError(
+            f"Refusing to eagerly load {ledger_count} raw GP residual records from {self.path}. "
+            "Use the streaming GP trace analysis scripts instead of GlobalPositioningTrace.load() "
+            "for large traces. To override for debugging, set "
+            f"{_HEAVY_RAW_LOAD_ENV}=1, or raise {_RAW_LOAD_MAX_RECORDS_ENV}."
         )
+
+    def _raw_residual_ledger_count(self) -> int:
+        static = _require_key(self.manifest, "static", str(self.path / "manifest.json"))
+        if not isinstance(static, dict):
+            raise TypeError(f"{self.path / 'manifest.json'}: static must be an object")
+        ledger_name = _require_str(_require_key(static, "residual_ledger", "static"), "static.residual_ledger")
+        ledger_path = _resolve_raw_trace_path(
+            self.path,
+            Path(ledger_name),
+            f"{self.path / 'manifest.json'}: static.residual_ledger",
+        )
+        with ledger_path.open("rb") as stream:
+            _read_magic(stream, _RAW_LEDGER_MAGIC, str(ledger_path))
+            version, count = _read_struct(stream, "IQ", str(ledger_path))
+        if version not in (1, 2):
+            raise ValueError(f"{ledger_path}: unsupported residual ledger schema version {version}")
+        return int(count)
+
+    def _parse_iterations(self) -> dict[int, dict[str, Any]]:
+        iterations = _require_key(self.manifest, "iterations", str(self.path / "manifest.json"))
         if not isinstance(iterations, list):
             raise TypeError(f"{self.path / 'manifest.json'}: iterations must be a list")
         parsed = {}
         for idx, item in enumerate(iterations):
             if not isinstance(item, dict):
-                raise TypeError(
-                    f"{self.path / 'manifest.json'}: iterations[{idx}] must be an object"
-                )
-            iteration = _require_int(
-                _require_key(item, "iteration", "iteration"), "iteration"
-            )
+                raise TypeError(f"{self.path / 'manifest.json'}: iterations[{idx}] must be an object")
+            iteration = _require_int(_require_key(item, "iteration", "iteration"), "iteration")
             if iteration < 0:
-                raise ValueError(
-                    f"{self.path / 'manifest.json'}: iterations[{idx}].iteration must be non-negative"
-                )
+                raise ValueError(f"{self.path / 'manifest.json'}: iterations[{idx}].iteration must be non-negative")
             if iteration in parsed:
-                raise ValueError(
-                    f"{self.path / 'manifest.json'}: duplicate iteration {iteration}"
-                )
-            directory = _require_str(
-                _require_key(item, "directory", "iteration"), "directory"
-            )
+                raise ValueError(f"{self.path / 'manifest.json'}: duplicate iteration {iteration}")
+            directory = _require_str(_require_key(item, "directory", "iteration"), "directory")
             relative = Path(directory)
             item = dict(item)
             item["_directory_relative_path"] = relative
@@ -2708,9 +2650,7 @@ class _RawBinaryGlobalPositioningTrace:
         static = _require_key(self.manifest, "static", str(self.path / "manifest.json"))
         if not isinstance(static, dict):
             raise TypeError(f"{self.path / 'manifest.json'}: static must be an object")
-        ledger_name = _require_str(
-            _require_key(static, "residual_ledger", "static"), "static.residual_ledger"
-        )
+        ledger_name = _require_str(_require_key(static, "residual_ledger", "static"), "static.residual_ledger")
         ledger_relative_path = Path(ledger_name)
         ledger_path = _resolve_raw_trace_path(
             self.path,
@@ -2720,34 +2660,27 @@ class _RawBinaryGlobalPositioningTrace:
         with ledger_path.open("rb") as stream:
             _read_magic(stream, _RAW_LEDGER_MAGIC, str(ledger_path))
             version, count = _read_struct(stream, "IQ", str(ledger_path))
-            if version != 1:
-                raise ValueError(
-                    f"{ledger_path}: unsupported residual ledger schema version {version}"
-                )
+            if version not in (1, 2):
+                raise ValueError(f"{ledger_path}: unsupported residual ledger schema version {version}")
             records = []
             for idx in range(count):
                 label = f"{ledger_path}: residual_ledger[{idx}]"
                 residual_id = _read_binary_string(stream, f"{label}.residual_id")
                 residual_type = _read_binary_string(stream, f"{label}.residual_type")
                 loss_bucket = _read_binary_string(stream, f"{label}.loss_bucket")
-                frame_id, image_id, point3D_id, is_lc_observation = _read_struct(
-                    stream, "qqq?", label
-                )
-                attrs = _read_binary_json(stream, f"{label}.attrs")
+                frame_id, image_id, point3D_id, is_lc_observation = _read_struct(stream, "qqq?", label)
+                if version == 1:
+                    attrs = _read_binary_json(stream, f"{label}.attrs")
+                else:
+                    attrs = _read_binary_trace_attrs(stream, f"{label}.attrs")
                 attrs.update(
                     {
                         "residual_id": residual_id,
                         "residual_type": residual_type,
                         "loss_bucket": loss_bucket,
-                        "frame_id": (
-                            None if frame_id == _RAW_NONE_ID else int(frame_id)
-                        ),
-                        "image_id": (
-                            None if image_id == _RAW_NONE_ID else int(image_id)
-                        ),
-                        "point3D_id": (
-                            None if point3D_id == _RAW_NONE_ID else int(point3D_id)
-                        ),
+                        "frame_id": (None if frame_id == _RAW_NONE_ID else int(frame_id)),
+                        "image_id": (None if image_id == _RAW_NONE_ID else int(image_id)),
+                        "point3D_id": (None if point3D_id == _RAW_NONE_ID else int(point3D_id)),
                         "is_lc_observation": bool(is_lc_observation),
                     }
                 )
@@ -2808,20 +2741,14 @@ class _RawBinaryGlobalPositioningTrace:
     @property
     def trace_level(self) -> str:
         return _require_str(
-            _require_key(
-                self.manifest, "trace_level", str(self.path / "manifest.json")
-            ),
+            _require_key(self.manifest, "trace_level", str(self.path / "manifest.json")),
             "trace_level",
         )
 
     @property
     def residual_value_iterations(self) -> tuple[int, ...]:
         return tuple(
-            sorted(
-                iteration
-                for iteration, metadata in self._iterations.items()
-                if "residual_values" in metadata
-            )
+            sorted(iteration for iteration, metadata in self._iterations.items() if "residual_values" in metadata)
         )
 
     @property
@@ -2873,11 +2800,7 @@ class _RawBinaryGlobalPositioningTrace:
             raise KeyError(f"Trace iteration {iteration} has no {key}")
         filename = _require_str(metadata[key], f"iterations[{iteration}].{key}")
         relative = Path(filename)
-        if (
-            relative.is_absolute()
-            or relative.name != filename
-            or ".." in relative.parts
-        ):
+        if relative.is_absolute() or relative.name != filename or ".." in relative.parts:
             raise ValueError(f"iterations[{iteration}].{key}: expected bare filename")
         return _resolve_raw_trace_path(
             self.path,
@@ -2889,9 +2812,7 @@ class _RawBinaryGlobalPositioningTrace:
         if iteration is None:
             iterations = self.residual_value_iterations
             if len(iterations) != 1:
-                raise ValueError(
-                    f"Trace has {len(iterations)} residual-value iterations; pass iteration explicitly"
-                )
+                raise ValueError(f"Trace has {len(iterations)} residual-value iterations; pass iteration explicitly")
             iteration = iterations[0]
         return _RawBinaryResidualValues(
             self._iteration_file(iteration, "residual_values"),
@@ -2914,9 +2835,7 @@ class _RawBinaryGlobalPositioningTrace:
             for idx, record in enumerate(self.residual_blocks)
         )
 
-    def snapshot(
-        self, iteration: int, max_points: int | None = None
-    ) -> GlobalPositioningParameterSnapshot:
+    def snapshot(self, iteration: int, max_points: int | None = None) -> GlobalPositioningParameterSnapshot:
         max_points = _normalize_max_points(max_points)
         metadata = self._iterations[iteration]
         frame_centers = _read_raw_snapshot_array(
@@ -2929,9 +2848,7 @@ class _RawBinaryGlobalPositioningTrace:
             max_rows=max_points,
         )
         scales = (
-            _read_raw_snapshot_array(
-                self._iteration_file(iteration, "scales"), expected_name="scales"
-            )
+            _read_raw_snapshot_array(self._iteration_file(iteration, "scales"), expected_name="scales")
             if "scales" in metadata
             else _empty_snapshot_array()
         )
@@ -2992,29 +2909,22 @@ class GlobalPositioningTrace:
             "iteration_metrics.jsonl",
             expected_run_id=expected_run_id,
         )
-        self._iteration_metrics_by_iteration = {
-            metric.iteration: metric for metric in self._iteration_metrics
-        }
+        self._iteration_metrics_by_iteration = {metric.iteration: metric for metric in self._iteration_metrics}
         self.residual_blocks = self._read_optional_jsonl("residual_blocks.jsonl")
         self.residual_skips = self._read_optional_jsonl("residual_skips.jsonl")
-        self._residual_values_by_iteration = _discover_iteration_metadata(
-            self.path / "residual_values"
-        )
-        self._snapshots_by_iteration = _discover_iteration_metadata(
-            self.path / "snapshots"
-        )
-        self._residual_ledger_blocks: (
-            tuple[GlobalPositioningResidualLedgerBlock, ...] | None
-        ) = None
+        self._residual_values_by_iteration = _discover_iteration_metadata(self.path / "residual_values")
+        self._snapshots_by_iteration = _discover_iteration_metadata(self.path / "snapshots")
+        self._residual_ledger_blocks: tuple[GlobalPositioningResidualLedgerBlock, ...] | None = None
 
     @classmethod
-    def load(
-        cls, path: str | Path
-    ) -> GlobalPositioningTrace | _RawBinaryGlobalPositioningTrace:
+    def load(cls, path: str | Path) -> GlobalPositioningTrace | _RawBinaryGlobalPositioningTrace:
         path = Path(path)
         manifest = _load_json(path / "manifest.json")
         if manifest.get("storage_format") == _RAW_BINARY_STORAGE_FORMAT:
             return _RawBinaryGlobalPositioningTrace(path, manifest)
+        raw_binary_manifest = path / "raw_binary" / "manifest.json"
+        if raw_binary_manifest.is_file():
+            return _RawBinaryGlobalPositioningTrace(path / "raw_binary", _load_json(raw_binary_manifest))
         return cls(path)
 
     def _read_optional_jsonl(self, filename: str) -> list[dict[str, Any]]:
@@ -3054,9 +2964,7 @@ class GlobalPositioningTrace:
     @property
     def trace_level(self) -> str:
         return _require_str(
-            _require_key(
-                self.manifest, "trace_level", str(self.path / "manifest.json")
-            ),
+            _require_key(self.manifest, "trace_level", str(self.path / "manifest.json")),
             "trace_level",
         )
 
@@ -3101,15 +3009,12 @@ class GlobalPositioningTrace:
             self._residual_ledger_blocks = tuple(blocks)
         return self._residual_ledger_blocks
 
-    def residual_values(
-        self, iteration: int | None = None
-    ) -> GlobalPositioningResidualValues:
+    def residual_values(self, iteration: int | None = None) -> GlobalPositioningResidualValues:
         if iteration is None:
             iterations = self.residual_value_iterations
             if len(iterations) != 1:
                 raise ValueError(
-                    f"Trace has {len(iterations)} residual-value iterations; "
-                    "pass iteration explicitly"
+                    f"Trace has {len(iterations)} residual-value iterations; " "pass iteration explicitly"
                 )
             iteration = iterations[0]
         if iteration not in self._residual_values_by_iteration:
@@ -3121,9 +3026,7 @@ class GlobalPositioningTrace:
             expected_residual_ids=self._ledger_residual_ids(),
         )
 
-    def snapshot(
-        self, iteration: int, max_points: int | None = None
-    ) -> GlobalPositioningParameterSnapshot:
+    def snapshot(self, iteration: int, max_points: int | None = None) -> GlobalPositioningParameterSnapshot:
         if iteration not in self._snapshots_by_iteration:
             raise KeyError(f"Trace has no parameter snapshot for iteration {iteration}")
         return GlobalPositioningParameterSnapshotLoader(

--- a/python/pycolmap/global_positioning_trace.py
+++ b/python/pycolmap/global_positioning_trace.py
@@ -438,6 +438,26 @@ class GlobalPositioningResidualBlock:
         return float(self._residual_values.robust_costs[self.index])
 
     @property
+    def loss_rho(self) -> np.ndarray:
+        return self._residual_values.loss_rho_values[self.index]
+
+    @property
+    def loss_rho0(self) -> float:
+        return float(self.loss_rho[0])
+
+    @property
+    def loss_rho1(self) -> float:
+        return float(self.loss_rho[1])
+
+    @property
+    def loss_rho2(self) -> float:
+        return float(self.loss_rho[2])
+
+    @property
+    def loss_derivative_scale(self) -> float:
+        return self.loss_rho1
+
+    @property
     def parameter_blocks(self) -> tuple[GlobalPositioningParameterBlock, ...]:
         if not self._residual_values.has_raw_jacobians:
             return ()
@@ -585,6 +605,16 @@ class GlobalPositioningResidualValues:
         self._raw_residuals_artifact = raw_residuals_artifact
         self._raw_costs_artifact = raw_costs_artifact
         self._robust_costs_artifact = robust_costs_artifact
+        self._loss_rho_values_artifact = _resolve_float64_artifact(
+            self.metadata_path,
+            self.metadata,
+            "loss_rho_values",
+            expected_shape=(self.num_residual_blocks, 3),
+            required=False,
+        )
+        self.has_loss_rho_values = self._loss_rho_values_artifact is not None
+        if self.has_loss_rho_values:
+            self._validate_loss_rho_contract()
 
         self.total_jacobian_scalars = 0
         self.parameter_blocks: list[list[GlobalPositioningParameterBlock]] = []
@@ -659,7 +689,61 @@ class GlobalPositioningResidualValues:
         self._raw_residuals: np.ndarray | None = None
         self._raw_costs: np.ndarray | None = None
         self._robust_costs: np.ndarray | None = None
+        self._loss_rho_values: np.ndarray | None = None
+        self._loss_rho_costs_validated = False
         self._raw_jacobians: np.ndarray | None = None
+
+    def _validate_loss_rho_contract(self) -> None:
+        loss_rho_layout = _require_str(
+            _require_key(
+                self.metadata, "loss_rho_layout", str(self.metadata_path)
+            ),
+            "loss_rho_layout",
+        )
+        if loss_rho_layout != "residual_block_major/rho0_rho1_rho2":
+            raise ValueError(
+                "loss_rho_layout must be "
+                "'residual_block_major/rho0_rho1_rho2'"
+            )
+
+    def _validate_loss_rho_costs(self) -> None:
+        if self._loss_rho_costs_validated:
+            return
+        loss_rho_values = self._require_loss_rho_values()
+        success_mask = np.asarray(self.evaluation_success, dtype=bool)
+        if np.any(success_mask):
+            robust_costs = np.asarray(self.robust_costs)
+            expected_robust_costs = 0.5 * loss_rho_values[:, 0]
+            matches = np.isclose(
+                robust_costs,
+                expected_robust_costs,
+                rtol=1e-10,
+                atol=1e-12,
+                equal_nan=False,
+            )
+            mismatch_mask = success_mask & ~matches
+            if np.any(mismatch_mask):
+                mismatch_idx = int(np.flatnonzero(mismatch_mask)[0])
+                raise ValueError(
+                    "robust_costs must equal 0.5 * loss_rho_values[:, 0] "
+                    "for successful residual evaluations; mismatch at "
+                    f"residual {mismatch_idx} "
+                    f"({self.residual_ids[mismatch_idx]!r})"
+                )
+        self._loss_rho_costs_validated = True
+
+    def _require_loss_rho_values(self) -> np.ndarray:
+        if self._loss_rho_values_artifact is None:
+            raise ValueError(
+                "loss_rho_values artifact is not present in this trace; "
+                "robust loss rho diagnostics require a newer trace"
+            )
+        if self._loss_rho_values is None:
+            self._loss_rho_values = _memmap_float64(
+                self._loss_rho_values_artifact.path,
+                self._loss_rho_values_artifact.shape,
+            )
+        return self._loss_rho_values
 
     def _validate_jacobian_contract(self) -> None:
         raw_jacobian_layout = _require_str(
@@ -882,6 +966,12 @@ class GlobalPositioningResidualValues:
                 self._robust_costs_artifact.shape,
             )
         return self._robust_costs
+
+    @property
+    def loss_rho_values(self) -> np.ndarray:
+        loss_rho_values = self._require_loss_rho_values()
+        self._validate_loss_rho_costs()
+        return loss_rho_values
 
     @property
     def raw_jacobians(self) -> np.ndarray | None:

--- a/python/pycolmap/global_positioning_trace_test.py
+++ b/python/pycolmap/global_positioning_trace_test.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import pycolmap
 
@@ -21,6 +22,16 @@ def _write_f64(path: Path, values) -> None:
     np.asarray(values, dtype="<f8").tofile(path)
 
 
+def _artifact(filename: str, ids, shape) -> dict:
+    return {
+        "file": filename,
+        "dtype": "float64",
+        "byte_order": "little_endian",
+        "ids": list(ids),
+        "shape": list(shape),
+    }
+
+
 def _make_trace(tmp_path: Path, *, with_jacobians: bool) -> Path:
     trace_dir = tmp_path / (
         "trace_jacobians" if with_jacobians else "trace_values"
@@ -34,9 +45,9 @@ def _make_trace(tmp_path: Path, *, with_jacobians: bool) -> Path:
             "schema_version": 1,
             "run_id": "run",
             "status": "finished",
-            "trace_level": "residual_jacobians"
-            if with_jacobians
-            else "residual_values",
+            "trace_level": (
+                "residual_jacobians" if with_jacobians else "residual_values"
+            ),
         },
     )
     _write_jsonl(
@@ -138,6 +149,90 @@ def _make_trace(tmp_path: Path, *, with_jacobians: bool) -> Path:
     return trace_dir
 
 
+def _make_snapshot_trace(
+    tmp_path: Path, *, include_optional: bool = True
+) -> Path:
+    trace_dir = tmp_path / "trace_snapshots"
+    snapshots_dir = trace_dir / "snapshots"
+    snapshots_dir.mkdir(parents=True)
+    _write_json(
+        trace_dir / "manifest.json",
+        {
+            "schema_version": 1,
+            "run_id": "run",
+            "status": "finished",
+            "trace_level": "parameter_snapshots",
+        },
+    )
+
+    iteration = 3
+    prefix = f"iter_{iteration:06d}"
+    frame_centers = np.array(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float64
+    )
+    points3D = np.arange(15, dtype=np.float64).reshape(5, 3)
+    scales = np.array([0.5, 1.5], dtype=np.float64)
+    dmap_scales = np.array([2.5, 3.5], dtype=np.float64)
+    cams_in_rig = np.array([[0.1, 0.2, 0.3]], dtype=np.float64)
+
+    frame_ids = [10, 20]
+    point3D_ids = [100, 101, 102, 103, 104]
+    scale_ids = [30, 40]
+    dmap_ids = [50, 60]
+    cam_ids = [70]
+
+    _write_f64(snapshots_dir / f"{prefix}_frame_centers_f64.bin", frame_centers)
+    _write_f64(snapshots_dir / f"{prefix}_points3D_f64.bin", points3D)
+    _write_f64(snapshots_dir / f"{prefix}_scales_f64.bin", scales)
+
+    artifacts = {
+        "frame_centers": _artifact(
+            f"{prefix}_frame_centers_f64.bin", frame_ids, frame_centers.shape
+        ),
+        "points3D": _artifact(
+            f"{prefix}_points3D_f64.bin", point3D_ids, points3D.shape
+        ),
+        "scales": _artifact(
+            f"{prefix}_scales_f64.bin", scale_ids, scales.shape
+        ),
+    }
+    dmap_shape = [0]
+    if include_optional:
+        _write_f64(snapshots_dir / f"{prefix}_dmap_scales_f64.bin", dmap_scales)
+        _write_f64(snapshots_dir / f"{prefix}_cams_in_rig_f64.bin", cams_in_rig)
+        artifacts["dmap_scales"] = _artifact(
+            f"{prefix}_dmap_scales_f64.bin", dmap_ids, dmap_scales.shape
+        )
+        artifacts["cams_in_rig"] = _artifact(
+            f"{prefix}_cams_in_rig_f64.bin", cam_ids, cams_in_rig.shape
+        )
+        dmap_shape = list(dmap_scales.shape)
+    else:
+        dmap_ids = []
+
+    _write_json(
+        snapshots_dir / f"{prefix}.json",
+        {
+            "schema_version": 1,
+            "run_id": "run",
+            "iteration": iteration,
+            "dtype": "float64",
+            "byte_order": "little_endian",
+            "frame_ids": frame_ids,
+            "frame_centers_world_shape": list(frame_centers.shape),
+            "point3D_ids": point3D_ids,
+            "points3D_world_shape": list(points3D.shape),
+            "bata_residual_ids": [],
+            "bata_scale_ids": scale_ids,
+            "bata_scales_shape": list(scales.shape),
+            "dmap_image_ids": dmap_ids,
+            "dmap_scales_stored_shape": dmap_shape,
+            "artifacts": artifacts,
+        },
+    )
+    return trace_dir
+
+
 def test_global_positioning_trace_loads_residual_values(tmp_path: Path) -> None:
     trace = pycolmap.GlobalPositioningTrace.load(
         _make_trace(tmp_path, with_jacobians=False)
@@ -197,3 +292,252 @@ def test_global_positioning_trace_rejects_bad_sidecar_size(
     trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
     with np.testing.assert_raises(ValueError):
         trace.residual_values(0)
+
+
+def test_global_positioning_trace_rejects_bad_residual_metadata(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["residual_ids"] = ["same", "same"]
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="residual_ids must be unique"):
+        trace.residual_values(0)
+
+    trace_dir = _make_trace(tmp_path / "offsets", with_jacobians=False)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["residual_offsets"] = [0, 0]
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="residual_offsets"):
+        trace.residual_values(0)
+
+
+def test_global_positioning_trace_rejects_residual_ledger_mismatch(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["residual_ids"] = ["r1", "r0"]
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="residual_blocks.jsonl order"):
+        trace.residual_values(0)
+
+
+def test_global_positioning_trace_rejects_bad_jacobian_metadata(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=True)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["raw_jacobian_offsets"] = [[0, 5], [8]]
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="raw_jacobian_offsets"):
+        trace.residual_values(0)
+
+    trace_dir = _make_trace(tmp_path / "bounds", with_jacobians=True)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["parameter_block_lower_bounds"][0][0] = [-1.0, -1.0]
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="parameter_block_lower_bounds"):
+        trace.residual_values(0)
+
+
+def test_global_positioning_trace_rejects_bad_jacobian_contract(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=True)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["raw_jacobian_layout"] = "wrong"
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="raw_jacobian_layout"):
+        trace.residual_values(0)
+
+    trace_dir = _make_trace(tmp_path / "domain", with_jacobians=True)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["jacobian_domain"] = "wrong"
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="jacobian_domain"):
+        trace.residual_values(0)
+
+    trace_dir = _make_trace(tmp_path / "loss", with_jacobians=True)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["loss_applied_to_jacobians"] = True
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="loss_applied_to_jacobians"):
+        trace.residual_values(0)
+
+
+def test_global_positioning_trace_rejects_residual_filename_iteration_mismatch(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["iteration"] = 1
+    _write_json(metadata_path, metadata)
+
+    with pytest.raises(
+        ValueError, match="filename does not match metadata iteration"
+    ):
+        pycolmap.GlobalPositioningTrace.load(trace_dir)
+
+
+def test_global_positioning_trace_rejects_residual_path_traversal(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["artifacts"]["raw_residuals"]["file"] = "../escape.bin"
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="bare relative filename"):
+        trace.residual_values(0)
+
+
+def test_global_positioning_trace_loads_snapshot_with_all_artifacts(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_snapshot_trace(tmp_path, include_optional=True)
+    )
+
+    assert trace.snapshot_iterations == (3,)
+    snapshot = trace.snapshot(3)
+
+    assert snapshot.iteration == 3
+    assert snapshot.frame_centers.ids == (10, 20)
+    assert snapshot.frame_centers.shape == (2, 3)
+    np.testing.assert_allclose(
+        snapshot.frame_centers.values,
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+    )
+    assert isinstance(snapshot.points3D.values, np.memmap)
+    assert snapshot.points3D.ids == (100, 101, 102, 103, 104)
+    np.testing.assert_allclose(
+        snapshot.points3D.values,
+        np.arange(15, dtype=np.float64).reshape(5, 3),
+    )
+    assert snapshot.scales.ids == (30, 40)
+    np.testing.assert_allclose(snapshot.scales.values, [0.5, 1.5])
+
+    assert snapshot.dmap_scales is not None
+    assert snapshot.dmap_scales.ids == (50, 60)
+    np.testing.assert_allclose(snapshot.dmap_scales.values, [2.5, 3.5])
+    assert snapshot.cams_in_rig is not None
+    assert snapshot.cams_in_rig.ids == (70,)
+    np.testing.assert_allclose(snapshot.cams_in_rig.values, [[0.1, 0.2, 0.3]])
+    assert isinstance(snapshot, pycolmap.GlobalPositioningParameterSnapshot)
+    assert isinstance(
+        snapshot.points3D, pycolmap.GlobalPositioningSnapshotArray
+    )
+
+
+def test_global_positioning_trace_snapshot_optional_artifacts_missing(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_snapshot_trace(tmp_path, include_optional=False)
+    )
+
+    snapshot = trace.snapshot(3)
+
+    assert snapshot.dmap_scales is None
+    assert snapshot.cams_in_rig is None
+    np.testing.assert_allclose(snapshot.scales.values, [0.5, 1.5])
+
+
+def test_global_positioning_trace_snapshot_accepts_legacy_missing_scales(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_snapshot_trace(tmp_path, include_optional=False)
+    metadata_path = trace_dir / "snapshots" / "iter_000003.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    del metadata["bata_scale_ids"]
+    del metadata["bata_scales_shape"]
+    del metadata["artifacts"]["scales"]
+    _write_json(metadata_path, metadata)
+
+    snapshot = pycolmap.GlobalPositioningTrace.load(trace_dir).snapshot(3)
+
+    assert snapshot.scales.ids == ()
+    assert snapshot.scales.shape == (0,)
+    np.testing.assert_allclose(snapshot.scales.values, [])
+
+
+def test_global_positioning_trace_snapshot_max_points(tmp_path: Path) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_snapshot_trace(tmp_path, include_optional=True)
+    )
+
+    snapshot = trace.snapshot(3, max_points=2)
+
+    assert snapshot.points3D.ids == (100, 101)
+    assert snapshot.points3D.shape == (2, 3)
+    assert isinstance(snapshot.points3D.values, np.memmap)
+    np.testing.assert_allclose(
+        snapshot.points3D.values,
+        np.arange(6, dtype=np.float64).reshape(2, 3),
+    )
+
+
+def test_global_positioning_trace_snapshot_rejects_malformed_shape_and_size(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_snapshot_trace(tmp_path / "shape", include_optional=True)
+    metadata_path = trace_dir / "snapshots" / "iter_000003.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["artifacts"]["points3D"]["shape"] = [4, 3]
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="points3D.*shape"):
+        trace.snapshot(3)
+
+    trace_dir = _make_snapshot_trace(tmp_path / "size", include_optional=True)
+    (trace_dir / "snapshots" / "iter_000003_points3D_f64.bin").write_bytes(
+        b"short"
+    )
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="byte size"):
+        trace.snapshot(3)
+
+
+def test_global_positioning_trace_snapshot_rejects_filename_iteration_mismatch(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_snapshot_trace(tmp_path, include_optional=True)
+    metadata_path = trace_dir / "snapshots" / "iter_000003.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["iteration"] = 4
+    _write_json(metadata_path, metadata)
+
+    with pytest.raises(
+        ValueError, match="filename does not match metadata iteration"
+    ):
+        pycolmap.GlobalPositioningTrace.load(trace_dir)

--- a/python/pycolmap/global_positioning_trace_test.py
+++ b/python/pycolmap/global_positioning_trace_test.py
@@ -1,0 +1,199 @@
+import json
+from pathlib import Path
+
+import numpy as np
+
+import pycolmap
+
+
+def _write_json(path: Path, value) -> None:
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _write_jsonl(path: Path, records) -> None:
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def _write_f64(path: Path, values) -> None:
+    np.asarray(values, dtype="<f8").tofile(path)
+
+
+def _make_trace(tmp_path: Path, *, with_jacobians: bool) -> Path:
+    trace_dir = tmp_path / (
+        "trace_jacobians" if with_jacobians else "trace_values"
+    )
+    residual_values_dir = trace_dir / "residual_values"
+    residual_values_dir.mkdir(parents=True)
+
+    _write_json(
+        trace_dir / "manifest.json",
+        {
+            "schema_version": 1,
+            "run_id": "run",
+            "status": "finished",
+            "trace_level": "residual_jacobians"
+            if with_jacobians
+            else "residual_values",
+        },
+    )
+    _write_jsonl(
+        trace_dir / "residual_blocks.jsonl",
+        [
+            {"event_type": "residual_added", "attrs": {"residual_id": "r0"}},
+            {"event_type": "residual_added", "attrs": {"residual_id": "r1"}},
+        ],
+    )
+
+    metadata = {
+        "schema_version": 1,
+        "run_id": "run",
+        "iteration": 0,
+        "dtype": "float64",
+        "byte_order": "little_endian",
+        "num_residual_blocks": 2,
+        "total_scalar_residuals": 3,
+        "has_raw_jacobians": with_jacobians,
+        "residual_ids": ["r0", "r1"],
+        "residual_dims": [2, 1],
+        "residual_offsets": [0, 2],
+        "evaluation_success": [True, True],
+        "artifacts": {
+            "raw_residuals": {
+                "file": "iter_000000_raw_residuals_f64.bin",
+                "dtype": "float64",
+                "byte_order": "little_endian",
+                "shape": [3],
+            },
+            "raw_costs": {
+                "file": "iter_000000_raw_costs_f64.bin",
+                "dtype": "float64",
+                "byte_order": "little_endian",
+                "shape": [2],
+            },
+            "robust_costs": {
+                "file": "iter_000000_robust_costs_f64.bin",
+                "dtype": "float64",
+                "byte_order": "little_endian",
+                "shape": [2],
+            },
+        },
+    }
+    if with_jacobians:
+        metadata.update(
+            {
+                "total_jacobian_scalars": 9,
+                "parameter_block_sizes": [[3, 1], [1]],
+                "raw_jacobian_offsets": [[0, 6], [8]],
+                "parameter_blocks": [
+                    [
+                        {
+                            "role": "frame_center",
+                            "kind": "frame_center",
+                            "id": 10,
+                        },
+                        {"role": "bata_scale", "kind": "bata_scale", "id": 0},
+                    ],
+                    [{"role": "dmap_scale", "kind": "dmap_scale", "id": 20}],
+                ],
+                "parameter_block_is_constant": [[False, True], [False]],
+                "parameter_block_lower_bounds": [
+                    [[-1.0, -1.0, -1.0], [1e-5]],
+                    [[1e-5]],
+                ],
+                "raw_jacobian_layout": (
+                    "residual_block_major/parameter_block_major/row_major"
+                ),
+                "jacobian_domain": "raw_cost_function_ambient_parameters",
+                "loss_applied_to_jacobians": False,
+                "manifold_applied_to_jacobians": False,
+                "constant_parameter_blocks_included": True,
+            }
+        )
+        metadata["artifacts"]["raw_jacobians"] = {
+            "file": "iter_000000_raw_jacobians_f64.bin",
+            "dtype": "float64",
+            "byte_order": "little_endian",
+            "shape": [9],
+        }
+
+    _write_json(residual_values_dir / "iter_000000.json", metadata)
+    _write_f64(
+        residual_values_dir / "iter_000000_raw_residuals_f64.bin",
+        [1.0, 2.0, 3.0],
+    )
+    _write_f64(
+        residual_values_dir / "iter_000000_raw_costs_f64.bin", [2.5, 4.5]
+    )
+    _write_f64(
+        residual_values_dir / "iter_000000_robust_costs_f64.bin", [2.25, 4.25]
+    )
+    if with_jacobians:
+        _write_f64(
+            residual_values_dir / "iter_000000_raw_jacobians_f64.bin",
+            np.arange(9, dtype=np.float64),
+        )
+    return trace_dir
+
+
+def test_global_positioning_trace_loads_residual_values(tmp_path: Path) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_trace(tmp_path, with_jacobians=False)
+    )
+
+    assert trace.status == "finished"
+    assert trace.trace_level == "residual_values"
+    assert trace.residual_value_iterations == (0,)
+
+    residual_values = trace.residual_values()
+    assert isinstance(residual_values.raw_residuals, np.memmap)
+    assert residual_values.has_raw_jacobians is False
+    assert residual_values.raw_jacobians is None
+
+    residual = residual_values.residual("r0")
+    np.testing.assert_allclose(residual.raw_residuals, [1.0, 2.0])
+    assert residual.raw_cost == 2.5
+    assert residual.robust_cost == 2.25
+    assert residual.parameter_blocks == ()
+    assert residual.jacobian_blocks == ()
+
+
+def test_global_positioning_trace_loads_raw_jacobians(tmp_path: Path) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_trace(tmp_path, with_jacobians=True)
+    )
+    residual_values = trace.residual_values(iteration=0)
+
+    assert residual_values.has_raw_jacobians is True
+    assert isinstance(residual_values.raw_jacobians, np.memmap)
+
+    residual = residual_values.residual(0)
+    assert [block.role for block in residual.parameter_blocks] == [
+        "frame_center",
+        "bata_scale",
+    ]
+    assert residual.parameter_blocks[1].is_constant is True
+    assert residual.parameter_blocks[1].lower_bounds == (1e-5,)
+
+    np.testing.assert_allclose(
+        residual.jacobian(0), np.arange(6, dtype=np.float64).reshape(2, 3)
+    )
+    np.testing.assert_allclose(residual.jacobian("bata_scale"), [[6.0], [7.0]])
+    np.testing.assert_allclose(
+        residual_values.residual("r1").jacobian("dmap_scale", id=20), [[8.0]]
+    )
+
+
+def test_global_positioning_trace_rejects_bad_sidecar_size(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    (
+        trace_dir / "residual_values" / "iter_000000_raw_costs_f64.bin"
+    ).write_bytes(b"short")
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with np.testing.assert_raises(ValueError):
+        trace.residual_values(0)

--- a/python/pycolmap/global_positioning_trace_test.py
+++ b/python/pycolmap/global_positioning_trace_test.py
@@ -33,6 +33,90 @@ def _write_raw_json(stream, value: dict) -> None:
     _write_raw_string(stream, json.dumps(value, sort_keys=True, separators=(",", ":")))
 
 
+def _write_raw_optional_double(stream, value) -> None:
+    stream.write(struct.pack("<?", value is not None))
+    if value is not None:
+        stream.write(struct.pack("<d", value))
+
+
+def _write_raw_parameter_block(stream, value: dict) -> None:
+    _write_raw_string(stream, value["role"])
+    _write_raw_string(stream, value["kind"])
+    stream.write(struct.pack("<Q", value["id"]))
+    stream.write(struct.pack("<?", "size" in value))
+    if "size" in value:
+        stream.write(struct.pack("<Q", value["size"]))
+
+
+def _write_raw_trace_value(stream, value) -> None:
+    if value is None:
+        stream.write(struct.pack("<B", 0))
+    elif isinstance(value, bool):
+        stream.write(struct.pack("<B?", 1, value))
+    elif isinstance(value, int):
+        stream.write(struct.pack("<Bq", 2, value))
+    elif isinstance(value, float):
+        stream.write(struct.pack("<Bd", 4, value))
+    elif isinstance(value, str):
+        stream.write(struct.pack("<B", 5))
+        _write_raw_string(stream, value)
+    elif isinstance(value, list):
+        stream.write(struct.pack("<BI", 7, len(value)))
+        for item in value:
+            _write_raw_parameter_block(stream, item)
+    elif isinstance(value, dict) and {"bucket", "type", "scale", "weight", "source"}.issubset(value):
+        stream.write(struct.pack("<B", 8))
+        _write_raw_string(stream, value["bucket"])
+        _write_raw_string(stream, value["type"])
+        _write_raw_optional_double(stream, value["scale"])
+        _write_raw_optional_double(stream, value["weight"])
+        _write_raw_string(stream, value["source"])
+        _write_raw_optional_double(stream, value.get("observation_count_weight"))
+    elif isinstance(value, dict):
+        stream.write(struct.pack("<B", 9))
+        for key in (
+            "cam_from_point3D_dir",
+            "keypoint_covariance_world_row_major",
+            "cam_from_rig_dir",
+            "rig_from_world_rotation_wxyz",
+            "world_from_rig_rotation_wxyz",
+            "camera_rotation_wxyz",
+        ):
+            item = value.get(key)
+            stream.write(struct.pack("<?", item is not None))
+            if item is not None:
+                stream.write(struct.pack("<I", len(item)))
+                for scalar in item:
+                    stream.write(struct.pack("<d", scalar))
+        item = value.get("metric_depth_use_log_scale")
+        stream.write(struct.pack("<?", item is not None))
+        if item is not None:
+            stream.write(struct.pack("<?", item))
+        item = value.get("metric_depth_residual_type")
+        stream.write(struct.pack("<?", item is not None))
+        if item is not None:
+            _write_raw_string(stream, item)
+        item = value.get("metric_depth_zero_residual_behind")
+        stream.write(struct.pack("<?", item is not None))
+        if item is not None:
+            stream.write(struct.pack("<?", item))
+        for key in (
+            "metric_depth_log_linear_threshold",
+            "scale_prior_target",
+            "scale_prior_stddev",
+        ):
+            _write_raw_optional_double(stream, value.get(key))
+    else:
+        raise TypeError(f"unsupported raw trace value: {value!r}")
+
+
+def _write_raw_trace_attrs(stream, attrs: dict) -> None:
+    stream.write(struct.pack("<I", len(attrs)))
+    for key, value in attrs.items():
+        _write_raw_string(stream, key)
+        _write_raw_trace_value(stream, value)
+
+
 def _write_raw_array(path: Path, name: str, ids, values) -> None:
     values = np.asarray(values, dtype="<f8")
     ids = np.asarray(ids, dtype="<i8")
@@ -50,10 +134,10 @@ def _write_raw_array(path: Path, name: str, ids, values) -> None:
         values.reshape(-1).tofile(stream)
 
 
-def _write_raw_residual_ledger(path: Path, records: list[dict]) -> None:
+def _write_raw_residual_ledger(path: Path, records: list[dict], *, version: int = 2) -> None:
     with path.open("wb") as stream:
         stream.write(b"GPTRLGR1")
-        stream.write(struct.pack("<IQ", 1, len(records)))
+        stream.write(struct.pack("<IQ", version, len(records)))
         for record in records:
             attrs = record["attrs"]
             _write_raw_string(stream, attrs["residual_id"])
@@ -68,7 +152,10 @@ def _write_raw_residual_ledger(path: Path, records: list[dict]) -> None:
                     attrs.get("is_lc_observation", False),
                 )
             )
-            _write_raw_json(stream, attrs)
+            if version == 1:
+                _write_raw_json(stream, attrs)
+            else:
+                _write_raw_trace_attrs(stream, attrs)
 
 
 def _write_raw_residual_values(
@@ -199,6 +286,7 @@ def _make_raw_binary_trace(
     *,
     with_jacobians: bool = False,
     force_residual_version: int | None = None,
+    residual_ledger_version: int = 2,
 ) -> Path:
     trace_dir = tmp_path / "trace_raw_binary"
     static_dir = trace_dir / "static"
@@ -207,16 +295,18 @@ def _make_raw_binary_trace(
     iteration_dir.mkdir(parents=True)
 
     records = _raw_support_records()
-    _write_raw_residual_ledger(static_dir / "residual_ledger.bin", records)
+    _write_raw_residual_ledger(
+        static_dir / "residual_ledger.bin",
+        records,
+        version=residual_ledger_version,
+    )
     _write_raw_array(
         iteration_dir / "frame_centers.bin",
         "frame_centers",
         [10, 20],
         [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
     )
-    _write_raw_array(
-        iteration_dir / "point_xyz.bin", "point_xyz", [100], [[0.0, 0.0, 2.0]]
-    )
+    _write_raw_array(iteration_dir / "point_xyz.bin", "point_xyz", [100], [[0.0, 0.0, 2.0]])
     _write_raw_array(iteration_dir / "scales.bin", "scales", [0], [1.0])
     parameter_blocks = None
     raw_jacobians = None
@@ -290,6 +380,29 @@ def _make_raw_binary_trace(
         },
     )
     return trace_dir
+
+
+def test_raw_binary_trace_load_refuses_large_eager_residual_ledger(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    trace_dir = _make_raw_binary_trace(tmp_path)
+    monkeypatch.delenv("PYCOLMAP_GP_TRACE_ALLOW_HEAVY_LOAD", raising=False)
+    monkeypatch.setenv("PYCOLMAP_GP_TRACE_MAX_EAGER_RAW_RECORDS", "1")
+
+    with pytest.raises(RuntimeError, match="Refusing to eagerly load 2 raw GP residual records"):
+        pycolmap.GlobalPositioningTrace.load(trace_dir)
+
+
+def test_raw_binary_trace_load_allows_explicit_heavy_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    trace_dir = _make_raw_binary_trace(tmp_path)
+    monkeypatch.setenv("PYCOLMAP_GP_TRACE_ALLOW_HEAVY_LOAD", "1")
+    monkeypatch.setenv("PYCOLMAP_GP_TRACE_MAX_EAGER_RAW_RECORDS", "1")
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+
+    assert len(trace.residual_blocks) == 2
 
 
 def _artifact(filename: str, ids, shape) -> dict:
@@ -384,9 +497,7 @@ def _iteration_metric(
     )
 
 
-def _make_trace(
-    tmp_path: Path, *, with_jacobians: bool, with_loss_rho: bool = False
-) -> Path:
+def _make_trace(tmp_path: Path, *, with_jacobians: bool, with_loss_rho: bool = False) -> Path:
     trace_dir = tmp_path / ("trace_jacobians" if with_jacobians else "trace_values")
     residual_values_dir = trace_dir / "residual_values"
     residual_values_dir.mkdir(parents=True)
@@ -397,9 +508,7 @@ def _make_trace(
             "schema_version": 1,
             "run_id": "run",
             "status": "finished",
-            "trace_level": (
-                "residual_jacobians" if with_jacobians else "residual_values"
-            ),
+            "trace_level": ("residual_jacobians" if with_jacobians else "residual_values"),
         },
     )
     _write_jsonl(
@@ -466,9 +575,7 @@ def _make_trace(
                     [[-1.0, -1.0, -1.0], [1e-5]],
                     [[1e-5]],
                 ],
-                "raw_jacobian_layout": (
-                    "residual_block_major/parameter_block_major/row_major"
-                ),
+                "raw_jacobian_layout": ("residual_block_major/parameter_block_major/row_major"),
                 "jacobian_domain": "raw_cost_function_ambient_parameters",
                 "loss_applied_to_jacobians": False,
                 "manifold_applied_to_jacobians": False,
@@ -543,24 +650,16 @@ def _make_snapshot_trace(tmp_path: Path, *, include_optional: bool = True) -> Pa
     _write_f64(snapshots_dir / f"{prefix}_scales_f64.bin", scales)
 
     artifacts = {
-        "frame_centers": _artifact(
-            f"{prefix}_frame_centers_f64.bin", frame_ids, frame_centers.shape
-        ),
-        "points3D": _artifact(
-            f"{prefix}_points3D_f64.bin", point3D_ids, points3D.shape
-        ),
+        "frame_centers": _artifact(f"{prefix}_frame_centers_f64.bin", frame_ids, frame_centers.shape),
+        "points3D": _artifact(f"{prefix}_points3D_f64.bin", point3D_ids, points3D.shape),
         "scales": _artifact(f"{prefix}_scales_f64.bin", scale_ids, scales.shape),
     }
     dmap_shape = [0]
     if include_optional:
         _write_f64(snapshots_dir / f"{prefix}_dmap_scales_f64.bin", dmap_scales)
         _write_f64(snapshots_dir / f"{prefix}_cams_in_rig_f64.bin", cams_in_rig)
-        artifacts["dmap_scales"] = _artifact(
-            f"{prefix}_dmap_scales_f64.bin", dmap_ids, dmap_scales.shape
-        )
-        artifacts["cams_in_rig"] = _artifact(
-            f"{prefix}_cams_in_rig_f64.bin", cam_ids, cams_in_rig.shape
-        )
+        artifacts["dmap_scales"] = _artifact(f"{prefix}_dmap_scales_f64.bin", dmap_ids, dmap_scales.shape)
+        artifacts["cams_in_rig"] = _artifact(f"{prefix}_cams_in_rig_f64.bin", cam_ids, cams_in_rig.shape)
         dmap_shape = list(dmap_scales.shape)
     else:
         dmap_ids = []
@@ -670,19 +769,11 @@ def _make_replay_trace(tmp_path: Path, records: list[dict] | None = None) -> Pat
             "dmap_image_ids": [50],
             "dmap_scales_stored_shape": list(dmap_scales.shape),
             "artifacts": {
-                "frame_centers": _artifact(
-                    f"{prefix}_frame_centers_f64.bin", [10], frame_centers.shape
-                ),
-                "points3D": _artifact(
-                    f"{prefix}_points3D_f64.bin", [20], points3D.shape
-                ),
+                "frame_centers": _artifact(f"{prefix}_frame_centers_f64.bin", [10], frame_centers.shape),
+                "points3D": _artifact(f"{prefix}_points3D_f64.bin", [20], points3D.shape),
                 "scales": _artifact(f"{prefix}_scales_f64.bin", [30], scales.shape),
-                "dmap_scales": _artifact(
-                    f"{prefix}_dmap_scales_f64.bin", [50], dmap_scales.shape
-                ),
-                "cams_in_rig": _artifact(
-                    f"{prefix}_cams_in_rig_f64.bin", [70], cams_in_rig.shape
-                ),
+                "dmap_scales": _artifact(f"{prefix}_dmap_scales_f64.bin", [50], dmap_scales.shape),
+                "cams_in_rig": _artifact(f"{prefix}_cams_in_rig_f64.bin", [70], cams_in_rig.shape),
             },
         },
     )
@@ -877,18 +968,11 @@ def _write_replay_residual_dump(trace_dir: Path) -> None:
         ],
         [{"role": "dmap_scale", "kind": "dmap_scale", "id": 50}],
     ]
-    parameter_block_sizes = [
-        [block.shape[1] for block in residual_blocks]
-        for residual_blocks in jacobian_blocks
-    ]
-    parameter_block_is_constant = [
-        [False] * len(residual_blocks) for residual_blocks in jacobian_blocks
-    ]
+    parameter_block_sizes = [[block.shape[1] for block in residual_blocks] for residual_blocks in jacobian_blocks]
+    parameter_block_is_constant = [[False] * len(residual_blocks) for residual_blocks in jacobian_blocks]
     parameter_block_lower_bounds = []
     for residual_blocks in jacobian_blocks:
-        parameter_block_lower_bounds.append(
-            [[-1e100] * block.shape[1] for block in residual_blocks]
-        )
+        parameter_block_lower_bounds.append([[-1e100] * block.shape[1] for block in residual_blocks])
 
     _write_json(
         residual_values_dir / f"{prefix}.json",
@@ -954,9 +1038,7 @@ def _write_replay_residual_dump(trace_dir: Path) -> None:
     _write_f64(residual_values_dir / f"{prefix}_raw_residuals_f64.bin", raw_residuals)
     _write_f64(residual_values_dir / f"{prefix}_raw_costs_f64.bin", raw_costs)
     _write_f64(residual_values_dir / f"{prefix}_robust_costs_f64.bin", robust_costs)
-    _write_f64(
-        residual_values_dir / f"{prefix}_loss_rho_values_f64.bin", loss_rho_values
-    )
+    _write_f64(residual_values_dir / f"{prefix}_loss_rho_values_f64.bin", loss_rho_values)
     _write_f64(residual_values_dir / f"{prefix}_raw_jacobians_f64.bin", raw_jacobians)
 
 
@@ -970,18 +1052,12 @@ def _flatten_replay_jacobians(
     replay: pycolmap.GlobalPositioningReplayEvaluation,
 ) -> np.ndarray:
     return np.concatenate(
-        [
-            block.values.ravel()
-            for residual_blocks in replay.raw_jacobians
-            for block in residual_blocks
-        ]
+        [block.values.ravel() for residual_blocks in replay.raw_jacobians for block in residual_blocks]
     )
 
 
 def test_global_positioning_trace_loads_residual_values(tmp_path: Path) -> None:
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_trace(tmp_path, with_jacobians=False)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_trace(tmp_path, with_jacobians=False))
 
     assert trace.status == "finished"
     assert trace.trace_level == "residual_values"
@@ -1130,9 +1206,7 @@ def test_global_positioning_trace_rejects_non_iteration_metric_event(
 def test_global_positioning_trace_loads_loss_rho_values(
     tmp_path: Path,
 ) -> None:
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_trace(tmp_path, with_jacobians=False, with_loss_rho=True)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_trace(tmp_path, with_jacobians=False, with_loss_rho=True))
 
     residual_values = trace.residual_values()
     assert residual_values.has_loss_rho_values is True
@@ -1220,9 +1294,7 @@ def test_global_positioning_trace_allows_failed_loss_rho_nan_rows(
 
 
 def test_global_positioning_trace_loads_raw_jacobians(tmp_path: Path) -> None:
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_trace(tmp_path, with_jacobians=True)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_trace(tmp_path, with_jacobians=True))
     residual_values = trace.residual_values(iteration=0)
 
     assert residual_values.has_raw_jacobians is True
@@ -1236,22 +1308,16 @@ def test_global_positioning_trace_loads_raw_jacobians(tmp_path: Path) -> None:
     assert residual.parameter_blocks[1].is_constant is True
     assert residual.parameter_blocks[1].lower_bounds == (1e-5,)
 
-    np.testing.assert_allclose(
-        residual.jacobian(0), np.arange(6, dtype=np.float64).reshape(2, 3)
-    )
+    np.testing.assert_allclose(residual.jacobian(0), np.arange(6, dtype=np.float64).reshape(2, 3))
     np.testing.assert_allclose(residual.jacobian("bata_scale"), [[6.0], [7.0]])
-    np.testing.assert_allclose(
-        residual_values.residual("r1").jacobian("dmap_scale", id=20), [[8.0]]
-    )
+    np.testing.assert_allclose(residual_values.residual("r1").jacobian("dmap_scale", id=20), [[8.0]])
 
 
 def test_global_positioning_trace_rejects_bad_sidecar_size(
     tmp_path: Path,
 ) -> None:
     trace_dir = _make_trace(tmp_path, with_jacobians=False)
-    (trace_dir / "residual_values" / "iter_000000_raw_costs_f64.bin").write_bytes(
-        b"short"
-    )
+    (trace_dir / "residual_values" / "iter_000000_raw_costs_f64.bin").write_bytes(b"short")
 
     trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
     with np.testing.assert_raises(ValueError):
@@ -1357,9 +1423,7 @@ def test_global_positioning_trace_rejects_deferred_residual_ledger_block(
     )
 
     trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
-    assert trace.residual_blocks[0]["attrs"]["fixed_parameters_status"] == (
-        "deferred_not_serialized"
-    )
+    assert trace.residual_blocks[0]["attrs"]["fixed_parameters_status"] == ("deferred_not_serialized")
     with pytest.raises(ValueError, match="fixed_parameters_status"):
         _ = trace.residual_ledger_blocks
 
@@ -1415,9 +1479,7 @@ def test_global_positioning_trace_rejects_bad_ledger_fixed_parameters(
 def test_global_positioning_trace_ignores_legacy_residual_ledger_rows(
     tmp_path: Path,
 ) -> None:
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_trace(tmp_path, with_jacobians=False)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_trace(tmp_path, with_jacobians=False))
 
     assert [record["attrs"]["residual_id"] for record in trace.residual_blocks] == [
         "r0",
@@ -1515,9 +1577,7 @@ def test_global_positioning_trace_rejects_residual_path_traversal(
 def test_global_positioning_trace_loads_snapshot_with_all_artifacts(
     tmp_path: Path,
 ) -> None:
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_snapshot_trace(tmp_path, include_optional=True)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_snapshot_trace(tmp_path, include_optional=True))
 
     assert trace.snapshot_iterations == (3,)
     snapshot = trace.snapshot(3)
@@ -1551,9 +1611,7 @@ def test_global_positioning_trace_loads_snapshot_with_all_artifacts(
 def test_global_positioning_trace_snapshot_optional_artifacts_missing(
     tmp_path: Path,
 ) -> None:
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_snapshot_trace(tmp_path, include_optional=False)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_snapshot_trace(tmp_path, include_optional=False))
 
     snapshot = trace.snapshot(3)
 
@@ -1581,9 +1639,7 @@ def test_global_positioning_trace_snapshot_accepts_legacy_missing_scales(
 
 
 def test_global_positioning_trace_snapshot_max_points(tmp_path: Path) -> None:
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_snapshot_trace(tmp_path, include_optional=True)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_snapshot_trace(tmp_path, include_optional=True))
 
     snapshot = trace.snapshot(3, max_points=2)
 
@@ -1723,9 +1779,7 @@ def test_global_positioning_trace_replay_exposes_residual_values_compatibility(
     residual_with_jacobians = replay_with_jacobians.residual("bata_ref")
     assert residual_with_jacobians.raw_cost == pytest.approx(residual.raw_cost)
     np.testing.assert_allclose(residual_with_jacobians.loss_rho, residual.loss_rho)
-    assert len(residual_with_jacobians.jacobian_blocks) == len(
-        residual_with_jacobians.parameter_blocks
-    )
+    assert len(residual_with_jacobians.jacobian_blocks) == len(residual_with_jacobians.parameter_blocks)
     jacobian_block = residual_with_jacobians.jacobian_blocks[0]
     assert jacobian_block.parameter_block.role == "frame_center"
     assert jacobian_block.parameter_block.kind == "frame_center"
@@ -1740,9 +1794,7 @@ def test_global_positioning_trace_replay_matches_synthetic_on_disk_residual_dump
     tmp_path: Path,
 ) -> None:
     """Synthetic on-disk parity, not a true C++-generated golden trace."""
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_replay_trace_with_residual_dump(tmp_path)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_replay_trace_with_residual_dump(tmp_path))
     dumped = trace.residual_values(iteration=3)
 
     replay = trace.replay(iteration=3)
@@ -1763,9 +1815,7 @@ def test_global_positioning_trace_replay_matches_synthetic_on_disk_residual_dump
         assert replay_residual.residual_dim == dumped_residual.residual_dim
         assert replay_residual.residual_offset == dumped_residual.residual_offset
         assert replay_residual.evaluation_success == dumped_residual.evaluation_success
-        np.testing.assert_allclose(
-            replay_residual.raw_residuals, dumped_residual.raw_residuals
-        )
+        np.testing.assert_allclose(replay_residual.raw_residuals, dumped_residual.raw_residuals)
         assert replay_residual.raw_cost == pytest.approx(dumped_residual.raw_cost)
         assert replay_residual.robust_cost == pytest.approx(dumped_residual.robust_cost)
         np.testing.assert_allclose(replay_residual.loss_rho, dumped_residual.loss_rho)
@@ -1782,9 +1832,7 @@ def test_global_positioning_trace_replay_matches_synthetic_on_disk_residual_dump
     for residual_id in replay_with_jacobians.residual_ids:
         replay_residual = replay_with_jacobians.residual(residual_id)
         dumped_residual = dumped.residual(residual_id)
-        assert len(replay_residual.jacobian_blocks) == len(
-            dumped_residual.jacobian_blocks
-        )
+        assert len(replay_residual.jacobian_blocks) == len(dumped_residual.jacobian_blocks)
         for replay_block, dumped_block in zip(
             replay_residual.jacobian_blocks,
             dumped_residual.jacobian_blocks,
@@ -1792,16 +1840,10 @@ def test_global_positioning_trace_replay_matches_synthetic_on_disk_residual_dump
         ):
             assert replay_block.offset == dumped_block.offset
             assert replay_block.residual_dim == dumped_block.residual_dim
-            assert (
-                replay_block.parameter_block.role == dumped_block.parameter_block.role
-            )
-            assert (
-                replay_block.parameter_block.kind == dumped_block.parameter_block.kind
-            )
+            assert replay_block.parameter_block.role == dumped_block.parameter_block.role
+            assert replay_block.parameter_block.kind == dumped_block.parameter_block.kind
             assert replay_block.parameter_block.id == dumped_block.parameter_block.id
-            assert (
-                replay_block.parameter_block.size == dumped_block.parameter_block.size
-            )
+            assert replay_block.parameter_block.size == dumped_block.parameter_block.size
             np.testing.assert_allclose(
                 replay_block.values,
                 dumped_block.values,
@@ -1847,9 +1889,7 @@ def test_global_positioning_trace_replay_finite_difference_jacobian_shape(
     assert residual.jacobian_blocks[2].values.shape == (3, 1)
     np.testing.assert_allclose(residual.jacobian_blocks[0].values, 0.5 * np.eye(3))
     np.testing.assert_allclose(residual.jacobian_blocks[1].values, -0.5 * np.eye(3))
-    np.testing.assert_allclose(
-        residual.jacobian_blocks[2].values[:, 0], [-3.0, -2.0, -3.0]
-    )
+    np.testing.assert_allclose(residual.jacobian_blocks[2].values[:, 0], [-3.0, -2.0, -3.0])
     assert residual.jacobian_blocks[0].offset == 0
     assert residual.jacobian_blocks[1].offset == 9
     assert residual.jacobian_blocks[2].offset == 18
@@ -1874,9 +1914,7 @@ def test_global_positioning_trace_replay_fails_loudly_for_bad_inputs(
             ),
         }
     ]
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_replay_trace(tmp_path / "bad_loss", unknown_loss_records)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_replay_trace(tmp_path / "bad_loss", unknown_loss_records))
     with pytest.raises(ValueError, match="unsupported loss type"):
         trace.replay(iteration=3)
 
@@ -1902,9 +1940,7 @@ def test_global_positioning_trace_replay_fails_loudly_for_bad_inputs(
             ),
         }
     ]
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_replay_trace(tmp_path / "bad_quat", bad_quat_records)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_replay_trace(tmp_path / "bad_quat", bad_quat_records))
     with pytest.raises(ValueError, match="camera_rotation_wxyz.*length 4"):
         trace.replay(iteration=3)
 
@@ -1923,9 +1959,7 @@ def test_global_positioning_trace_replay_fails_loudly_for_bad_inputs(
             ),
         }
     ]
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_replay_trace(tmp_path / "missing_fixed", missing_fixed_records)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_replay_trace(tmp_path / "missing_fixed", missing_fixed_records))
     with pytest.raises(KeyError, match="cam_from_rig_dir"):
         trace.replay(iteration=3)
 
@@ -1983,19 +2017,76 @@ def test_global_positioning_trace_raw_binary_fixture_contract_minimal(
     assert snapshot.frame_centers.ids == (10, 20)
     assert snapshot.points3D.ids == (100,)
     assert snapshot.scales.ids == (0,)
-    np.testing.assert_allclose(
-        snapshot.frame_centers.values, [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
-    )
+    np.testing.assert_allclose(snapshot.frame_centers.values, [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
     np.testing.assert_allclose(snapshot.points3D.values, [[0.0, 0.0, 2.0]])
     np.testing.assert_allclose(snapshot.scales.values, [1.0])
+
+
+def test_global_positioning_trace_raw_binary_accepts_legacy_json_ledger(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(_make_raw_binary_trace(tmp_path, residual_ledger_version=1))
+
+    assert [record["attrs"]["residual_id"] for record in trace.residual_blocks] == [
+        "r10",
+        "r20",
+    ]
+    assert trace.residual_blocks[0]["attrs"]["frame_id"] == 10
+
+
+def test_global_positioning_trace_raw_binary_loads_structured_v2_ledger(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_raw_binary_trace(tmp_path)
+    records = _raw_support_records()
+    records[0]["attrs"].update(
+        {
+            "replay_schema_version": 1,
+            "parameter_blocks": [
+                {"role": "frame_center", "kind": "frame_center", "id": 10, "size": 3},
+                {"role": "point3D", "kind": "point3D", "id": 100, "size": 3},
+            ],
+            "loss": {
+                "bucket": "geometry_normal_inlier",
+                "type": "huber",
+                "scale": 0.1,
+                "weight": 0.5,
+                "source": "test",
+                "observation_count_weight": 2.0,
+            },
+            "fixed_parameters_status": "serialized",
+            "fixed_parameters": {
+                "cam_from_point3D_dir": [1.0, 0.0, 0.0],
+                "metric_depth_use_log_scale": True,
+                "metric_depth_residual_type": "log",
+                "metric_depth_zero_residual_behind": False,
+                "metric_depth_log_linear_threshold": 0.25,
+                "scale_prior_target": 1.5,
+                "scale_prior_stddev": 0.2,
+            },
+        }
+    )
+    _write_raw_residual_ledger(
+        trace_dir / "static" / "residual_ledger.bin",
+        records,
+        version=2,
+    )
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    block = trace.residual_ledger_blocks[0]
+
+    assert block.replay_schema_version == 1
+    assert block.parameter_blocks[0].size == 3
+    assert block.loss.type == "huber"
+    assert block.loss.observation_count_weight == 2.0
+    assert block.fixed_parameters["cam_from_point3D_dir"] == [1.0, 0.0, 0.0]
+    assert block.fixed_parameters["metric_depth_use_log_scale"] is True
 
 
 def test_global_positioning_trace_raw_binary_accepts_v2_without_jacobians(
     tmp_path: Path,
 ) -> None:
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_raw_binary_trace(tmp_path, force_residual_version=2)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_raw_binary_trace(tmp_path, force_residual_version=2))
 
     residual_values = trace.residual_values(0)
     assert residual_values.has_raw_jacobians is False
@@ -2006,9 +2097,7 @@ def test_global_positioning_trace_raw_binary_accepts_v2_without_jacobians(
 def test_global_positioning_trace_raw_binary_loads_optional_jacobians(
     tmp_path: Path,
 ) -> None:
-    trace = pycolmap.GlobalPositioningTrace.load(
-        _make_raw_binary_trace(tmp_path, with_jacobians=True)
-    )
+    trace = pycolmap.GlobalPositioningTrace.load(_make_raw_binary_trace(tmp_path, with_jacobians=True))
 
     residual_values = trace.residual_values(0)
     assert residual_values.has_raw_jacobians is True
@@ -2032,9 +2121,7 @@ def test_global_positioning_trace_raw_binary_loads_optional_jacobians(
         [-np.inf, -np.inf, -np.inf],
     )
     np.testing.assert_allclose(residual.parameter_blocks[1].lower_bounds, [1e-5])
-    np.testing.assert_allclose(
-        residual.jacobian("frame_center"), np.arange(6).reshape(2, 3)
-    )
+    np.testing.assert_allclose(residual.jacobian("frame_center"), np.arange(6).reshape(2, 3))
     np.testing.assert_allclose(residual.jacobian("bata_scale"), [[6.0], [7.0]])
 
     residual_2 = residual_values.residual("r20")

--- a/python/pycolmap/global_positioning_trace_test.py
+++ b/python/pycolmap/global_positioning_trace_test.py
@@ -1,4 +1,5 @@
 import json
+import struct
 from pathlib import Path
 
 import numpy as np
@@ -22,6 +23,275 @@ def _write_f64(path: Path, values) -> None:
     np.asarray(values, dtype="<f8").tofile(path)
 
 
+def _write_raw_string(stream, value: str) -> None:
+    payload = value.encode("utf-8")
+    stream.write(struct.pack("<I", len(payload)))
+    stream.write(payload)
+
+
+def _write_raw_json(stream, value: dict) -> None:
+    _write_raw_string(stream, json.dumps(value, sort_keys=True, separators=(",", ":")))
+
+
+def _write_raw_array(path: Path, name: str, ids, values) -> None:
+    values = np.asarray(values, dtype="<f8")
+    ids = np.asarray(ids, dtype="<i8")
+    if values.ndim == 1:
+        rows = values.shape[0]
+        cols = 1
+    else:
+        rows, cols = values.shape
+    assert rows == ids.shape[0]
+    with path.open("wb") as stream:
+        stream.write(b"GPTRARR1")
+        stream.write(struct.pack("<IQQ", 1, rows, cols))
+        _write_raw_string(stream, name)
+        ids.tofile(stream)
+        values.reshape(-1).tofile(stream)
+
+
+def _write_raw_residual_ledger(path: Path, records: list[dict]) -> None:
+    with path.open("wb") as stream:
+        stream.write(b"GPTRLGR1")
+        stream.write(struct.pack("<IQ", 1, len(records)))
+        for record in records:
+            attrs = record["attrs"]
+            _write_raw_string(stream, attrs["residual_id"])
+            _write_raw_string(stream, attrs["residual_type"])
+            _write_raw_string(stream, attrs["loss_bucket"])
+            stream.write(
+                struct.pack(
+                    "<qqq?",
+                    -1 if attrs.get("frame_id") is None else attrs["frame_id"],
+                    -1 if attrs.get("image_id") is None else attrs["image_id"],
+                    -1 if attrs.get("point3D_id") is None else attrs["point3D_id"],
+                    attrs.get("is_lc_observation", False),
+                )
+            )
+            _write_raw_json(stream, attrs)
+
+
+def _write_raw_residual_values(
+    path: Path,
+    *,
+    iteration: int,
+    residual_ids: list[str],
+    residual_dims: list[int],
+    evaluation_success: list[bool],
+    raw_residuals,
+    raw_costs,
+    robust_costs,
+    loss_rho_values=None,
+    parameter_blocks: list[list[dict]] | None = None,
+    raw_jacobians=None,
+    force_version: int | None = None,
+) -> None:
+    residual_offsets = []
+    offset = 0
+    for dim in residual_dims:
+        residual_offsets.append(offset)
+        offset += dim
+    raw_residuals = np.asarray(raw_residuals, dtype="<f8")
+    raw_costs = np.asarray(raw_costs, dtype="<f8")
+    robust_costs = np.asarray(robust_costs, dtype="<f8")
+    has_raw_jacobians = parameter_blocks is not None
+    if has_raw_jacobians:
+        assert raw_jacobians is not None
+        raw_jacobians = np.asarray(raw_jacobians, dtype="<f8")
+    with path.open("wb") as stream:
+        stream.write(b"GPTRRSV1")
+        version = force_version or (2 if has_raw_jacobians else 1)
+        if version == 2:
+            stream.write(
+                struct.pack(
+                    "<IqQQ??",
+                    2,
+                    iteration,
+                    len(residual_ids),
+                    raw_residuals.size,
+                    loss_rho_values is not None,
+                    has_raw_jacobians,
+                )
+            )
+        else:
+            assert version == 1
+            assert not has_raw_jacobians
+            stream.write(
+                struct.pack(
+                    "<IqQQ?",
+                    1,
+                    iteration,
+                    len(residual_ids),
+                    raw_residuals.size,
+                    loss_rho_values is not None,
+                )
+            )
+        for residual_id, residual_dim, residual_offset, success in zip(
+            residual_ids,
+            residual_dims,
+            residual_offsets,
+            evaluation_success,
+            strict=True,
+        ):
+            _write_raw_string(stream, residual_id)
+            stream.write(struct.pack("<IQ?", residual_dim, residual_offset, success))
+        raw_residuals.tofile(stream)
+        raw_costs.tofile(stream)
+        robust_costs.tofile(stream)
+        if loss_rho_values is not None:
+            np.asarray(loss_rho_values, dtype="<f8").reshape((-1, 3)).tofile(stream)
+        if has_raw_jacobians:
+            assert parameter_blocks is not None
+            stream.write(struct.pack("<Q", raw_jacobians.size))
+            expected_offset = 0
+            for residual_idx, residual_blocks in enumerate(parameter_blocks):
+                stream.write(struct.pack("<I", len(residual_blocks)))
+                for block in residual_blocks:
+                    block_size = int(block["size"])
+                    _write_raw_string(stream, block["role"])
+                    _write_raw_string(stream, block["kind"])
+                    stream.write(
+                        struct.pack(
+                            "<QIQ?",
+                            int(block["id"]),
+                            block_size,
+                            expected_offset,
+                            bool(block.get("is_constant", False)),
+                        )
+                    )
+                    np.asarray(block["lower_bounds"], dtype="<f8").tofile(stream)
+                    expected_offset += residual_dims[residual_idx] * block_size
+            assert expected_offset == raw_jacobians.size
+            raw_jacobians.tofile(stream)
+
+
+def _raw_support_records() -> list[dict]:
+    return [
+        {
+            "event_type": "residual_added",
+            "attrs": {
+                "residual_id": "r10",
+                "residual_type": "bata_ref_frame",
+                "loss_bucket": "geometry_normal_inlier",
+                "frame_id": 10,
+                "image_id": 1010,
+                "point3D_id": 100,
+                "is_lc_observation": False,
+            },
+        },
+        {
+            "event_type": "residual_added",
+            "attrs": {
+                "residual_id": "r20",
+                "residual_type": "bata_ref_frame",
+                "loss_bucket": "geometry_normal_inlier",
+                "frame_id": 20,
+                "image_id": 1020,
+                "point3D_id": 100,
+                "is_lc_observation": False,
+            },
+        },
+    ]
+
+
+def _make_raw_binary_trace(
+    tmp_path: Path,
+    *,
+    with_jacobians: bool = False,
+    force_residual_version: int | None = None,
+) -> Path:
+    trace_dir = tmp_path / "trace_raw_binary"
+    static_dir = trace_dir / "static"
+    iteration_dir = trace_dir / "iterations" / "iter_000000"
+    static_dir.mkdir(parents=True)
+    iteration_dir.mkdir(parents=True)
+
+    records = _raw_support_records()
+    _write_raw_residual_ledger(static_dir / "residual_ledger.bin", records)
+    _write_raw_array(
+        iteration_dir / "frame_centers.bin",
+        "frame_centers",
+        [10, 20],
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+    )
+    _write_raw_array(
+        iteration_dir / "point_xyz.bin", "point_xyz", [100], [[0.0, 0.0, 2.0]]
+    )
+    _write_raw_array(iteration_dir / "scales.bin", "scales", [0], [1.0])
+    parameter_blocks = None
+    raw_jacobians = None
+    if with_jacobians:
+        parameter_blocks = [
+            [
+                {
+                    "role": "frame_center",
+                    "kind": "frame_center",
+                    "id": 10,
+                    "size": 3,
+                    "is_constant": False,
+                    "lower_bounds": [-np.inf, -np.inf, -np.inf],
+                },
+                {
+                    "role": "bata_scale",
+                    "kind": "bata_scale",
+                    "id": 0,
+                    "size": 1,
+                    "is_constant": True,
+                    "lower_bounds": [1e-5],
+                },
+            ],
+            [
+                {
+                    "role": "dmap_scale",
+                    "kind": "dmap_scale",
+                    "id": 20,
+                    "size": 1,
+                    "is_constant": False,
+                    "lower_bounds": [1e-5],
+                }
+            ],
+        ]
+        raw_jacobians = np.arange(9, dtype=np.float64)
+    _write_raw_residual_values(
+        iteration_dir / "residual_values.bin",
+        iteration=0,
+        residual_ids=["r10", "r20"],
+        residual_dims=[2, 1],
+        evaluation_success=[True, True],
+        raw_residuals=[1.0, 2.0, 3.0],
+        raw_costs=[2.5, 4.5],
+        robust_costs=[2.25, 4.25],
+        loss_rho_values=[[4.5, 0.25, -0.125], [8.5, 1.0, 0.0]],
+        parameter_blocks=parameter_blocks,
+        raw_jacobians=raw_jacobians,
+        force_version=force_residual_version,
+    )
+    _write_json(
+        trace_dir / "manifest.json",
+        {
+            "schema_version": 1,
+            "storage_format": "global_positioning_raw_binary_v1",
+            "run_id": "run",
+            "status": "finished",
+            "trace_level": "raw_binary_minimal",
+            "byte_order": "little_endian",
+            "dtype": "float64",
+            "static": {"residual_ledger": "static/residual_ledger.bin"},
+            "iterations": [
+                {
+                    "iteration": 0,
+                    "directory": "iterations/iter_000000",
+                    "frame_centers": "frame_centers.bin",
+                    "point_xyz": "point_xyz.bin",
+                    "scales": "scales.bin",
+                    "residual_values": "residual_values.bin",
+                }
+            ],
+        },
+    )
+    return trace_dir
+
+
 def _artifact(filename: str, ids, shape) -> dict:
     return {
         "file": filename,
@@ -32,12 +302,92 @@ def _artifact(filename: str, ids, shape) -> dict:
     }
 
 
+def _ledger_attrs(residual_id: str) -> dict:
+    return {
+        "residual_id": residual_id,
+        "replay_schema_version": 1,
+        "parameter_blocks": [
+            {
+                "role": "frame_center",
+                "kind": "frame_center",
+                "id": 10,
+                "size": 3,
+            },
+            {
+                "role": "point3D",
+                "kind": "point3D",
+                "id": 20,
+                "size": 3,
+            },
+        ],
+        "loss": {
+            "bucket": "track",
+            "type": "cauchy",
+            "scale": 1.5,
+            "weight": None,
+            "source": "config",
+            "observation_count_weight": 0.25,
+        },
+        "fixed_parameters_status": "serialized",
+        "fixed_parameters": {
+            "image_id": 7,
+            "point2D_idx": 3,
+            "is_lc_observation": False,
+        },
+    }
+
+
+def _trace_record(
+    event_type: str,
+    *,
+    seq: int,
+    stage: str = "ceres_solve",
+    iteration: int | None = None,
+    attrs: dict | None = None,
+) -> dict:
+    return {
+        "schema_version": 1,
+        "run_id": "run",
+        "seq": seq,
+        "event_type": event_type,
+        "stage": stage,
+        "iteration": iteration,
+        "timestamp_ns": 1000 + seq,
+        "attrs": attrs or {},
+    }
+
+
+def _iteration_metric(
+    iteration: int,
+    *,
+    seq: int,
+    attrs: dict | None = None,
+) -> dict:
+    metric_attrs = {
+        "step_is_successful": True,
+        "cost": 42.0,
+        "cost_change": -3.5,
+        "gradient_max_norm": 0.25,
+        "step_norm": 1.5,
+        "trust_region_radius": 10.0,
+        "linear_solver_iterations": 7,
+        "iteration_time_sec": 0.125,
+        "cumulative_time_sec": 0.5,
+    }
+    if attrs:
+        metric_attrs.update(attrs)
+    return _trace_record(
+        "ceres_iteration",
+        seq=seq,
+        iteration=iteration,
+        attrs=metric_attrs,
+    )
+
+
 def _make_trace(
     tmp_path: Path, *, with_jacobians: bool, with_loss_rho: bool = False
 ) -> Path:
-    trace_dir = tmp_path / (
-        "trace_jacobians" if with_jacobians else "trace_values"
-    )
+    trace_dir = tmp_path / ("trace_jacobians" if with_jacobians else "trace_values")
     residual_values_dir = trace_dir / "residual_values"
     residual_values_dir.mkdir(parents=True)
 
@@ -145,12 +495,8 @@ def _make_trace(
         residual_values_dir / "iter_000000_raw_residuals_f64.bin",
         [1.0, 2.0, 3.0],
     )
-    _write_f64(
-        residual_values_dir / "iter_000000_raw_costs_f64.bin", [2.5, 4.5]
-    )
-    _write_f64(
-        residual_values_dir / "iter_000000_robust_costs_f64.bin", [2.25, 4.25]
-    )
+    _write_f64(residual_values_dir / "iter_000000_raw_costs_f64.bin", [2.5, 4.5])
+    _write_f64(residual_values_dir / "iter_000000_robust_costs_f64.bin", [2.25, 4.25])
     if with_loss_rho:
         _write_f64(
             residual_values_dir / "iter_000000_loss_rho_values_f64.bin",
@@ -164,9 +510,7 @@ def _make_trace(
     return trace_dir
 
 
-def _make_snapshot_trace(
-    tmp_path: Path, *, include_optional: bool = True
-) -> Path:
+def _make_snapshot_trace(tmp_path: Path, *, include_optional: bool = True) -> Path:
     trace_dir = tmp_path / "trace_snapshots"
     snapshots_dir = trace_dir / "snapshots"
     snapshots_dir.mkdir(parents=True)
@@ -182,9 +526,7 @@ def _make_snapshot_trace(
 
     iteration = 3
     prefix = f"iter_{iteration:06d}"
-    frame_centers = np.array(
-        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float64
-    )
+    frame_centers = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float64)
     points3D = np.arange(15, dtype=np.float64).reshape(5, 3)
     scales = np.array([0.5, 1.5], dtype=np.float64)
     dmap_scales = np.array([2.5, 3.5], dtype=np.float64)
@@ -207,9 +549,7 @@ def _make_snapshot_trace(
         "points3D": _artifact(
             f"{prefix}_points3D_f64.bin", point3D_ids, points3D.shape
         ),
-        "scales": _artifact(
-            f"{prefix}_scales_f64.bin", scale_ids, scales.shape
-        ),
+        "scales": _artifact(f"{prefix}_scales_f64.bin", scale_ids, scales.shape),
     }
     dmap_shape = [0]
     if include_optional:
@@ -248,6 +588,396 @@ def _make_snapshot_trace(
     return trace_dir
 
 
+def _replay_parameter_block(role: str, kind: str, block_id: int, size: int) -> dict:
+    return {"role": role, "kind": kind, "id": block_id, "size": size}
+
+
+def _replay_loss(loss_type: str = "trivial", scale: float = 1.0, weight=1.0) -> dict:
+    return {
+        "bucket": "test",
+        "type": loss_type,
+        "scale": scale,
+        "weight": weight,
+        "source": "test",
+    }
+
+
+def _replay_attrs(
+    residual_id: str,
+    residual_type: str,
+    parameter_blocks: list[dict],
+    fixed_parameters: dict,
+    *,
+    loss: dict | None = None,
+    extra: dict | None = None,
+) -> dict:
+    attrs = {
+        "residual_id": residual_id,
+        "residual_type": residual_type,
+        "replay_schema_version": 1,
+        "parameter_blocks": parameter_blocks,
+        "loss": loss or _replay_loss(),
+        "fixed_parameters_status": "serialized",
+        "fixed_parameters": fixed_parameters,
+    }
+    if extra:
+        attrs.update(extra)
+    return attrs
+
+
+def _make_replay_trace(tmp_path: Path, records: list[dict] | None = None) -> Path:
+    trace_dir = tmp_path / "trace_replay"
+    snapshots_dir = trace_dir / "snapshots"
+    snapshots_dir.mkdir(parents=True)
+    _write_json(
+        trace_dir / "manifest.json",
+        {
+            "schema_version": 1,
+            "run_id": "run",
+            "status": "finished",
+            "trace_level": "parameter_snapshots",
+        },
+    )
+
+    iteration = 3
+    prefix = f"iter_{iteration:06d}"
+    frame_centers = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+    points3D = np.array([[4.0, 4.0, 6.0]], dtype=np.float64)
+    scales = np.array([0.5], dtype=np.float64)
+    dmap_scales = np.array([2.0], dtype=np.float64)
+    cams_in_rig = np.array([[0.1, 0.2, 0.3]], dtype=np.float64)
+
+    _write_f64(snapshots_dir / f"{prefix}_frame_centers_f64.bin", frame_centers)
+    _write_f64(snapshots_dir / f"{prefix}_points3D_f64.bin", points3D)
+    _write_f64(snapshots_dir / f"{prefix}_scales_f64.bin", scales)
+    _write_f64(snapshots_dir / f"{prefix}_dmap_scales_f64.bin", dmap_scales)
+    _write_f64(snapshots_dir / f"{prefix}_cams_in_rig_f64.bin", cams_in_rig)
+    _write_json(
+        snapshots_dir / f"{prefix}.json",
+        {
+            "schema_version": 1,
+            "run_id": "run",
+            "iteration": iteration,
+            "dtype": "float64",
+            "byte_order": "little_endian",
+            "frame_ids": [10],
+            "frame_centers_world_shape": list(frame_centers.shape),
+            "point3D_ids": [20],
+            "points3D_world_shape": list(points3D.shape),
+            "bata_residual_ids": [],
+            "bata_scale_ids": [30],
+            "bata_scales_shape": list(scales.shape),
+            "dmap_image_ids": [50],
+            "dmap_scales_stored_shape": list(dmap_scales.shape),
+            "artifacts": {
+                "frame_centers": _artifact(
+                    f"{prefix}_frame_centers_f64.bin", [10], frame_centers.shape
+                ),
+                "points3D": _artifact(
+                    f"{prefix}_points3D_f64.bin", [20], points3D.shape
+                ),
+                "scales": _artifact(f"{prefix}_scales_f64.bin", [30], scales.shape),
+                "dmap_scales": _artifact(
+                    f"{prefix}_dmap_scales_f64.bin", [50], dmap_scales.shape
+                ),
+                "cams_in_rig": _artifact(
+                    f"{prefix}_cams_in_rig_f64.bin", [70], cams_in_rig.shape
+                ),
+            },
+        },
+    )
+
+    common_bata_blocks = [
+        _replay_parameter_block("frame_center", "frame_center", 10, 3),
+        _replay_parameter_block("point3D", "point3D", 20, 3),
+        _replay_parameter_block("bata_scale", "bata_scale", 30, 1),
+    ]
+    if records is None:
+        records = [
+            {
+                "event_type": "residual_added",
+                "attrs": _replay_attrs(
+                    "bata_ref",
+                    "bata_ref_frame",
+                    common_bata_blocks,
+                    {"cam_from_point3D_dir": [2.0, 0.0, 1.0]},
+                    loss=_replay_loss("cauchy", 2.0, 1.0),
+                ),
+            },
+            {
+                "event_type": "residual_added",
+                "attrs": _replay_attrs(
+                    "bata_const",
+                    "bata_constant_rig",
+                    [
+                        _replay_parameter_block("point3D", "point3D", 20, 3),
+                        _replay_parameter_block("frame_center", "frame_center", 10, 3),
+                        _replay_parameter_block("bata_scale", "bata_scale", 30, 1),
+                    ],
+                    {
+                        "cam_from_point3D_dir": [1.0, 1.0, 1.0],
+                        "cam_from_rig_dir": [0.1, 0.2, 0.3],
+                    },
+                ),
+            },
+            {
+                "event_type": "residual_added",
+                "attrs": _replay_attrs(
+                    "bata_var",
+                    "bata_variable_rig",
+                    [
+                        _replay_parameter_block("point3D", "point3D", 20, 3),
+                        _replay_parameter_block("frame_center", "frame_center", 10, 3),
+                        _replay_parameter_block("cam_in_rig", "cam_in_rig", 70, 3),
+                        _replay_parameter_block("bata_scale", "bata_scale", 30, 1),
+                    ],
+                    {
+                        "cam_from_point3D_dir": [1.0, 1.0, 1.0],
+                        "world_from_rig_rotation_wxyz": [1.0, 0.0, 0.0, 0.0],
+                    },
+                ),
+            },
+            {
+                "event_type": "residual_added",
+                "attrs": _replay_attrs(
+                    "metric",
+                    "metric_depth",
+                    [
+                        _replay_parameter_block("frame_center", "frame_center", 10, 3),
+                        _replay_parameter_block("point3D", "point3D", 20, 3),
+                        _replay_parameter_block("dmap_scale", "dmap_scale", 50, 1),
+                    ],
+                    {
+                        "camera_rotation_wxyz": [1.0, 0.0, 0.0, 0.0],
+                        "metric_depth_use_log_scale": False,
+                        "metric_depth_residual_type": "linear",
+                        "metric_depth_zero_residual_behind": False,
+                        "metric_depth_log_linear_threshold": 0.1,
+                    },
+                    extra={"depth_prior": 1.0, "depth_sigma": 0.5},
+                ),
+            },
+            {
+                "event_type": "residual_added",
+                "attrs": _replay_attrs(
+                    "scale_prior",
+                    "scale_prior",
+                    [_replay_parameter_block("dmap_scale", "dmap_scale", 50, 1)],
+                    {"scale_prior_target": 1.0, "scale_prior_stddev": 0.5},
+                    loss=_replay_loss("trivial", 1.0, 3.0),
+                ),
+            },
+        ]
+    _write_jsonl(trace_dir / "residual_blocks.jsonl", records)
+    return trace_dir
+
+
+def _write_replay_residual_dump(trace_dir: Path) -> None:
+    residual_values_dir = trace_dir / "residual_values"
+    residual_values_dir.mkdir()
+    iteration = 3
+    prefix = f"iter_{iteration:06d}"
+
+    residual_ids = [
+        "bata_ref",
+        "bata_const",
+        "bata_var",
+        "metric",
+        "scale_prior",
+    ]
+    residual_dims = [3, 3, 3, 1, 1]
+    residual_offsets = [0, 3, 6, 9, 10]
+    raw_residuals = np.array(
+        [
+            0.5,
+            -1.0,
+            -0.5,
+            -0.55,
+            -0.1,
+            -0.65,
+            -0.45,
+            0.1,
+            -0.35,
+            1.0,
+            2.0,
+        ],
+        dtype=np.float64,
+    )
+    raw_costs = np.array([0.75, 0.3675, 0.1675, 0.5, 2.0], dtype=np.float64)
+    cauchy_rho0 = 4.0 * np.log1p(1.5 / 4.0)
+    loss_rho_values = np.array(
+        [
+            [cauchy_rho0, 1.0 / 1.375, -1.0 / (4.0 * 1.375**2)],
+            [0.735, 1.0, 0.0],
+            [0.335, 1.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [12.0, 3.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    robust_costs = 0.5 * loss_rho_values[:, 0]
+
+    jacobian_blocks = [
+        [
+            0.5 * np.eye(3),
+            -0.5 * np.eye(3),
+            np.array([[-3.0], [-2.0], [-3.0]], dtype=np.float64),
+        ],
+        [
+            -0.5 * np.eye(3),
+            0.5 * np.eye(3),
+            np.array([[-3.1], [-2.2], [-3.3]], dtype=np.float64),
+        ],
+        [
+            -0.5 * np.eye(3),
+            0.5 * np.eye(3),
+            0.5 * np.eye(3),
+            np.array([[-2.9], [-1.8], [-2.7]], dtype=np.float64),
+        ],
+        [
+            np.array([[0.0, 0.0, -1.0]], dtype=np.float64),
+            np.array([[0.0, 0.0, 1.0]], dtype=np.float64),
+            np.array([[-1.5]], dtype=np.float64),
+        ],
+        [np.array([[2.0]], dtype=np.float64)],
+    ]
+    raw_jacobian_offsets = []
+    raw_jacobian_parts = []
+    jacobian_offset = 0
+    for residual_blocks in jacobian_blocks:
+        residual_offsets_for_blocks = []
+        for block in residual_blocks:
+            residual_offsets_for_blocks.append(jacobian_offset)
+            raw_jacobian_parts.append(block.ravel())
+            jacobian_offset += block.size
+        raw_jacobian_offsets.append(residual_offsets_for_blocks)
+    raw_jacobians = np.concatenate(raw_jacobian_parts)
+
+    parameter_blocks = [
+        [
+            {"role": "frame_center", "kind": "frame_center", "id": 10},
+            {"role": "point3D", "kind": "point3D", "id": 20},
+            {"role": "bata_scale", "kind": "bata_scale", "id": 30},
+        ],
+        [
+            {"role": "point3D", "kind": "point3D", "id": 20},
+            {"role": "frame_center", "kind": "frame_center", "id": 10},
+            {"role": "bata_scale", "kind": "bata_scale", "id": 30},
+        ],
+        [
+            {"role": "point3D", "kind": "point3D", "id": 20},
+            {"role": "frame_center", "kind": "frame_center", "id": 10},
+            {"role": "cam_in_rig", "kind": "cam_in_rig", "id": 70},
+            {"role": "bata_scale", "kind": "bata_scale", "id": 30},
+        ],
+        [
+            {"role": "frame_center", "kind": "frame_center", "id": 10},
+            {"role": "point3D", "kind": "point3D", "id": 20},
+            {"role": "dmap_scale", "kind": "dmap_scale", "id": 50},
+        ],
+        [{"role": "dmap_scale", "kind": "dmap_scale", "id": 50}],
+    ]
+    parameter_block_sizes = [
+        [block.shape[1] for block in residual_blocks]
+        for residual_blocks in jacobian_blocks
+    ]
+    parameter_block_is_constant = [
+        [False] * len(residual_blocks) for residual_blocks in jacobian_blocks
+    ]
+    parameter_block_lower_bounds = []
+    for residual_blocks in jacobian_blocks:
+        parameter_block_lower_bounds.append(
+            [[-1e100] * block.shape[1] for block in residual_blocks]
+        )
+
+    _write_json(
+        residual_values_dir / f"{prefix}.json",
+        {
+            "schema_version": 1,
+            "run_id": "run",
+            "iteration": iteration,
+            "dtype": "float64",
+            "byte_order": "little_endian",
+            "num_residual_blocks": len(residual_ids),
+            "total_scalar_residuals": int(raw_residuals.size),
+            "has_raw_jacobians": True,
+            "residual_ids": residual_ids,
+            "residual_dims": residual_dims,
+            "residual_offsets": residual_offsets,
+            "evaluation_success": [True] * len(residual_ids),
+            "total_jacobian_scalars": int(raw_jacobians.size),
+            "parameter_block_sizes": parameter_block_sizes,
+            "raw_jacobian_offsets": raw_jacobian_offsets,
+            "parameter_blocks": parameter_blocks,
+            "parameter_block_is_constant": parameter_block_is_constant,
+            "parameter_block_lower_bounds": parameter_block_lower_bounds,
+            "raw_jacobian_layout": "residual_block_major/parameter_block_major/row_major",
+            "jacobian_domain": "raw_cost_function_ambient_parameters",
+            "loss_applied_to_jacobians": False,
+            "manifold_applied_to_jacobians": False,
+            "constant_parameter_blocks_included": True,
+            "loss_rho_layout": "residual_block_major/rho0_rho1_rho2",
+            "artifacts": {
+                "raw_residuals": {
+                    "file": f"{prefix}_raw_residuals_f64.bin",
+                    "dtype": "float64",
+                    "byte_order": "little_endian",
+                    "shape": list(raw_residuals.shape),
+                },
+                "raw_costs": {
+                    "file": f"{prefix}_raw_costs_f64.bin",
+                    "dtype": "float64",
+                    "byte_order": "little_endian",
+                    "shape": list(raw_costs.shape),
+                },
+                "robust_costs": {
+                    "file": f"{prefix}_robust_costs_f64.bin",
+                    "dtype": "float64",
+                    "byte_order": "little_endian",
+                    "shape": list(robust_costs.shape),
+                },
+                "loss_rho_values": {
+                    "file": f"{prefix}_loss_rho_values_f64.bin",
+                    "dtype": "float64",
+                    "byte_order": "little_endian",
+                    "shape": list(loss_rho_values.shape),
+                },
+                "raw_jacobians": {
+                    "file": f"{prefix}_raw_jacobians_f64.bin",
+                    "dtype": "float64",
+                    "byte_order": "little_endian",
+                    "shape": list(raw_jacobians.shape),
+                },
+            },
+        },
+    )
+    _write_f64(residual_values_dir / f"{prefix}_raw_residuals_f64.bin", raw_residuals)
+    _write_f64(residual_values_dir / f"{prefix}_raw_costs_f64.bin", raw_costs)
+    _write_f64(residual_values_dir / f"{prefix}_robust_costs_f64.bin", robust_costs)
+    _write_f64(
+        residual_values_dir / f"{prefix}_loss_rho_values_f64.bin", loss_rho_values
+    )
+    _write_f64(residual_values_dir / f"{prefix}_raw_jacobians_f64.bin", raw_jacobians)
+
+
+def _make_replay_trace_with_residual_dump(tmp_path: Path) -> Path:
+    trace_dir = _make_replay_trace(tmp_path)
+    _write_replay_residual_dump(trace_dir)
+    return trace_dir
+
+
+def _flatten_replay_jacobians(
+    replay: pycolmap.GlobalPositioningReplayEvaluation,
+) -> np.ndarray:
+    return np.concatenate(
+        [
+            block.values.ravel()
+            for residual_blocks in replay.raw_jacobians
+            for block in residual_blocks
+        ]
+    )
+
+
 def test_global_positioning_trace_loads_residual_values(tmp_path: Path) -> None:
     trace = pycolmap.GlobalPositioningTrace.load(
         _make_trace(tmp_path, with_jacobians=False)
@@ -256,6 +986,10 @@ def test_global_positioning_trace_loads_residual_values(tmp_path: Path) -> None:
     assert trace.status == "finished"
     assert trace.trace_level == "residual_values"
     assert trace.residual_value_iterations == (0,)
+    assert trace.events == ()
+    assert trace.solver_events == ()
+    assert trace.iteration_metrics == ()
+    assert trace.iteration_metrics_by_iteration == {}
 
     residual_values = trace.residual_values()
     assert isinstance(residual_values.raw_residuals, np.memmap)
@@ -273,6 +1007,124 @@ def test_global_positioning_trace_loads_residual_values(tmp_path: Path) -> None:
         _ = residual_values.loss_rho_values
     with pytest.raises(ValueError, match="loss_rho_values artifact"):
         _ = residual.loss_rho
+
+
+def test_global_positioning_trace_loads_events_and_iteration_metrics(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    _write_jsonl(
+        trace_dir / "events.jsonl",
+        [
+            _trace_record(
+                "solve_started",
+                seq=0,
+                iteration=None,
+                attrs={"linear_solver_type": "SPARSE_SCHUR"},
+            ),
+            _trace_record(
+                "solve_finished",
+                seq=1,
+                iteration=None,
+                attrs={
+                    "termination_type": "CONVERGENCE",
+                    "message": "done",
+                    "final_cost": 12.5,
+                },
+            ),
+        ],
+    )
+    _write_jsonl(
+        trace_dir / "iteration_metrics.jsonl",
+        [
+            _iteration_metric(0, seq=2, attrs={"gradient_norm": 0.75}),
+            _iteration_metric(
+                1,
+                seq=3,
+                attrs={
+                    "step_is_successful": False,
+                    "cost": 38.0,
+                    "linear_solver_iterations": 9,
+                },
+            ),
+        ],
+    )
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+
+    assert [event.event_type for event in trace.events] == [
+        "solve_started",
+        "solve_finished",
+    ]
+    assert trace.solver_events == trace.events
+    assert trace.events[0].attrs["linear_solver_type"] == "SPARSE_SCHUR"
+    assert trace.events[0].iteration is None
+    assert trace.events[1].attrs["termination_type"] == "CONVERGENCE"
+    assert [metric.iteration for metric in trace.iteration_metrics] == [0, 1]
+    first = trace.iteration_metrics[0]
+    assert first.event_type == "ceres_iteration"
+    assert first.step_is_successful is True
+    assert first.cost == pytest.approx(42.0)
+    assert first.cost_change == pytest.approx(-3.5)
+    assert first.gradient_norm == pytest.approx(0.75)
+    assert first.gradient_max_norm == pytest.approx(0.25)
+    assert first.step_norm == pytest.approx(1.5)
+    assert first.trust_region_radius == pytest.approx(10.0)
+    assert first.linear_solver_iterations == 7
+    assert first.iteration_time_sec == pytest.approx(0.125)
+    assert first.cumulative_time_sec == pytest.approx(0.5)
+    assert trace.iteration_metrics[1].step_is_successful is False
+    assert trace.iteration_metrics_by_iteration[1].linear_solver_iterations == 9
+
+
+def test_global_positioning_trace_rejects_bad_event_record(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    record = _trace_record("solve_started", seq=0)
+    record["schema_version"] = 2
+    _write_jsonl(trace_dir / "events.jsonl", [record])
+
+    with pytest.raises(ValueError, match="unsupported schema_version"):
+        pycolmap.GlobalPositioningTrace.load(trace_dir)
+
+
+def test_global_positioning_trace_rejects_bad_iteration_metric(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    record = _iteration_metric(0, seq=0)
+    del record["attrs"]["cost"]
+    _write_jsonl(trace_dir / "iteration_metrics.jsonl", [record])
+
+    with pytest.raises(KeyError, match="cost"):
+        pycolmap.GlobalPositioningTrace.load(trace_dir)
+
+
+def test_global_positioning_trace_rejects_duplicate_iteration_metrics(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    _write_jsonl(
+        trace_dir / "iteration_metrics.jsonl",
+        [_iteration_metric(0, seq=0), _iteration_metric(0, seq=1)],
+    )
+
+    with pytest.raises(ValueError, match="duplicate iteration metric 0"):
+        pycolmap.GlobalPositioningTrace.load(trace_dir)
+
+
+def test_global_positioning_trace_rejects_non_iteration_metric_event(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    _write_jsonl(
+        trace_dir / "iteration_metrics.jsonl",
+        [_trace_record("solve_started", seq=0, iteration=None)],
+    )
+
+    with pytest.raises(ValueError, match="ceres_iteration"):
+        pycolmap.GlobalPositioningTrace.load(trace_dir)
 
 
 def test_global_positioning_trace_loads_loss_rho_values(
@@ -335,9 +1187,7 @@ def test_global_positioning_trace_validates_loss_rho_costs_on_access(
         [999.0, 4.25],
     )
 
-    residual_values = pycolmap.GlobalPositioningTrace.load(
-        trace_dir
-    ).residual_values(0)
+    residual_values = pycolmap.GlobalPositioningTrace.load(trace_dir).residual_values(0)
     with pytest.raises(ValueError, match=r"0\.5 \* loss_rho_values"):
         _ = residual_values.loss_rho_values
 
@@ -359,9 +1209,7 @@ def test_global_positioning_trace_allows_failed_loss_rho_nan_rows(
         [[float("nan"), float("nan"), float("nan")], [8.5, 1.0, 0.0]],
     )
 
-    residual_values = pycolmap.GlobalPositioningTrace.load(
-        trace_dir
-    ).residual_values(0)
+    residual_values = pycolmap.GlobalPositioningTrace.load(trace_dir).residual_values(0)
 
     assert residual_values.has_loss_rho_values is True
     np.testing.assert_allclose(
@@ -401,9 +1249,9 @@ def test_global_positioning_trace_rejects_bad_sidecar_size(
     tmp_path: Path,
 ) -> None:
     trace_dir = _make_trace(tmp_path, with_jacobians=False)
-    (
-        trace_dir / "residual_values" / "iter_000000_raw_costs_f64.bin"
-    ).write_bytes(b"short")
+    (trace_dir / "residual_values" / "iter_000000_raw_costs_f64.bin").write_bytes(
+        b"short"
+    )
 
     trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
     with np.testing.assert_raises(ValueError):
@@ -446,6 +1294,137 @@ def test_global_positioning_trace_rejects_residual_ledger_mismatch(
     trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
     with pytest.raises(ValueError, match="residual_blocks.jsonl order"):
         trace.residual_values(0)
+
+
+def test_global_positioning_trace_loads_residual_ledger_blocks(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    _write_jsonl(
+        trace_dir / "residual_blocks.jsonl",
+        [
+            {
+                "event_type": "residual_added",
+                "attrs": _ledger_attrs("r0"),
+            },
+            {
+                "event_type": "residual_added",
+                "attrs": _ledger_attrs("r1"),
+            },
+        ],
+    )
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    ledger_blocks = trace.residual_ledger_blocks
+
+    assert len(ledger_blocks) == 2
+    assert trace.residual_blocks[0]["attrs"]["replay_schema_version"] == 1
+    first = ledger_blocks[0]
+    assert isinstance(first, pycolmap.GlobalPositioningResidualLedgerBlock)
+    assert first.residual_id == "r0"
+    assert first.event_type == "residual_added"
+    assert first.replay_schema_version == 1
+    assert [block.role for block in first.parameter_blocks] == [
+        "frame_center",
+        "point3D",
+    ]
+    assert first.parameter_blocks[0].size == 3
+    assert isinstance(
+        first.parameter_blocks[0],
+        pycolmap.GlobalPositioningResidualLedgerParameterBlock,
+    )
+    assert first.loss.bucket == "track"
+    assert isinstance(first.loss, pycolmap.GlobalPositioningResidualLedgerLoss)
+    assert first.loss.type == "cauchy"
+    assert first.loss.scale == 1.5
+    assert first.loss.weight is None
+    assert first.loss.observation_count_weight == 0.25
+    assert first.fixed_parameters_status == "serialized"
+    assert first.fixed_parameters["image_id"] == 7
+
+
+def test_global_positioning_trace_rejects_deferred_residual_ledger_block(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    attrs = _ledger_attrs("r0")
+    attrs["fixed_parameters_status"] = "deferred_not_serialized"
+    del attrs["fixed_parameters"]
+    attrs["fixed_parameters_todo"] = "GP_REPLAY_FIXED_PARAMETERS_track"
+    _write_jsonl(
+        trace_dir / "residual_blocks.jsonl",
+        [{"event_type": "residual_added", "attrs": attrs}],
+    )
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    assert trace.residual_blocks[0]["attrs"]["fixed_parameters_status"] == (
+        "deferred_not_serialized"
+    )
+    with pytest.raises(ValueError, match="fixed_parameters_status"):
+        _ = trace.residual_ledger_blocks
+
+
+def test_global_positioning_trace_rejects_bad_ledger_parameter_block_size(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    attrs = _ledger_attrs("r0")
+    attrs["parameter_blocks"][0]["size"] = 0
+    _write_jsonl(
+        trace_dir / "residual_blocks.jsonl",
+        [{"event_type": "residual_added", "attrs": attrs}],
+    )
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match=r"parameter_blocks\[0\].*size"):
+        _ = trace.residual_ledger_blocks
+
+
+def test_global_positioning_trace_rejects_unsupported_residual_ledger_schema(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    attrs = _ledger_attrs("r0")
+    attrs["replay_schema_version"] = 2
+    _write_jsonl(
+        trace_dir / "residual_blocks.jsonl",
+        [{"event_type": "residual_added", "attrs": attrs}],
+    )
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="unsupported replay_schema_version"):
+        _ = trace.residual_ledger_blocks
+
+
+def test_global_positioning_trace_rejects_bad_ledger_fixed_parameters(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False)
+    attrs = _ledger_attrs("r0")
+    attrs["fixed_parameters"] = ["not", "an", "object"]
+    _write_jsonl(
+        trace_dir / "residual_blocks.jsonl",
+        [{"event_type": "residual_added", "attrs": attrs}],
+    )
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(TypeError, match="fixed_parameters must be an object"):
+        _ = trace.residual_ledger_blocks
+
+
+def test_global_positioning_trace_ignores_legacy_residual_ledger_rows(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_trace(tmp_path, with_jacobians=False)
+    )
+
+    assert [record["attrs"]["residual_id"] for record in trace.residual_blocks] == [
+        "r0",
+        "r1",
+    ]
+    assert trace.residual_ledger_blocks == ()
+    assert trace.residual_values(0).residual_ids == ["r0", "r1"]
 
 
 def test_global_positioning_trace_rejects_bad_jacobian_metadata(
@@ -515,9 +1494,7 @@ def test_global_positioning_trace_rejects_residual_filename_iteration_mismatch(
     metadata["iteration"] = 1
     _write_json(metadata_path, metadata)
 
-    with pytest.raises(
-        ValueError, match="filename does not match metadata iteration"
-    ):
+    with pytest.raises(ValueError, match="filename does not match metadata iteration"):
         pycolmap.GlobalPositioningTrace.load(trace_dir)
 
 
@@ -568,9 +1545,7 @@ def test_global_positioning_trace_loads_snapshot_with_all_artifacts(
     assert snapshot.cams_in_rig.ids == (70,)
     np.testing.assert_allclose(snapshot.cams_in_rig.values, [[0.1, 0.2, 0.3]])
     assert isinstance(snapshot, pycolmap.GlobalPositioningParameterSnapshot)
-    assert isinstance(
-        snapshot.points3D, pycolmap.GlobalPositioningSnapshotArray
-    )
+    assert isinstance(snapshot.points3D, pycolmap.GlobalPositioningSnapshotArray)
 
 
 def test_global_positioning_trace_snapshot_optional_artifacts_missing(
@@ -635,9 +1610,7 @@ def test_global_positioning_trace_snapshot_rejects_malformed_shape_and_size(
         trace.snapshot(3)
 
     trace_dir = _make_snapshot_trace(tmp_path / "size", include_optional=True)
-    (trace_dir / "snapshots" / "iter_000003_points3D_f64.bin").write_bytes(
-        b"short"
-    )
+    (trace_dir / "snapshots" / "iter_000003_points3D_f64.bin").write_bytes(b"short")
 
     trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
     with pytest.raises(ValueError, match="byte size"):
@@ -653,7 +1626,431 @@ def test_global_positioning_trace_snapshot_rejects_filename_iteration_mismatch(
     metadata["iteration"] = 4
     _write_json(metadata_path, metadata)
 
-    with pytest.raises(
-        ValueError, match="filename does not match metadata iteration"
-    ):
+    with pytest.raises(ValueError, match="filename does not match metadata iteration"):
         pycolmap.GlobalPositioningTrace.load(trace_dir)
+
+
+def test_global_positioning_trace_replay_evaluates_known_residual_families(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(_make_replay_trace(tmp_path))
+
+    replay = trace.replay(iteration=3)
+
+    assert isinstance(replay, pycolmap.GlobalPositioningReplayEvaluation)
+    assert replay.residual_ids == (
+        "bata_ref",
+        "bata_const",
+        "bata_var",
+        "metric",
+        "scale_prior",
+    )
+    assert replay.residual_dims == (3, 3, 3, 1, 1)
+    assert replay.residual_offsets == (0, 3, 6, 9, 10)
+    np.testing.assert_allclose(
+        replay.raw_residuals,
+        [
+            0.5,
+            -1.0,
+            -0.5,
+            -0.55,
+            -0.1,
+            -0.65,
+            -0.45,
+            0.1,
+            -0.35,
+            1.0,
+            2.0,
+        ],
+    )
+    np.testing.assert_allclose(
+        replay.raw_costs,
+        [0.75, 0.3675, 0.1675, 0.5, 2.0],
+    )
+    np.testing.assert_allclose(replay.evaluation_success, [True] * 5)
+    assert [block.role for block in replay.parameter_blocks[0]] == [
+        "frame_center",
+        "point3D",
+        "bata_scale",
+    ]
+
+    cauchy_rho0 = 4.0 * np.log1p(1.5 / 4.0)
+    np.testing.assert_allclose(
+        replay.loss_rho_values[0],
+        [cauchy_rho0, 1.0 / 1.375, -1.0 / (4.0 * 1.375**2)],
+    )
+    assert replay.robust_costs[0] == pytest.approx(0.5 * cauchy_rho0)
+    assert replay.robust_costs[-1] == pytest.approx(6.0)
+    np.testing.assert_allclose(
+        replay.residual("metric").raw_residuals,
+        [1.0],
+    )
+
+
+def test_global_positioning_trace_replay_exposes_residual_values_compatibility(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(_make_replay_trace(tmp_path))
+
+    replay = trace.replay(iteration=3)
+
+    assert replay.has_raw_jacobians is False
+    assert replay.has_loss_rho_values is True
+    residual = replay.residual("bata_ref")
+    assert residual.residual_id == "bata_ref"
+    assert residual.residual_dim == 3
+    assert residual.residual_offset == 0
+    assert residual.evaluation_success is True
+    np.testing.assert_allclose(residual.raw_residuals, [0.5, -1.0, -0.5])
+    assert residual.raw_cost == pytest.approx(0.75)
+    assert residual.robust_cost == pytest.approx(replay.robust_costs[0])
+    np.testing.assert_allclose(residual.loss_rho, replay.loss_rho_values[0])
+    assert residual.loss_rho0 == pytest.approx(replay.loss_rho_values[0, 0])
+    assert residual.loss_rho1 == pytest.approx(replay.loss_rho_values[0, 1])
+    assert residual.loss_rho2 == pytest.approx(replay.loss_rho_values[0, 2])
+    assert residual.loss_derivative_scale == pytest.approx(residual.loss_rho1)
+    assert [block.role for block in residual.parameter_blocks] == [
+        "frame_center",
+        "point3D",
+        "bata_scale",
+    ]
+    assert residual.jacobian_blocks == ()
+
+    replay_with_jacobians = trace.replay(iteration=3, compute_jacobians=True)
+
+    assert replay_with_jacobians.has_raw_jacobians is True
+    assert replay_with_jacobians.has_loss_rho_values is True
+    residual_with_jacobians = replay_with_jacobians.residual("bata_ref")
+    assert residual_with_jacobians.raw_cost == pytest.approx(residual.raw_cost)
+    np.testing.assert_allclose(residual_with_jacobians.loss_rho, residual.loss_rho)
+    assert len(residual_with_jacobians.jacobian_blocks) == len(
+        residual_with_jacobians.parameter_blocks
+    )
+    jacobian_block = residual_with_jacobians.jacobian_blocks[0]
+    assert jacobian_block.parameter_block.role == "frame_center"
+    assert jacobian_block.parameter_block.kind == "frame_center"
+    assert jacobian_block.parameter_block.id == 10
+    assert jacobian_block.parameter_block.size == 3
+    assert jacobian_block.offset == 0
+    assert jacobian_block.residual_dim == residual_with_jacobians.residual_dim
+    assert jacobian_block.values.shape == (residual_with_jacobians.residual_dim, 3)
+
+
+def test_global_positioning_trace_replay_matches_synthetic_on_disk_residual_dump(
+    tmp_path: Path,
+) -> None:
+    """Synthetic on-disk parity, not a true C++-generated golden trace."""
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_replay_trace_with_residual_dump(tmp_path)
+    )
+    dumped = trace.residual_values(iteration=3)
+
+    replay = trace.replay(iteration=3)
+
+    assert replay.residual_ids == tuple(dumped.residual_ids)
+    assert replay.residual_dims == tuple(dumped.residual_dims)
+    assert replay.residual_offsets == tuple(dumped.residual_offsets)
+    assert replay.evaluation_success == tuple(dumped.evaluation_success)
+    np.testing.assert_allclose(replay.raw_residuals, dumped.raw_residuals)
+    np.testing.assert_allclose(replay.raw_costs, dumped.raw_costs)
+    np.testing.assert_allclose(replay.robust_costs, dumped.robust_costs)
+    np.testing.assert_allclose(replay.loss_rho_values, dumped.loss_rho_values)
+
+    for residual_id in replay.residual_ids:
+        replay_residual = replay.residual(residual_id)
+        dumped_residual = dumped.residual(residual_id)
+        assert replay_residual.residual_id == dumped_residual.residual_id
+        assert replay_residual.residual_dim == dumped_residual.residual_dim
+        assert replay_residual.residual_offset == dumped_residual.residual_offset
+        assert replay_residual.evaluation_success == dumped_residual.evaluation_success
+        np.testing.assert_allclose(
+            replay_residual.raw_residuals, dumped_residual.raw_residuals
+        )
+        assert replay_residual.raw_cost == pytest.approx(dumped_residual.raw_cost)
+        assert replay_residual.robust_cost == pytest.approx(dumped_residual.robust_cost)
+        np.testing.assert_allclose(replay_residual.loss_rho, dumped_residual.loss_rho)
+
+    replay_with_jacobians = trace.replay(iteration=3, compute_jacobians=True)
+    assert dumped.raw_jacobians is not None
+    np.testing.assert_allclose(
+        _flatten_replay_jacobians(replay_with_jacobians),
+        dumped.raw_jacobians,
+        rtol=1e-8,
+        atol=1e-10,
+    )
+
+    for residual_id in replay_with_jacobians.residual_ids:
+        replay_residual = replay_with_jacobians.residual(residual_id)
+        dumped_residual = dumped.residual(residual_id)
+        assert len(replay_residual.jacobian_blocks) == len(
+            dumped_residual.jacobian_blocks
+        )
+        for replay_block, dumped_block in zip(
+            replay_residual.jacobian_blocks,
+            dumped_residual.jacobian_blocks,
+            strict=True,
+        ):
+            assert replay_block.offset == dumped_block.offset
+            assert replay_block.residual_dim == dumped_block.residual_dim
+            assert (
+                replay_block.parameter_block.role == dumped_block.parameter_block.role
+            )
+            assert (
+                replay_block.parameter_block.kind == dumped_block.parameter_block.kind
+            )
+            assert replay_block.parameter_block.id == dumped_block.parameter_block.id
+            assert (
+                replay_block.parameter_block.size == dumped_block.parameter_block.size
+            )
+            np.testing.assert_allclose(
+                replay_block.values,
+                dumped_block.values,
+                rtol=1e-8,
+                atol=1e-10,
+            )
+
+
+def test_global_positioning_trace_replay_selects_residual_ids(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(_make_replay_trace(tmp_path))
+
+    replay = trace.replay(iteration=3, residual_ids=["scale_prior", "bata_ref"])
+
+    assert replay.residual_ids == ("scale_prior", "bata_ref")
+    assert replay.residual_dims == (1, 3)
+    assert replay.residual_offsets == (0, 1)
+    np.testing.assert_allclose(replay.raw_residuals, [2.0, 0.5, -1.0, -0.5])
+
+    single_replay = trace.replay(iteration=3, residual_ids="metric")
+    assert single_replay.residual_ids == ("metric",)
+    np.testing.assert_allclose(single_replay.raw_residuals, [1.0])
+
+    with pytest.raises(KeyError, match="missing replay residual ids"):
+        trace.replay(iteration=3, residual_ids="missing")
+    with pytest.raises(ValueError, match="non-empty"):
+        trace.replay(iteration=3, residual_ids=[])
+    with pytest.raises(ValueError, match="duplicates"):
+        trace.replay(iteration=3, residual_ids=["metric", "metric"])
+
+
+def test_global_positioning_trace_replay_finite_difference_jacobian_shape(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(_make_replay_trace(tmp_path))
+
+    replay = trace.replay(iteration=3, compute_jacobians=True)
+
+    residual = replay.residual("bata_ref")
+    assert len(residual.jacobian_blocks) == 3
+    assert residual.jacobian_blocks[0].values.shape == (3, 3)
+    assert residual.jacobian_blocks[2].values.shape == (3, 1)
+    np.testing.assert_allclose(residual.jacobian_blocks[0].values, 0.5 * np.eye(3))
+    np.testing.assert_allclose(residual.jacobian_blocks[1].values, -0.5 * np.eye(3))
+    np.testing.assert_allclose(
+        residual.jacobian_blocks[2].values[:, 0], [-3.0, -2.0, -3.0]
+    )
+    assert residual.jacobian_blocks[0].offset == 0
+    assert residual.jacobian_blocks[1].offset == 9
+    assert residual.jacobian_blocks[2].offset == 18
+
+
+def test_global_positioning_trace_replay_fails_loudly_for_bad_inputs(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(_make_replay_trace(tmp_path))
+    with pytest.raises(KeyError, match="parameter snapshot"):
+        trace.replay(iteration=99)
+
+    unknown_loss_records = [
+        {
+            "event_type": "residual_added",
+            "attrs": _replay_attrs(
+                "bad_loss",
+                "scale_prior",
+                [_replay_parameter_block("dmap_scale", "dmap_scale", 50, 1)],
+                {"scale_prior_target": 1.0, "scale_prior_stddev": 0.5},
+                loss=_replay_loss("not_a_loss", 1.0, 1.0),
+            ),
+        }
+    ]
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_replay_trace(tmp_path / "bad_loss", unknown_loss_records)
+    )
+    with pytest.raises(ValueError, match="unsupported loss type"):
+        trace.replay(iteration=3)
+
+    bad_quat_records = [
+        {
+            "event_type": "residual_added",
+            "attrs": _replay_attrs(
+                "bad_quat",
+                "metric_depth",
+                [
+                    _replay_parameter_block("frame_center", "frame_center", 10, 3),
+                    _replay_parameter_block("point3D", "point3D", 20, 3),
+                    _replay_parameter_block("dmap_scale", "dmap_scale", 50, 1),
+                ],
+                {
+                    "camera_rotation_wxyz": [1.0, 0.0, 0.0],
+                    "metric_depth_use_log_scale": False,
+                    "metric_depth_residual_type": "linear",
+                    "metric_depth_zero_residual_behind": False,
+                    "metric_depth_log_linear_threshold": 0.1,
+                },
+                extra={"depth_prior": 1.0, "depth_sigma": 0.5},
+            ),
+        }
+    ]
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_replay_trace(tmp_path / "bad_quat", bad_quat_records)
+    )
+    with pytest.raises(ValueError, match="camera_rotation_wxyz.*length 4"):
+        trace.replay(iteration=3)
+
+    missing_fixed_records = [
+        {
+            "event_type": "residual_added",
+            "attrs": _replay_attrs(
+                "missing_fixed",
+                "bata_constant_rig",
+                [
+                    _replay_parameter_block("point3D", "point3D", 20, 3),
+                    _replay_parameter_block("frame_center", "frame_center", 10, 3),
+                    _replay_parameter_block("bata_scale", "bata_scale", 30, 1),
+                ],
+                {"cam_from_point3D_dir": [1.0, 1.0, 1.0]},
+            ),
+        }
+    ]
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_replay_trace(tmp_path / "missing_fixed", missing_fixed_records)
+    )
+    with pytest.raises(KeyError, match="cam_from_rig_dir"):
+        trace.replay(iteration=3)
+
+    missing_snapshot_records = [
+        {
+            "event_type": "residual_added",
+            "attrs": _replay_attrs(
+                "missing_snapshot",
+                "scale_prior",
+                [_replay_parameter_block("dmap_scale", "dmap_scale", 999, 1)],
+                {"scale_prior_target": 1.0, "scale_prior_stddev": 0.5},
+            ),
+        }
+    ]
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_replay_trace(tmp_path / "missing_snapshot", missing_snapshot_records)
+    )
+    with pytest.raises(KeyError, match="id=999"):
+        trace.replay(iteration=3)
+
+
+def test_global_positioning_trace_raw_binary_fixture_contract_minimal(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(_make_raw_binary_trace(tmp_path))
+
+    assert trace.status == "finished"
+    assert trace.trace_level == "raw_binary_minimal"
+    assert trace.residual_value_iterations == (0,)
+    assert trace.snapshot_iterations == (0,)
+    assert [record["attrs"]["residual_id"] for record in trace.residual_blocks] == [
+        "r10",
+        "r20",
+    ]
+    assert trace.residual_blocks[0]["attrs"]["frame_id"] == 10
+    assert trace.residual_blocks[1]["attrs"]["point3D_id"] == 100
+
+    residual_values = trace.residual_values(0)
+    assert residual_values.residual_ids == ["r10", "r20"]
+    assert residual_values.residual_dims == [2, 1]
+    assert residual_values.residual_offsets == [0, 2]
+    assert residual_values.evaluation_success == [True, True]
+    assert residual_values.has_loss_rho_values is True
+    assert residual_values.has_raw_jacobians is False
+    np.testing.assert_allclose(residual_values.raw_residuals, [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(residual_values.raw_costs, [2.5, 4.5])
+    np.testing.assert_allclose(residual_values.robust_costs, [2.25, 4.25])
+
+    residual = residual_values.residual("r10")
+    assert residual.residual_dim == 2
+    np.testing.assert_allclose(residual.raw_residuals, [1.0, 2.0])
+    np.testing.assert_allclose(residual.loss_rho, [4.5, 0.25, -0.125])
+
+    snapshot = trace.snapshot(0)
+    assert snapshot.frame_centers.ids == (10, 20)
+    assert snapshot.points3D.ids == (100,)
+    assert snapshot.scales.ids == (0,)
+    np.testing.assert_allclose(
+        snapshot.frame_centers.values, [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+    )
+    np.testing.assert_allclose(snapshot.points3D.values, [[0.0, 0.0, 2.0]])
+    np.testing.assert_allclose(snapshot.scales.values, [1.0])
+
+
+def test_global_positioning_trace_raw_binary_accepts_v2_without_jacobians(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_raw_binary_trace(tmp_path, force_residual_version=2)
+    )
+
+    residual_values = trace.residual_values(0)
+    assert residual_values.has_raw_jacobians is False
+    assert residual_values.raw_jacobians is None
+    assert residual_values.residual("r10").jacobian_blocks == ()
+
+
+def test_global_positioning_trace_raw_binary_loads_optional_jacobians(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_raw_binary_trace(tmp_path, with_jacobians=True)
+    )
+
+    residual_values = trace.residual_values(0)
+    assert residual_values.has_raw_jacobians is True
+    np.testing.assert_allclose(residual_values.raw_jacobians, np.arange(9))
+
+    residual = residual_values.residual("r10")
+    assert [block.role for block in residual.parameter_blocks] == [
+        "frame_center",
+        "bata_scale",
+    ]
+    assert [block.kind for block in residual.parameter_blocks] == [
+        "frame_center",
+        "bata_scale",
+    ]
+    assert [block.id for block in residual.parameter_blocks] == [10, 0]
+    assert [block.size for block in residual.parameter_blocks] == [3, 1]
+    assert residual.parameter_blocks[0].is_constant is False
+    assert residual.parameter_blocks[1].is_constant is True
+    np.testing.assert_allclose(
+        residual.parameter_blocks[0].lower_bounds,
+        [-np.inf, -np.inf, -np.inf],
+    )
+    np.testing.assert_allclose(residual.parameter_blocks[1].lower_bounds, [1e-5])
+    np.testing.assert_allclose(
+        residual.jacobian("frame_center"), np.arange(6).reshape(2, 3)
+    )
+    np.testing.assert_allclose(residual.jacobian("bata_scale"), [[6.0], [7.0]])
+
+    residual_2 = residual_values.residual("r20")
+    assert residual_2.parameter_blocks[0].kind == "dmap_scale"
+    assert residual_2.parameter_blocks[0].id == 20
+    np.testing.assert_allclose(residual_2.parameter_blocks[0].lower_bounds, [1e-5])
+    np.testing.assert_allclose(residual_2.jacobian("dmap_scale"), [[8.0]])
+
+
+def test_global_positioning_trace_raw_binary_rejects_bad_artifact_contract(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_raw_binary_trace(tmp_path)
+    residual_path = trace_dir / "iterations" / "iter_000000" / "residual_values.bin"
+    residual_path.write_bytes(residual_path.read_bytes()[:-1])
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="truncated binary file"):
+        trace.residual_values(0)

--- a/python/pycolmap/global_positioning_trace_test.py
+++ b/python/pycolmap/global_positioning_trace_test.py
@@ -32,7 +32,9 @@ def _artifact(filename: str, ids, shape) -> dict:
     }
 
 
-def _make_trace(tmp_path: Path, *, with_jacobians: bool) -> Path:
+def _make_trace(
+    tmp_path: Path, *, with_jacobians: bool, with_loss_rho: bool = False
+) -> Path:
     trace_dir = tmp_path / (
         "trace_jacobians" if with_jacobians else "trace_values"
     )
@@ -129,6 +131,14 @@ def _make_trace(tmp_path: Path, *, with_jacobians: bool) -> Path:
             "byte_order": "little_endian",
             "shape": [9],
         }
+    if with_loss_rho:
+        metadata["loss_rho_layout"] = "residual_block_major/rho0_rho1_rho2"
+        metadata["artifacts"]["loss_rho_values"] = {
+            "file": "iter_000000_loss_rho_values_f64.bin",
+            "dtype": "float64",
+            "byte_order": "little_endian",
+            "shape": [2, 3],
+        }
 
     _write_json(residual_values_dir / "iter_000000.json", metadata)
     _write_f64(
@@ -141,6 +151,11 @@ def _make_trace(tmp_path: Path, *, with_jacobians: bool) -> Path:
     _write_f64(
         residual_values_dir / "iter_000000_robust_costs_f64.bin", [2.25, 4.25]
     )
+    if with_loss_rho:
+        _write_f64(
+            residual_values_dir / "iter_000000_loss_rho_values_f64.bin",
+            [[4.5, 0.25, -0.125], [8.5, 1.0, 0.0]],
+        )
     if with_jacobians:
         _write_f64(
             residual_values_dir / "iter_000000_raw_jacobians_f64.bin",
@@ -246,6 +261,7 @@ def test_global_positioning_trace_loads_residual_values(tmp_path: Path) -> None:
     assert isinstance(residual_values.raw_residuals, np.memmap)
     assert residual_values.has_raw_jacobians is False
     assert residual_values.raw_jacobians is None
+    assert residual_values.has_loss_rho_values is False
 
     residual = residual_values.residual("r0")
     np.testing.assert_allclose(residual.raw_residuals, [1.0, 2.0])
@@ -253,6 +269,106 @@ def test_global_positioning_trace_loads_residual_values(tmp_path: Path) -> None:
     assert residual.robust_cost == 2.25
     assert residual.parameter_blocks == ()
     assert residual.jacobian_blocks == ()
+    with pytest.raises(ValueError, match="loss_rho_values artifact"):
+        _ = residual_values.loss_rho_values
+    with pytest.raises(ValueError, match="loss_rho_values artifact"):
+        _ = residual.loss_rho
+
+
+def test_global_positioning_trace_loads_loss_rho_values(
+    tmp_path: Path,
+) -> None:
+    trace = pycolmap.GlobalPositioningTrace.load(
+        _make_trace(tmp_path, with_jacobians=False, with_loss_rho=True)
+    )
+
+    residual_values = trace.residual_values()
+    assert residual_values.has_loss_rho_values is True
+    assert isinstance(residual_values.loss_rho_values, np.memmap)
+    np.testing.assert_allclose(
+        residual_values.loss_rho_values,
+        [[4.5, 0.25, -0.125], [8.5, 1.0, 0.0]],
+    )
+
+    residual = residual_values.residual("r0")
+    np.testing.assert_allclose(residual.loss_rho, [4.5, 0.25, -0.125])
+    assert residual.loss_rho0 == 4.5
+    assert residual.loss_rho1 == 0.25
+    assert residual.loss_rho2 == -0.125
+    assert residual.loss_derivative_scale == 0.25
+
+
+def test_global_positioning_trace_rejects_bad_loss_rho_shape(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False, with_loss_rho=True)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["artifacts"]["loss_rho_values"]["shape"] = [2, 2]
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="loss_rho_values.*shape"):
+        trace.residual_values(0)
+
+
+def test_global_positioning_trace_rejects_bad_loss_rho_layout(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False, with_loss_rho=True)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["loss_rho_layout"] = "wrong"
+    _write_json(metadata_path, metadata)
+
+    trace = pycolmap.GlobalPositioningTrace.load(trace_dir)
+    with pytest.raises(ValueError, match="loss_rho_layout"):
+        trace.residual_values(0)
+
+
+def test_global_positioning_trace_validates_loss_rho_costs_on_access(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False, with_loss_rho=True)
+    _write_f64(
+        trace_dir / "residual_values" / "iter_000000_robust_costs_f64.bin",
+        [999.0, 4.25],
+    )
+
+    residual_values = pycolmap.GlobalPositioningTrace.load(
+        trace_dir
+    ).residual_values(0)
+    with pytest.raises(ValueError, match=r"0\.5 \* loss_rho_values"):
+        _ = residual_values.loss_rho_values
+
+
+def test_global_positioning_trace_allows_failed_loss_rho_nan_rows(
+    tmp_path: Path,
+) -> None:
+    trace_dir = _make_trace(tmp_path, with_jacobians=False, with_loss_rho=True)
+    metadata_path = trace_dir / "residual_values" / "iter_000000.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata["evaluation_success"] = [False, True]
+    _write_json(metadata_path, metadata)
+    _write_f64(
+        trace_dir / "residual_values" / "iter_000000_robust_costs_f64.bin",
+        [float("nan"), 4.25],
+    )
+    _write_f64(
+        trace_dir / "residual_values" / "iter_000000_loss_rho_values_f64.bin",
+        [[float("nan"), float("nan"), float("nan")], [8.5, 1.0, 0.0]],
+    )
+
+    residual_values = pycolmap.GlobalPositioningTrace.load(
+        trace_dir
+    ).residual_values(0)
+
+    assert residual_values.has_loss_rho_values is True
+    np.testing.assert_allclose(
+        residual_values.loss_rho_values[1],
+        [8.5, 1.0, 0.0],
+    )
+    assert np.isnan(residual_values.loss_rho_values[0, 0])
 
 
 def test_global_positioning_trace_loads_raw_jacobians(tmp_path: Path) -> None:

--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -44,6 +44,7 @@ COLMAP_ADD_LIBRARY(
         generalized_pose.h generalized_pose.cc
         global_positioning.h global_positioning.cc
         global_positioning_trace.h global_positioning_trace.cc
+        global_positioning_tracer.h global_positioning_tracer.cc
         gravity_refinement.h gravity_refinement.cc
         pose.h pose.cc
         rotation_averaging.h rotation_averaging.cc

--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -43,6 +43,7 @@ COLMAP_ADD_LIBRARY(
         covariance.h covariance.cc
         generalized_pose.h generalized_pose.cc
         global_positioning.h global_positioning.cc
+        global_positioning_trace.h global_positioning_trace.cc
         gravity_refinement.h gravity_refinement.cc
         pose.h pose.cc
         rotation_averaging.h rotation_averaging.cc

--- a/src/colmap/estimators/CMakeLists.txt
+++ b/src/colmap/estimators/CMakeLists.txt
@@ -43,6 +43,7 @@ COLMAP_ADD_LIBRARY(
         covariance.h covariance.cc
         generalized_pose.h generalized_pose.cc
         global_positioning.h global_positioning.cc
+        global_positioning_residual_evaluation.h global_positioning_residual_evaluation.cc
         global_positioning_trace.h global_positioning_trace.cc
         global_positioning_tracer.h global_positioning_tracer.cc
         gravity_refinement.h gravity_refinement.cc

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <limits>
 #include <utility>
 
 namespace colmap {
@@ -91,53 +90,7 @@ bool IsLossConfigOverride(const LossConfig& loss_config) {
          loss_config.scale != 1.0 || loss_config.weight != 1.0;
 }
 
-bool IsTraceEnabled(const GlobalPositioningTraceOptions& options) {
-  return options.level != GlobalPositioningTraceLevel::kOff;
-}
-
-bool IsResidualLedgerTraceEnabled(
-    const GlobalPositioningTraceOptions& options) {
-  return static_cast<int>(options.level) >=
-         static_cast<int>(GlobalPositioningTraceLevel::kResidualLedger);
-}
-
-bool IsParameterSnapshotTraceEnabled(
-    const GlobalPositioningTraceOptions& options) {
-  return static_cast<int>(options.level) >=
-         static_cast<int>(GlobalPositioningTraceLevel::kParameterSnapshots);
-}
-
-bool IsResidualValuesTraceEnabled(
-    const GlobalPositioningTraceOptions& options) {
-  return static_cast<int>(options.level) >=
-         static_cast<int>(GlobalPositioningTraceLevel::kResidualValues);
-}
-
-using TraceAttrs = std::map<std::string, GlobalPositioningTraceValue>;
 using TraceValue = GlobalPositioningTraceValue;
-
-template <typename T>
-TraceValue TraceOptionalId(const std::optional<T>& value) {
-  if (!value.has_value()) {
-    return TraceValue::Null();
-  }
-  return TraceValue::UInt(static_cast<uint64_t>(*value));
-}
-
-TraceValue TraceOptionalDouble(const std::optional<double>& value) {
-  if (!value.has_value()) {
-    return TraceValue::Null();
-  }
-  return TraceValue::Double(*value);
-}
-
-std::optional<uint64_t> TraceSensorId(
-    const std::optional<sensor_t>& sensor_id) {
-  if (!sensor_id.has_value() || *sensor_id == kInvalidSensorId) {
-    return std::nullopt;
-  }
-  return static_cast<uint64_t>(sensor_id->id);
-}
 
 std::string DepthOutlierSource(
     const std::set<std::pair<image_t, point2D_t>>& runtime_depth_outliers,
@@ -162,278 +115,6 @@ bool HasValidDepthPriorMetadata(const Image& image,
          observation.point2D_idx < image.depth_prior_stddevs.size();
 }
 
-void WriteTraceEvent(GlobalPositioningTraceRecorder* recorder,
-                     std::string event_type,
-                     std::string stage,
-                     TraceAttrs attrs = {}) {
-  if (recorder == nullptr) {
-    return;
-  }
-
-  GlobalPositioningTraceRecord record;
-  record.event_type = std::move(event_type);
-  record.stage = std::move(stage);
-  record.attrs = std::move(attrs);
-  recorder->WriteEvent(std::move(record));
-}
-
-void WriteParameterSnapshot(
-    GlobalPositioningTraceRecorder* recorder,
-    const int iteration,
-    const Reconstruction& reconstruction,
-    const std::unordered_map<frame_t, Eigen::Vector3d>& frame_centers,
-    const std::vector<double>& scales,
-    const std::map<image_t, double>& dmap_scales,
-    const std::unordered_map<sensor_t, Eigen::Vector3d>& cams_in_rig,
-    const int max_snapshotted_points) {
-  if (recorder == nullptr) {
-    return;
-  }
-
-  GlobalPositioningTraceParameterSnapshot snapshot;
-  snapshot.iteration = iteration;
-
-  std::vector<frame_t> frame_ids;
-  frame_ids.reserve(frame_centers.size());
-  for (const auto& [frame_id, center] : frame_centers) {
-    frame_ids.push_back(frame_id);
-  }
-  std::sort(frame_ids.begin(), frame_ids.end());
-  snapshot.frame_centers.shape = {frame_ids.size(), 3};
-  snapshot.frame_centers.ids.reserve(frame_ids.size());
-  snapshot.frame_centers.values.reserve(3 * frame_ids.size());
-  for (const frame_t frame_id : frame_ids) {
-    const Eigen::Vector3d& center = frame_centers.at(frame_id);
-    snapshot.frame_centers.ids.push_back(static_cast<uint64_t>(frame_id));
-    snapshot.frame_centers.values.push_back(center.x());
-    snapshot.frame_centers.values.push_back(center.y());
-    snapshot.frame_centers.values.push_back(center.z());
-  }
-
-  std::vector<point3D_t> point3D_ids;
-  point3D_ids.reserve(reconstruction.NumPoints3D());
-  for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
-    point3D_ids.push_back(point3D_id);
-  }
-  std::sort(point3D_ids.begin(), point3D_ids.end());
-  if (max_snapshotted_points >= 0 &&
-      point3D_ids.size() > static_cast<size_t>(max_snapshotted_points)) {
-    point3D_ids.resize(static_cast<size_t>(max_snapshotted_points));
-  }
-  snapshot.points3D.shape = {point3D_ids.size(), 3};
-  snapshot.points3D.ids.reserve(point3D_ids.size());
-  snapshot.points3D.values.reserve(3 * point3D_ids.size());
-  for (const point3D_t point3D_id : point3D_ids) {
-    const Eigen::Vector3d& xyz = reconstruction.Point3D(point3D_id).xyz;
-    snapshot.points3D.ids.push_back(static_cast<uint64_t>(point3D_id));
-    snapshot.points3D.values.push_back(xyz.x());
-    snapshot.points3D.values.push_back(xyz.y());
-    snapshot.points3D.values.push_back(xyz.z());
-  }
-
-  snapshot.scales.shape = {scales.size()};
-  snapshot.scales.ids.reserve(scales.size());
-  snapshot.scales.values.reserve(scales.size());
-  for (size_t scale_idx = 0; scale_idx < scales.size(); ++scale_idx) {
-    snapshot.scales.ids.push_back(static_cast<uint64_t>(scale_idx));
-    snapshot.scales.values.push_back(scales[scale_idx]);
-  }
-
-  if (!dmap_scales.empty()) {
-    snapshot.dmap_scales.emplace();
-    snapshot.dmap_scales->shape = {dmap_scales.size()};
-    snapshot.dmap_scales->ids.reserve(dmap_scales.size());
-    snapshot.dmap_scales->values.reserve(dmap_scales.size());
-    for (const auto& [image_id, scale] : dmap_scales) {
-      snapshot.dmap_scales->ids.push_back(static_cast<uint64_t>(image_id));
-      snapshot.dmap_scales->values.push_back(scale);
-    }
-  }
-
-  std::vector<sensor_t> sensor_ids;
-  sensor_ids.reserve(cams_in_rig.size());
-  for (const auto& [sensor_id, center] : cams_in_rig) {
-    sensor_ids.push_back(sensor_id);
-  }
-  std::sort(sensor_ids.begin(), sensor_ids.end());
-  if (!sensor_ids.empty()) {
-    snapshot.cams_in_rig.emplace();
-    snapshot.cams_in_rig->shape = {sensor_ids.size(), 3};
-    snapshot.cams_in_rig->ids.reserve(sensor_ids.size());
-    snapshot.cams_in_rig->values.reserve(3 * sensor_ids.size());
-    for (const sensor_t sensor_id : sensor_ids) {
-      const Eigen::Vector3d& cam_in_rig = cams_in_rig.at(sensor_id);
-      snapshot.cams_in_rig->ids.push_back(static_cast<uint64_t>(sensor_id.id));
-      snapshot.cams_in_rig->values.push_back(cam_in_rig.x());
-      snapshot.cams_in_rig->values.push_back(cam_in_rig.y());
-      snapshot.cams_in_rig->values.push_back(cam_in_rig.z());
-    }
-  }
-
-  recorder->WriteParameterSnapshot(snapshot);
-}
-
-void WriteResidualValues(
-    GlobalPositioningTraceRecorder* recorder,
-    const int iteration,
-    const std::vector<GlobalPositioningResidualReplayEntry>& replay_entries) {
-  if (recorder == nullptr) {
-    return;
-  }
-
-  GlobalPositioningTraceResidualValues residual_values;
-  residual_values.iteration = iteration;
-  residual_values.residual_ids.reserve(replay_entries.size());
-  residual_values.residual_dims.reserve(replay_entries.size());
-  residual_values.residual_offsets.reserve(replay_entries.size());
-  residual_values.evaluation_success.resize(replay_entries.size(), false);
-  residual_values.raw_costs.resize(replay_entries.size(),
-                                   std::numeric_limits<double>::quiet_NaN());
-  residual_values.robust_costs.resize(replay_entries.size(),
-                                      std::numeric_limits<double>::quiet_NaN());
-
-  size_t total_scalar_residuals = 0;
-  for (const GlobalPositioningResidualReplayEntry& entry : replay_entries) {
-    residual_values.residual_ids.push_back(entry.residual_id);
-    residual_values.residual_dims.push_back(entry.residual_dimension);
-    residual_values.residual_offsets.push_back(total_scalar_residuals);
-    total_scalar_residuals += entry.residual_dimension;
-  }
-  residual_values.raw_residuals.resize(
-      total_scalar_residuals, std::numeric_limits<double>::quiet_NaN());
-
-  for (size_t entry_idx = 0; entry_idx < replay_entries.size(); ++entry_idx) {
-    const GlobalPositioningResidualReplayEntry& entry =
-        replay_entries[entry_idx];
-    if (entry.cost_function == nullptr) {
-      continue;
-    }
-
-    double* raw_residuals = residual_values.raw_residuals.data() +
-                            residual_values.residual_offsets[entry_idx];
-    const bool evaluation_success = entry.cost_function->Evaluate(
-        entry.parameter_blocks.data(), raw_residuals, nullptr);
-    residual_values.evaluation_success[entry_idx] = evaluation_success;
-    if (!evaluation_success) {
-      continue;
-    }
-
-    double squared_norm = 0.0;
-    for (size_t residual_idx = 0; residual_idx < entry.residual_dimension;
-         ++residual_idx) {
-      squared_norm += raw_residuals[residual_idx] * raw_residuals[residual_idx];
-    }
-
-    const double raw_cost = 0.5 * squared_norm;
-    residual_values.raw_costs[entry_idx] = raw_cost;
-    if (entry.loss_function != nullptr) {
-      double rho[3];
-      entry.loss_function->Evaluate(squared_norm, rho);
-      residual_values.robust_costs[entry_idx] = 0.5 * rho[0];
-    } else {
-      residual_values.robust_costs[entry_idx] = raw_cost;
-    }
-  }
-
-  recorder->WriteResidualValues(residual_values);
-}
-
-class GlobalPositioningTraceIterationCallback
-    : public ceres::IterationCallback {
- public:
-  GlobalPositioningTraceIterationCallback(
-      GlobalPositioningTraceRecorder* recorder,
-      const Reconstruction* reconstruction,
-      const std::unordered_map<frame_t, Eigen::Vector3d>* frame_centers,
-      const std::vector<double>* scales,
-      const std::map<image_t, double>* dmap_scales,
-      const std::unordered_map<sensor_t, Eigen::Vector3d>* cams_in_rig,
-      const std::vector<GlobalPositioningResidualReplayEntry>*
-          residual_replay_entries,
-      const int snapshot_every_n_iterations,
-      const int max_snapshotted_points,
-      const bool write_parameter_snapshots,
-      const bool write_residual_values)
-      : recorder_(recorder),
-        reconstruction_(reconstruction),
-        frame_centers_(frame_centers),
-        scales_(scales),
-        dmap_scales_(dmap_scales),
-        cams_in_rig_(cams_in_rig),
-        residual_replay_entries_(residual_replay_entries),
-        snapshot_every_n_iterations_(snapshot_every_n_iterations),
-        max_snapshotted_points_(max_snapshotted_points),
-        write_parameter_snapshots_(write_parameter_snapshots),
-        write_residual_values_(write_residual_values) {}
-
-  ceres::CallbackReturnType operator()(
-      const ceres::IterationSummary& summary) override {
-    if (recorder_ != nullptr) {
-      recorder_->WriteIteration(summary);
-    }
-    if ((write_parameter_snapshots_ || write_residual_values_) &&
-        summary.iteration % snapshot_every_n_iterations_ == 0) {
-      if (write_parameter_snapshots_) {
-        WriteParameterSnapshot(recorder_,
-                               summary.iteration,
-                               *reconstruction_,
-                               *frame_centers_,
-                               *scales_,
-                               *dmap_scales_,
-                               *cams_in_rig_,
-                               max_snapshotted_points_);
-      }
-      if (write_residual_values_) {
-        WriteResidualValues(
-            recorder_, summary.iteration, *residual_replay_entries_);
-      }
-    }
-    return ceres::SOLVER_CONTINUE;
-  }
-
- private:
-  GlobalPositioningTraceRecorder* recorder_ = nullptr;
-  const Reconstruction* reconstruction_ = nullptr;
-  const std::unordered_map<frame_t, Eigen::Vector3d>* frame_centers_ = nullptr;
-  const std::vector<double>* scales_ = nullptr;
-  const std::map<image_t, double>* dmap_scales_ = nullptr;
-  const std::unordered_map<sensor_t, Eigen::Vector3d>* cams_in_rig_ = nullptr;
-  const std::vector<GlobalPositioningResidualReplayEntry>*
-      residual_replay_entries_ = nullptr;
-  int snapshot_every_n_iterations_ = 1;
-  int max_snapshotted_points_ = -1;
-  bool write_parameter_snapshots_ = false;
-  bool write_residual_values_ = false;
-};
-
-class GlobalPositioningTraceStatusGuard {
- public:
-  explicit GlobalPositioningTraceStatusGuard(
-      GlobalPositioningTraceRecorder* recorder,
-      GlobalPositioningTraceRecorder** active_recorder)
-      : recorder_(recorder), active_recorder_(active_recorder) {}
-
-  ~GlobalPositioningTraceStatusGuard() {
-    if (active_recorder_ != nullptr) {
-      *active_recorder_ = nullptr;
-    }
-  }
-
-  void MarkFinished() {
-    if (recorder_ != nullptr) {
-      recorder_->MarkFinished("finished");
-      recorder_ = nullptr;
-    }
-    if (active_recorder_ != nullptr) {
-      *active_recorder_ = nullptr;
-    }
-  }
-
- private:
-  GlobalPositioningTraceRecorder* recorder_ = nullptr;
-  GlobalPositioningTraceRecorder** active_recorder_ = nullptr;
-};
-
 }  // namespace
 
 GlobalPositioner::GlobalPositioner(const GlobalPositionerOptions& options)
@@ -454,18 +135,10 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
     return false;
   }
 
-  std::unique_ptr<GlobalPositioningTraceRecorder> trace_recorder;
-  if (IsTraceEnabled(options_.trace)) {
-    trace_recorder =
-        std::make_unique<GlobalPositioningTraceRecorder>(options_.trace);
-  }
-  trace_recorder_ = trace_recorder.get();
+  tracer_ = std::make_unique<GlobalPositioningTracer>(options_.trace);
 
   {
-    GlobalPositioningTraceStatusGuard trace_status(trace_recorder.get(),
-                                                   &trace_recorder_);
-    WriteTraceEvent(
-        trace_recorder.get(),
+    tracer_->WriteEvent(
         "run_started",
         "solve",
         {{"num_images", TraceValue::UInt(reconstruction.NumImages())},
@@ -493,14 +166,12 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
 
     LOG(INFO) << "Setting up the global positioner problem";
 
-    WriteTraceEvent(
-        trace_recorder.get(), "problem_setup_started", "setup_problem");
+    tracer_->WriteEvent("problem_setup_started", "setup_problem");
 
     // Setup the problem.
     SetupProblem(pose_graph, reconstruction);
 
-    WriteTraceEvent(
-        trace_recorder.get(),
+    tracer_->WriteEvent(
         "problem_setup_finished",
         "setup_problem",
         {{"reserved_scale_capacity", TraceValue::UInt(scales_.capacity())}});
@@ -509,8 +180,7 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
     // Also, convert the camera pose translation to be the camera center.
     InitializeRandomPositions(pose_graph, reconstruction);
 
-    WriteTraceEvent(
-        trace_recorder.get(),
+    tracer_->WriteEvent(
         "initialization_finished",
         "initialization",
         {{"num_frame_centers", TraceValue::UInt(frame_centers_.size())},
@@ -535,22 +205,19 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
     } else {
       dmap_scale_skip_reason = "initial_dmap_scales_provided";
     }
-    WriteTraceEvent(
-        trace_recorder.get(),
+    tracer_->WriteEvent(
         "dmap_scale_initialization_finished",
         "initialization",
         {{"skipped", TraceValue::Bool(!initialize_dmap_scales)},
          {"reason", TraceValue::String(dmap_scale_skip_reason)},
          {"num_dmap_scales", TraceValue::UInt(dmap_scales_.size())}});
 
-    WriteTraceEvent(
-        trace_recorder.get(), "residual_build_started", "problem_build");
+    tracer_->WriteEvent("residual_build_started", "problem_build");
 
     // Add the point to camera constraints to the problem.
     AddPointToCameraConstraints(reconstruction);
 
-    WriteTraceEvent(
-        trace_recorder.get(),
+    tracer_->WriteEvent(
         "problem_built",
         "problem_build",
         {{"num_residual_blocks",
@@ -569,8 +236,7 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
     // constant if desired.
     ParameterizeVariables(reconstruction);
 
-    WriteTraceEvent(
-        trace_recorder.get(),
+    tracer_->WriteEvent(
         "parameterization_finished",
         "parameterization",
         {{"optimize_positions", TraceValue::Bool(options_.optimize_positions)},
@@ -586,34 +252,27 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
     options_.solver_options.minimizer_progress_to_stdout = VLOG_IS_ON(2);
 
     ceres::Solver::Options solver_options = options_.solver_options;
-    const bool trace_parameter_snapshots = ShouldTraceParameterSnapshots();
-    const bool trace_residual_values = ShouldTraceResidualValues();
+    const bool trace_parameter_snapshots = tracer_->ParameterSnapshotsEnabled();
+    const bool trace_residual_values = tracer_->ResidualValuesEnabled();
     if (trace_parameter_snapshots || trace_residual_values) {
       THROW_CHECK_GT(options_.trace.snapshot_every_n_iterations, 0)
           << "Global positioning trace snapshot_every_n_iterations must be "
              "positive when sampled trace artifacts are enabled.";
       solver_options.update_state_every_iteration = true;
     }
-    std::unique_ptr<GlobalPositioningTraceIterationCallback> trace_callback;
-    if (trace_recorder != nullptr) {
-      trace_callback =
-          std::make_unique<GlobalPositioningTraceIterationCallback>(
-              trace_recorder.get(),
-              &reconstruction,
-              &frame_centers_,
-              &scales_,
-              &dmap_scales_,
-              &cams_in_rig_,
-              &residual_replay_entries_,
-              options_.trace.snapshot_every_n_iterations,
-              options_.trace.max_snapshotted_points,
-              trace_parameter_snapshots,
-              trace_residual_values);
+    std::unique_ptr<ceres::IterationCallback> trace_callback;
+    if (tracer_->Enabled()) {
+      trace_callback = tracer_->CreateIterationCallback({
+          reconstruction,
+          frame_centers_,
+          scales_,
+          dmap_scales_,
+          cams_in_rig_,
+      });
       solver_options.callbacks.push_back(trace_callback.get());
     }
 
-    WriteTraceEvent(
-        trace_recorder.get(),
+    tracer_->WriteEvent(
         "solve_started",
         "ceres_solve",
         {{"max_num_iterations",
@@ -629,8 +288,7 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
     ceres::Solve(solver_options, problem_.get(), &summary);
 
     const bool is_solution_usable = summary.IsSolutionUsable();
-    WriteTraceEvent(
-        trace_recorder.get(),
+    tracer_->WriteEvent(
         "solve_finished",
         "ceres_solve",
         {{"is_solution_usable", TraceValue::Bool(is_solution_usable)},
@@ -654,13 +312,12 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
     }
 
     ConvertBackResults(reconstruction);
-    WriteTraceEvent(
-        trace_recorder.get(),
+    tracer_->WriteEvent(
         "results_converted",
         "convert_results",
         {{"num_frame_centers", TraceValue::UInt(frame_centers_.size())},
          {"num_cams_in_rig", TraceValue::UInt(cams_in_rig_.size())}});
-    trace_status.MarkFinished();
+    tracer_->MarkFinished();
     return is_solution_usable;
   }
 }
@@ -676,167 +333,27 @@ void GlobalPositioner::SetupProblem(const PoseGraph& pose_graph,
   frame_centers_.clear();
   cams_in_rig_.clear();
   per_image_scale_losses_.clear();
-  ResetResidualLedger();
+  if (tracer_ == nullptr) {
+    tracer_ = std::make_unique<GlobalPositioningTracer>(options_.trace);
+  }
+  tracer_->ResetProblemState();
 
   // Reserve to avoid pointer-invalidating reallocs.
   scales_.clear();
+  cams_in_rig_.reserve(reconstruction.NumCameras());
   size_t total_observations = 0;
   for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
     total_observations += point3D.track.Length();
     total_observations += point3D.track.lc_elements.size();
   }
   scales_.reserve(total_observations);
-  scale_observations_.reserve(total_observations);
 }
 
-bool GlobalPositioner::ShouldTraceResidualLedger() const {
-  return trace_recorder_ != nullptr &&
-         IsResidualLedgerTraceEnabled(options_.trace);
-}
-
-bool GlobalPositioner::ShouldTraceParameterSnapshots() const {
-  return trace_recorder_ != nullptr &&
-         IsParameterSnapshotTraceEnabled(options_.trace);
-}
-
-bool GlobalPositioner::ShouldTraceResidualValues() const {
-  return trace_recorder_ != nullptr &&
-         IsResidualValuesTraceEnabled(options_.trace);
-}
-
-void GlobalPositioner::ResetResidualLedger() {
-  residual_bucket_counts_.clear();
-  scale_observations_.clear();
-  residual_replay_entries_.clear();
-}
-
-void GlobalPositioner::RecordScaleObservation(const size_t scale_index,
-                                              const point3D_t point3D_id,
-                                              const TrackElement& observation,
-                                              const bool is_lc_observation) {
-  if (!ShouldTraceResidualLedger()) {
-    return;
-  }
-  if (scale_observations_.size() <= scale_index) {
-    scale_observations_.resize(scale_index + 1);
-  }
-  scale_observations_[scale_index] = {
-      point3D_id,
-      observation.image_id,
-      observation.point2D_idx,
-      is_lc_observation,
-  };
-}
-
-std::string GlobalPositioner::RecordResidualBlock(
-    const ResidualLedgerEntry& entry) {
-  if (!ShouldTraceResidualLedger()) {
-    return "";
-  }
-
-  std::string residual_id = trace_recorder_->AllocateResidualId();
-  GlobalPositioningTraceRecord record;
-  record.event_type = "residual_added";
-  record.stage = "problem_build";
-  record.attrs = {
-      {"residual_id", TraceValue::String(residual_id)},
-      {"residual_type", TraceValue::String(entry.residual_type)},
-      {"point3D_id", TraceOptionalId(entry.point3D_id)},
-      {"image_id", TraceOptionalId(entry.image_id)},
-      {"point2D_idx", TraceOptionalId(entry.point2D_idx)},
-      {"frame_id", TraceOptionalId(entry.frame_id)},
-      {"camera_id", TraceOptionalId(entry.camera_id)},
-      {"sensor_id", TraceOptionalId(TraceSensorId(entry.sensor_id))},
-      {"is_lc_observation", TraceValue::Bool(entry.is_lc_observation)},
-      {"is_ref_in_frame", TraceValue::Bool(entry.is_ref_in_frame)},
-      {"camera_has_prior_focal_length",
-       TraceValue::Bool(entry.camera_has_prior_focal_length)},
-      {"loss_bucket", TraceValue::String(entry.loss_bucket)},
-      {"uses_keypoint_covariance",
-       TraceValue::Bool(entry.uses_keypoint_covariance)},
-      {"has_depth_prior", TraceValue::Bool(entry.has_depth_prior)},
-      {"depth_prior", TraceOptionalDouble(entry.depth_prior)},
-      {"depth_sigma", TraceOptionalDouble(entry.depth_sigma)},
-      {"dmap_scale_image_id", TraceOptionalId(entry.dmap_scale_image_id)},
-      {"depth_outlier_source", TraceValue::String(entry.depth_outlier_source)},
-  };
-  trace_recorder_->WriteResidualBlock(std::move(record));
-  ++residual_bucket_counts_[entry.residual_type + "|" + entry.loss_bucket];
-  return residual_id;
-}
-
-void GlobalPositioner::RecordReplayResidual(
-    const std::string& residual_id,
-    const ceres::CostFunction* cost_function,
-    const ceres::LossFunction* loss_function,
-    std::vector<const double*> parameter_blocks) {
-  if (!ShouldTraceResidualValues() || residual_id.empty() ||
-      cost_function == nullptr) {
-    return;
-  }
-
-  residual_replay_entries_.push_back(
-      {residual_id,
-       cost_function,
-       loss_function,
-       static_cast<size_t>(cost_function->num_residuals()),
-       std::move(parameter_blocks)});
-}
-
-void GlobalPositioner::RecordResidualSkip(const ResidualLedgerEntry& entry,
-                                          const std::string& skip_reason) {
-  if (!ShouldTraceResidualLedger()) {
-    return;
-  }
-
-  GlobalPositioningTraceRecord record;
-  record.event_type = "residual_skipped";
-  record.stage = "problem_build";
-  record.attrs = {
-      {"residual_type", TraceValue::String(entry.residual_type)},
-      {"skip_reason", TraceValue::String(skip_reason)},
-      {"point3D_id", TraceOptionalId(entry.point3D_id)},
-      {"image_id", TraceOptionalId(entry.image_id)},
-      {"point2D_idx", TraceOptionalId(entry.point2D_idx)},
-      {"frame_id", TraceOptionalId(entry.frame_id)},
-      {"camera_id", TraceOptionalId(entry.camera_id)},
-      {"sensor_id", TraceOptionalId(TraceSensorId(entry.sensor_id))},
-      {"is_lc_observation", TraceValue::Bool(entry.is_lc_observation)},
-      {"is_ref_in_frame", TraceValue::Bool(entry.is_ref_in_frame)},
-      {"camera_has_prior_focal_length",
-       TraceValue::Bool(entry.camera_has_prior_focal_length)},
-      {"loss_bucket", TraceValue::String(entry.loss_bucket)},
-      {"uses_keypoint_covariance",
-       TraceValue::Bool(entry.uses_keypoint_covariance)},
-      {"has_depth_prior", TraceValue::Bool(entry.has_depth_prior)},
-      {"depth_prior", TraceOptionalDouble(entry.depth_prior)},
-      {"depth_sigma", TraceOptionalDouble(entry.depth_sigma)},
-      {"dmap_scale_image_id", TraceOptionalId(entry.dmap_scale_image_id)},
-      {"depth_outlier_source", TraceValue::String(entry.depth_outlier_source)},
-  };
-  trace_recorder_->WriteResidualSkip(std::move(record));
-}
-
-void GlobalPositioner::RecordResidualBucketSummaries() {
-  if (!ShouldTraceResidualLedger()) {
-    return;
-  }
-
-  for (const auto& [key, count] : residual_bucket_counts_) {
-    const size_t separator = key.find('|');
-    GlobalPositioningTraceRecord record;
-    record.event_type = "residual_bucket_summary";
-    record.stage = "problem_build";
-    record.attrs = {
-        {"residual_type", TraceValue::String(key.substr(0, separator))},
-        {"loss_bucket",
-         TraceValue::String(separator == std::string::npos
-                                ? "none"
-                                : key.substr(separator + 1))},
-        {"count", TraceValue::UInt(count)},
-    };
-    trace_recorder_->WriteResidualBucketSummary(std::move(record));
-  }
+const std::vector<GlobalPositioningResidualReplayEntry>&
+GlobalPositioner::ResidualReplayEntriesForTest() const {
+  static const std::vector<GlobalPositioningResidualReplayEntry>
+      kEmptyReplayEntries;
+  return tracer_ == nullptr ? kEmptyReplayEntries : tracer_->ReplayEntries();
 }
 
 void GlobalPositioner::InitializeRandomPositions(
@@ -950,21 +467,21 @@ void GlobalPositioner::AddPointToCameraConstraints(
   for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
     if (NumRegularObservationsForMinViewGate(point3D.track) <
         static_cast<size_t>(options_.min_num_view_per_track)) {
-      if (ShouldTraceResidualLedger()) {
+      if (tracer_->ResidualLedgerEnabled()) {
         for (const auto& observation : point3D.track.Elements()) {
-          ResidualLedgerEntry skip;
+          GlobalPositioningResidualDescriptor skip;
           skip.residual_type = "bata_ref_frame";
           skip.point3D_id = point3D_id;
           skip.image_id = observation.image_id;
           skip.point2D_idx = observation.point2D_idx;
-          RecordResidualSkip(skip, "track_min_view_gate");
+          tracer_->RecordSkip(skip, "track_min_view_gate");
           if (options_.use_metric_depth_constraint) {
             skip.residual_type = "metric_depth";
-            RecordResidualSkip(skip, "track_min_view_gate");
+            tracer_->RecordSkip(skip, "track_min_view_gate");
           }
         }
         for (const auto& observation : point3D.track.lc_elements) {
-          ResidualLedgerEntry skip;
+          GlobalPositioningResidualDescriptor skip;
           skip.residual_type = "bata_ref_frame";
           skip.point3D_id = point3D_id;
           skip.image_id = observation.image_id;
@@ -973,10 +490,10 @@ void GlobalPositioner::AddPointToCameraConstraints(
           const std::string skip_reason = options_.use_lc_observations
                                               ? "track_min_view_gate"
                                               : "lc_observation_disabled";
-          RecordResidualSkip(skip, skip_reason);
+          tracer_->RecordSkip(skip, skip_reason);
           if (options_.use_metric_depth_constraint) {
             skip.residual_type = "metric_depth";
-            RecordResidualSkip(skip, skip_reason);
+            tracer_->RecordSkip(skip, skip_reason);
           }
         }
       }
@@ -1005,12 +522,12 @@ void GlobalPositioner::AddPointToCameraConstraints(
           CovarianceWeightedCostFunctor<NormalPriorCostFunctor<1>>::Create(
               cov_1x1, prior_vec);
       if (scale_prior_cost == nullptr) {
-        ResidualLedgerEntry skip;
+        GlobalPositioningResidualDescriptor skip;
         skip.residual_type = "scale_prior";
         skip.image_id = image_id;
         skip.dmap_scale_image_id = image_id;
         skip.loss_bucket = "scale_prior";
-        RecordResidualSkip(skip, "scale_prior_cost_create_failed");
+        tracer_->RecordSkip(skip, "scale_prior_cost_create_failed");
         continue;
       }
 
@@ -1029,17 +546,16 @@ void GlobalPositioner::AddPointToCameraConstraints(
       problem_->AddResidualBlock(
           scale_prior_cost, obs_count_scaled_loss, &scale);
 
-      ResidualLedgerEntry residual;
+      GlobalPositioningResidualDescriptor residual;
       residual.residual_type = "scale_prior";
       residual.image_id = image_id;
       residual.dmap_scale_image_id = image_id;
       residual.loss_bucket = "scale_prior";
-      const std::string residual_id = RecordResidualBlock(residual);
-      RecordReplayResidual(
-          residual_id, scale_prior_cost, obs_count_scaled_loss, {&scale});
+      tracer_->RecordResidual(
+          residual, scale_prior_cost, obs_count_scaled_loss, {&scale});
     }
   }
-  RecordResidualBucketSummaries();
+  tracer_->RecordBucketSummaries();
   VLOG(2) << "GP: residual blocks=" << problem_->NumResidualBlocks()
           << ", parameter blocks=" << problem_->NumParameterBlocks()
           << ", scales=" << scales_.size()
@@ -1074,18 +590,18 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
                               reconstruction,
                               /*is_lc_observation=*/true);
     }
-  } else if (ShouldTraceResidualLedger()) {
+  } else if (tracer_->ResidualLedgerEnabled()) {
     for (const auto& observation : point3D.track.lc_elements) {
-      ResidualLedgerEntry skip;
+      GlobalPositioningResidualDescriptor skip;
       skip.residual_type = "bata_ref_frame";
       skip.point3D_id = point3D_id;
       skip.image_id = observation.image_id;
       skip.point2D_idx = observation.point2D_idx;
       skip.is_lc_observation = true;
-      RecordResidualSkip(skip, "lc_observation_disabled");
+      tracer_->RecordSkip(skip, "lc_observation_disabled");
       if (options_.use_metric_depth_constraint) {
         skip.residual_type = "metric_depth";
-        RecordResidualSkip(skip, "lc_observation_disabled");
+        tracer_->RecordSkip(skip, "lc_observation_disabled");
       }
     }
   }
@@ -1098,23 +614,23 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                                bool is_lc_observation) {
   Point3D& point3D = reconstruction.Point3D(point3D_id);
   if (!reconstruction.ExistsImage(observation.image_id)) {
-    ResidualLedgerEntry skip;
+    GlobalPositioningResidualDescriptor skip;
     skip.residual_type = "bata_ref_frame";
     skip.point3D_id = point3D_id;
     skip.image_id = observation.image_id;
     skip.point2D_idx = observation.point2D_idx;
     skip.is_lc_observation = is_lc_observation;
-    RecordResidualSkip(skip, "missing_image");
+    tracer_->RecordSkip(skip, "missing_image");
     if (options_.use_metric_depth_constraint) {
       skip.residual_type = "metric_depth";
-      RecordResidualSkip(skip, "missing_image");
+      tracer_->RecordSkip(skip, "missing_image");
     }
     return;
   }
 
   Image& image = reconstruction.Image(observation.image_id);
   Camera& camera = reconstruction.Camera(image.CameraId());
-  ResidualLedgerEntry observation_record;
+  GlobalPositioningResidualDescriptor observation_record;
   observation_record.point3D_id = point3D_id;
   observation_record.image_id = observation.image_id;
   observation_record.point2D_idx = observation.point2D_idx;
@@ -1142,10 +658,10 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   if (!image.HasPose()) {
     observation_record.residual_type =
         image.IsRefInFrame() ? "bata_ref_frame" : "bata_variable_rig";
-    RecordResidualSkip(observation_record, "image_without_pose");
+    tracer_->RecordSkip(observation_record, "image_without_pose");
     if (options_.use_metric_depth_constraint) {
       observation_record.residual_type = "metric_depth";
-      RecordResidualSkip(observation_record, "image_without_pose");
+      tracer_->RecordSkip(observation_record, "image_without_pose");
     }
     return;
   }
@@ -1155,10 +671,10 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   if (!cam_point.has_value()) {
     observation_record.residual_type =
         image.IsRefInFrame() ? "bata_ref_frame" : "bata_variable_rig";
-    RecordResidualSkip(observation_record, "invalid_keypoint_projection");
+    tracer_->RecordSkip(observation_record, "invalid_keypoint_projection");
     if (options_.use_metric_depth_constraint) {
       observation_record.residual_type = "metric_depth";
-      RecordResidualSkip(observation_record, "invalid_keypoint_projection");
+      tracer_->RecordSkip(observation_record, "invalid_keypoint_projection");
     }
     LOG(WARNING) << "Ignoring feature because it failed to project: point3D_id="
                  << point3D_id << ", image_id=" << observation.image_id
@@ -1174,7 +690,7 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
       << "Not enough capacity was reserved for the scales.";
   double& scale = scales_.emplace_back(1);
   const size_t scale_index = scales_.size() - 1;
-  RecordScaleObservation(
+  tracer_->RecordScaleObservation(
       scale_index, point3D_id, observation, is_lc_observation);
 
   if (!options_.generate_scales && random_initialization) {
@@ -1260,13 +776,12 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                point3D.xyz.data(),
                                &scale);
 
-    ResidualLedgerEntry residual = observation_record;
+    GlobalPositioningResidualDescriptor residual = observation_record;
     residual.residual_type = "bata_ref_frame";
     residual.loss_bucket = geometry_loss_bucket;
     residual.uses_keypoint_covariance = uses_keypoint_covariance;
-    const std::string residual_id = RecordResidualBlock(residual);
-    RecordReplayResidual(
-        residual_id,
+    tracer_->RecordResidual(
+        residual,
         cost_function,
         loss_function,
         {frame_centers_[image.FrameId()].data(), point3D.xyz.data(), &scale});
@@ -1276,9 +791,9 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
       AddMetricDepthResidual(
           point3D_id, observation, is_lc_observation, reconstruction);
     } else {
-      ResidualLedgerEntry skip = observation_record;
+      GlobalPositioningResidualDescriptor skip = observation_record;
       skip.residual_type = "metric_depth";
-      RecordResidualSkip(skip, "metric_depth_disabled");
+      tracer_->RecordSkip(skip, "metric_depth_disabled");
     }
   } else {
     // If the image is part of a camera rig, use the RigBATA error.
@@ -1302,12 +817,11 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                  frame_centers_[image.FrameId()].data(),
                                  &scale);
 
-      ResidualLedgerEntry residual = observation_record;
+      GlobalPositioningResidualDescriptor residual = observation_record;
       residual.residual_type = "bata_constant_rig";
       residual.loss_bucket = geometry_loss_bucket;
-      const std::string residual_id = RecordResidualBlock(residual);
-      RecordReplayResidual(
-          residual_id,
+      tracer_->RecordResidual(
+          residual,
           cost_function,
           loss_function,
           {point3D.xyz.data(), frame_centers_[image.FrameId()].data(), &scale});
@@ -1332,22 +846,21 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                  cams_in_rig_[sensor_id].data(),
                                  &scale);
 
-      ResidualLedgerEntry residual = observation_record;
+      GlobalPositioningResidualDescriptor residual = observation_record;
       residual.residual_type = "bata_variable_rig";
       residual.loss_bucket = geometry_loss_bucket;
-      const std::string residual_id = RecordResidualBlock(residual);
-      RecordReplayResidual(residual_id,
-                           cost_function,
-                           loss_function,
-                           {point3D.xyz.data(),
-                            frame_centers_[image.FrameId()].data(),
-                            cams_in_rig_[sensor_id].data(),
-                            &scale});
+      tracer_->RecordResidual(residual,
+                              cost_function,
+                              loss_function,
+                              {point3D.xyz.data(),
+                               frame_centers_[image.FrameId()].data(),
+                               cams_in_rig_[sensor_id].data(),
+                               &scale});
     }
     if (!options_.use_metric_depth_constraint) {
-      ResidualLedgerEntry skip = observation_record;
+      GlobalPositioningResidualDescriptor skip = observation_record;
       skip.residual_type = "metric_depth";
-      RecordResidualSkip(skip, "metric_depth_disabled");
+      tracer_->RecordSkip(skip, "metric_depth_disabled");
     }
   }
 
@@ -1359,19 +872,19 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
                                               bool is_lc_observation,
                                               Reconstruction& reconstruction) {
   if (!reconstruction.ExistsImage(observation.image_id)) {
-    ResidualLedgerEntry skip;
+    GlobalPositioningResidualDescriptor skip;
     skip.residual_type = "metric_depth";
     skip.point3D_id = point3D_id;
     skip.image_id = observation.image_id;
     skip.point2D_idx = observation.point2D_idx;
     skip.is_lc_observation = is_lc_observation;
-    RecordResidualSkip(skip, "missing_image");
+    tracer_->RecordSkip(skip, "missing_image");
     return;
   }
   const Image& image = reconstruction.Image(observation.image_id);
   const Camera& camera = reconstruction.Camera(image.CameraId());
 
-  ResidualLedgerEntry residual;
+  GlobalPositioningResidualDescriptor residual;
   residual.residual_type = "metric_depth";
   residual.point3D_id = point3D_id;
   residual.image_id = observation.image_id;
@@ -1388,7 +901,7 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
 
   if (observation.point2D_idx >= image.depth_prior_validity.size() ||
       !image.depth_prior_validity[observation.point2D_idx]) {
-    RecordResidualSkip(residual, "missing_depth_validity");
+    tracer_->RecordSkip(residual, "missing_depth_validity");
     return;
   }
   THROW_CHECK_LT(observation.point2D_idx, image.depth_priors.size());
@@ -1401,11 +914,11 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
   residual.depth_sigma = depth_sigma;
 
   if (depth_prior <= 0.0) {
-    RecordResidualSkip(residual, "invalid_depth_prior");
+    tracer_->RecordSkip(residual, "invalid_depth_prior");
     return;
   }
   if (depth_sigma <= 1e-9) {
-    RecordResidualSkip(residual, "invalid_depth_sigma");
+    tracer_->RecordSkip(residual, "invalid_depth_sigma");
     return;
   }
 
@@ -1434,7 +947,7 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
                                CreateMetricDepthOptions(options_));
 
   if (metric_depth_cost == nullptr) {
-    RecordResidualSkip(residual, "metric_depth_cost_create_failed");
+    tracer_->RecordSkip(residual, "metric_depth_cost_create_failed");
     return;
   }
 
@@ -1465,7 +978,7 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
       // LC outlier: skip depth residual entirely.
       delete metric_depth_cost;
       residual.loss_bucket = "depth_lc";
-      RecordResidualSkip(residual, "runtime_lc_depth_outlier_skipped");
+      tracer_->RecordSkip(residual, "runtime_lc_depth_outlier_skipped");
       return;
     }
     // Non-LC outlier: soft fallback (HuberLoss(1)).
@@ -1499,13 +1012,12 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
                              point3D.xyz.data(),
                              &dmap_scales_[observation.image_id]);
   residual.loss_bucket = depth_loss_bucket;
-  const std::string residual_id = RecordResidualBlock(residual);
-  RecordReplayResidual(residual_id,
-                       metric_depth_cost,
-                       depth_loss,
-                       {frame_centers_[image.FrameId()].data(),
-                        point3D.xyz.data(),
-                        &dmap_scales_[observation.image_id]});
+  tracer_->RecordResidual(residual,
+                          metric_depth_cost,
+                          depth_loss,
+                          {frame_centers_[image.FrameId()].data(),
+                           point3D.xyz.data(),
+                           &dmap_scales_[observation.image_id]});
 }
 
 void GlobalPositioner::AddCamerasAndPointsToParameterGroups(

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -21,6 +21,11 @@ Eigen::Vector3d RandVector3d(double low, double high) {
                          RandomUniformReal(low, high));
 }
 
+GlobalPositioningTraceParameterBlockDescriptor TraceParameterBlock(
+    std::string role, std::string kind, const uint64_t id) {
+  return {std::move(role), std::move(kind), id};
+}
+
 MetricDepthOptions CreateMetricDepthOptions(
     const GlobalPositionerOptions& options) {
   MetricDepthOptions metric_depth_options;
@@ -263,6 +268,7 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
     std::unique_ptr<ceres::IterationCallback> trace_callback;
     if (tracer_->Enabled()) {
       trace_callback = tracer_->CreateIterationCallback({
+          *problem_,
           reconstruction,
           frame_centers_,
           scales_,
@@ -552,7 +558,11 @@ void GlobalPositioner::AddPointToCameraConstraints(
       residual.dmap_scale_image_id = image_id;
       residual.loss_bucket = "scale_prior";
       tracer_->RecordResidual(
-          residual, scale_prior_cost, obs_count_scaled_loss, {&scale});
+          residual,
+          scale_prior_cost,
+          obs_count_scaled_loss,
+          {&scale},
+          {TraceParameterBlock("dmap_scale", "dmap_scale", image_id)});
     }
   }
   tracer_->RecordBucketSummaries();
@@ -784,7 +794,10 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
         residual,
         cost_function,
         loss_function,
-        {frame_centers_[image.FrameId()].data(), point3D.xyz.data(), &scale});
+        {frame_centers_[image.FrameId()].data(), point3D.xyz.data(), &scale},
+        {TraceParameterBlock("frame_center", "frame_center", image.FrameId()),
+         TraceParameterBlock("point3D", "point3D", point3D_id),
+         TraceParameterBlock("bata_scale", "bata_scale", scale_index)});
 
     // 1-D MetricDepthError: anchors absolute scale via depth prior.
     if (options_.use_metric_depth_constraint) {
@@ -824,7 +837,10 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
           residual,
           cost_function,
           loss_function,
-          {point3D.xyz.data(), frame_centers_[image.FrameId()].data(), &scale});
+          {point3D.xyz.data(), frame_centers_[image.FrameId()].data(), &scale},
+          {TraceParameterBlock("point3D", "point3D", point3D_id),
+           TraceParameterBlock("frame_center", "frame_center", image.FrameId()),
+           TraceParameterBlock("bata_scale", "bata_scale", scale_index)});
     } else {
       // If the cam_from_rig contains nan values, it needs to be re-estimated.
       // Initialize cams_in_rig_ if not already done.
@@ -849,13 +865,18 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
       GlobalPositioningResidualDescriptor residual = observation_record;
       residual.residual_type = "bata_variable_rig";
       residual.loss_bucket = geometry_loss_bucket;
-      tracer_->RecordResidual(residual,
-                              cost_function,
-                              loss_function,
-                              {point3D.xyz.data(),
-                               frame_centers_[image.FrameId()].data(),
-                               cams_in_rig_[sensor_id].data(),
-                               &scale});
+      tracer_->RecordResidual(
+          residual,
+          cost_function,
+          loss_function,
+          {point3D.xyz.data(),
+           frame_centers_[image.FrameId()].data(),
+           cams_in_rig_[sensor_id].data(),
+           &scale},
+          {TraceParameterBlock("point3D", "point3D", point3D_id),
+           TraceParameterBlock("frame_center", "frame_center", image.FrameId()),
+           TraceParameterBlock("cam_in_rig", "cam_in_rig", sensor_id.id),
+           TraceParameterBlock("bata_scale", "bata_scale", scale_index)});
     }
     if (!options_.use_metric_depth_constraint) {
       GlobalPositioningResidualDescriptor skip = observation_record;
@@ -1012,12 +1033,16 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
                              point3D.xyz.data(),
                              &dmap_scales_[observation.image_id]);
   residual.loss_bucket = depth_loss_bucket;
-  tracer_->RecordResidual(residual,
-                          metric_depth_cost,
-                          depth_loss,
-                          {frame_centers_[image.FrameId()].data(),
-                           point3D.xyz.data(),
-                           &dmap_scales_[observation.image_id]});
+  tracer_->RecordResidual(
+      residual,
+      metric_depth_cost,
+      depth_loss,
+      {frame_centers_[image.FrameId()].data(),
+       point3D.xyz.data(),
+       &dmap_scales_[observation.image_id]},
+      {TraceParameterBlock("frame_center", "frame_center", image.FrameId()),
+       TraceParameterBlock("point3D", "point3D", point3D_id),
+       TraceParameterBlock("dmap_scale", "dmap_scale", observation.image_id)});
 }
 
 void GlobalPositioner::AddCamerasAndPointsToParameterGroups(

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <limits>
 #include <utility>
 
 namespace colmap {
@@ -104,6 +105,12 @@ bool IsParameterSnapshotTraceEnabled(
     const GlobalPositioningTraceOptions& options) {
   return static_cast<int>(options.level) >=
          static_cast<int>(GlobalPositioningTraceLevel::kParameterSnapshots);
+}
+
+bool IsResidualValuesTraceEnabled(
+    const GlobalPositioningTraceOptions& options) {
+  return static_cast<int>(options.level) >=
+         static_cast<int>(GlobalPositioningTraceLevel::kResidualValues);
 }
 
 using TraceAttrs = std::map<std::string, GlobalPositioningTraceValue>;
@@ -266,6 +273,71 @@ void WriteParameterSnapshot(
   recorder->WriteParameterSnapshot(snapshot);
 }
 
+void WriteResidualValues(
+    GlobalPositioningTraceRecorder* recorder,
+    const int iteration,
+    const std::vector<GlobalPositioningResidualReplayEntry>& replay_entries) {
+  if (recorder == nullptr) {
+    return;
+  }
+
+  GlobalPositioningTraceResidualValues residual_values;
+  residual_values.iteration = iteration;
+  residual_values.residual_ids.reserve(replay_entries.size());
+  residual_values.residual_dims.reserve(replay_entries.size());
+  residual_values.residual_offsets.reserve(replay_entries.size());
+  residual_values.evaluation_success.resize(replay_entries.size(), false);
+  residual_values.raw_costs.resize(replay_entries.size(),
+                                   std::numeric_limits<double>::quiet_NaN());
+  residual_values.robust_costs.resize(replay_entries.size(),
+                                      std::numeric_limits<double>::quiet_NaN());
+
+  size_t total_scalar_residuals = 0;
+  for (const GlobalPositioningResidualReplayEntry& entry : replay_entries) {
+    residual_values.residual_ids.push_back(entry.residual_id);
+    residual_values.residual_dims.push_back(entry.residual_dimension);
+    residual_values.residual_offsets.push_back(total_scalar_residuals);
+    total_scalar_residuals += entry.residual_dimension;
+  }
+  residual_values.raw_residuals.resize(
+      total_scalar_residuals, std::numeric_limits<double>::quiet_NaN());
+
+  for (size_t entry_idx = 0; entry_idx < replay_entries.size(); ++entry_idx) {
+    const GlobalPositioningResidualReplayEntry& entry =
+        replay_entries[entry_idx];
+    if (entry.cost_function == nullptr) {
+      continue;
+    }
+
+    double* raw_residuals = residual_values.raw_residuals.data() +
+                            residual_values.residual_offsets[entry_idx];
+    const bool evaluation_success = entry.cost_function->Evaluate(
+        entry.parameter_blocks.data(), raw_residuals, nullptr);
+    residual_values.evaluation_success[entry_idx] = evaluation_success;
+    if (!evaluation_success) {
+      continue;
+    }
+
+    double squared_norm = 0.0;
+    for (size_t residual_idx = 0; residual_idx < entry.residual_dimension;
+         ++residual_idx) {
+      squared_norm += raw_residuals[residual_idx] * raw_residuals[residual_idx];
+    }
+
+    const double raw_cost = 0.5 * squared_norm;
+    residual_values.raw_costs[entry_idx] = raw_cost;
+    if (entry.loss_function != nullptr) {
+      double rho[3];
+      entry.loss_function->Evaluate(squared_norm, rho);
+      residual_values.robust_costs[entry_idx] = 0.5 * rho[0];
+    } else {
+      residual_values.robust_costs[entry_idx] = raw_cost;
+    }
+  }
+
+  recorder->WriteResidualValues(residual_values);
+}
+
 class GlobalPositioningTraceIterationCallback
     : public ceres::IterationCallback {
  public:
@@ -276,34 +348,45 @@ class GlobalPositioningTraceIterationCallback
       const std::vector<double>* scales,
       const std::map<image_t, double>* dmap_scales,
       const std::unordered_map<sensor_t, Eigen::Vector3d>* cams_in_rig,
+      const std::vector<GlobalPositioningResidualReplayEntry>*
+          residual_replay_entries,
       const int snapshot_every_n_iterations,
       const int max_snapshotted_points,
-      const bool write_parameter_snapshots)
+      const bool write_parameter_snapshots,
+      const bool write_residual_values)
       : recorder_(recorder),
         reconstruction_(reconstruction),
         frame_centers_(frame_centers),
         scales_(scales),
         dmap_scales_(dmap_scales),
         cams_in_rig_(cams_in_rig),
+        residual_replay_entries_(residual_replay_entries),
         snapshot_every_n_iterations_(snapshot_every_n_iterations),
         max_snapshotted_points_(max_snapshotted_points),
-        write_parameter_snapshots_(write_parameter_snapshots) {}
+        write_parameter_snapshots_(write_parameter_snapshots),
+        write_residual_values_(write_residual_values) {}
 
   ceres::CallbackReturnType operator()(
       const ceres::IterationSummary& summary) override {
     if (recorder_ != nullptr) {
       recorder_->WriteIteration(summary);
     }
-    if (write_parameter_snapshots_ &&
+    if ((write_parameter_snapshots_ || write_residual_values_) &&
         summary.iteration % snapshot_every_n_iterations_ == 0) {
-      WriteParameterSnapshot(recorder_,
-                             summary.iteration,
-                             *reconstruction_,
-                             *frame_centers_,
-                             *scales_,
-                             *dmap_scales_,
-                             *cams_in_rig_,
-                             max_snapshotted_points_);
+      if (write_parameter_snapshots_) {
+        WriteParameterSnapshot(recorder_,
+                               summary.iteration,
+                               *reconstruction_,
+                               *frame_centers_,
+                               *scales_,
+                               *dmap_scales_,
+                               *cams_in_rig_,
+                               max_snapshotted_points_);
+      }
+      if (write_residual_values_) {
+        WriteResidualValues(
+            recorder_, summary.iteration, *residual_replay_entries_);
+      }
     }
     return ceres::SOLVER_CONTINUE;
   }
@@ -315,9 +398,12 @@ class GlobalPositioningTraceIterationCallback
   const std::vector<double>* scales_ = nullptr;
   const std::map<image_t, double>* dmap_scales_ = nullptr;
   const std::unordered_map<sensor_t, Eigen::Vector3d>* cams_in_rig_ = nullptr;
+  const std::vector<GlobalPositioningResidualReplayEntry>*
+      residual_replay_entries_ = nullptr;
   int snapshot_every_n_iterations_ = 1;
   int max_snapshotted_points_ = -1;
   bool write_parameter_snapshots_ = false;
+  bool write_residual_values_ = false;
 };
 
 class GlobalPositioningTraceStatusGuard {
@@ -501,10 +587,11 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
 
     ceres::Solver::Options solver_options = options_.solver_options;
     const bool trace_parameter_snapshots = ShouldTraceParameterSnapshots();
-    if (trace_parameter_snapshots) {
+    const bool trace_residual_values = ShouldTraceResidualValues();
+    if (trace_parameter_snapshots || trace_residual_values) {
       THROW_CHECK_GT(options_.trace.snapshot_every_n_iterations, 0)
           << "Global positioning trace snapshot_every_n_iterations must be "
-             "positive when parameter snapshots are enabled.";
+             "positive when sampled trace artifacts are enabled.";
       solver_options.update_state_every_iteration = true;
     }
     std::unique_ptr<GlobalPositioningTraceIterationCallback> trace_callback;
@@ -517,9 +604,11 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
               &scales_,
               &dmap_scales_,
               &cams_in_rig_,
+              &residual_replay_entries_,
               options_.trace.snapshot_every_n_iterations,
               options_.trace.max_snapshotted_points,
-              trace_parameter_snapshots);
+              trace_parameter_snapshots,
+              trace_residual_values);
       solver_options.callbacks.push_back(trace_callback.get());
     }
 
@@ -610,9 +699,15 @@ bool GlobalPositioner::ShouldTraceParameterSnapshots() const {
          IsParameterSnapshotTraceEnabled(options_.trace);
 }
 
+bool GlobalPositioner::ShouldTraceResidualValues() const {
+  return trace_recorder_ != nullptr &&
+         IsResidualValuesTraceEnabled(options_.trace);
+}
+
 void GlobalPositioner::ResetResidualLedger() {
   residual_bucket_counts_.clear();
   scale_observations_.clear();
+  residual_replay_entries_.clear();
 }
 
 void GlobalPositioner::RecordScaleObservation(const size_t scale_index,
@@ -633,17 +728,18 @@ void GlobalPositioner::RecordScaleObservation(const size_t scale_index,
   };
 }
 
-void GlobalPositioner::RecordResidualBlock(const ResidualLedgerEntry& entry) {
+std::string GlobalPositioner::RecordResidualBlock(
+    const ResidualLedgerEntry& entry) {
   if (!ShouldTraceResidualLedger()) {
-    return;
+    return "";
   }
 
+  std::string residual_id = trace_recorder_->AllocateResidualId();
   GlobalPositioningTraceRecord record;
   record.event_type = "residual_added";
   record.stage = "problem_build";
   record.attrs = {
-      {"residual_id",
-       TraceValue::String(trace_recorder_->AllocateResidualId())},
+      {"residual_id", TraceValue::String(residual_id)},
       {"residual_type", TraceValue::String(entry.residual_type)},
       {"point3D_id", TraceOptionalId(entry.point3D_id)},
       {"image_id", TraceOptionalId(entry.image_id)},
@@ -666,6 +762,25 @@ void GlobalPositioner::RecordResidualBlock(const ResidualLedgerEntry& entry) {
   };
   trace_recorder_->WriteResidualBlock(std::move(record));
   ++residual_bucket_counts_[entry.residual_type + "|" + entry.loss_bucket];
+  return residual_id;
+}
+
+void GlobalPositioner::RecordReplayResidual(
+    const std::string& residual_id,
+    const ceres::CostFunction* cost_function,
+    const ceres::LossFunction* loss_function,
+    std::vector<const double*> parameter_blocks) {
+  if (!ShouldTraceResidualValues() || residual_id.empty() ||
+      cost_function == nullptr) {
+    return;
+  }
+
+  residual_replay_entries_.push_back(
+      {residual_id,
+       cost_function,
+       loss_function,
+       static_cast<size_t>(cost_function->num_residuals()),
+       std::move(parameter_blocks)});
 }
 
 void GlobalPositioner::RecordResidualSkip(const ResidualLedgerEntry& entry,
@@ -919,7 +1034,9 @@ void GlobalPositioner::AddPointToCameraConstraints(
       residual.image_id = image_id;
       residual.dmap_scale_image_id = image_id;
       residual.loss_bucket = "scale_prior";
-      RecordResidualBlock(residual);
+      const std::string residual_id = RecordResidualBlock(residual);
+      RecordReplayResidual(
+          residual_id, scale_prior_cost, obs_count_scaled_loss, {&scale});
     }
   }
   RecordResidualBucketSummaries();
@@ -1147,7 +1264,12 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
     residual.residual_type = "bata_ref_frame";
     residual.loss_bucket = geometry_loss_bucket;
     residual.uses_keypoint_covariance = uses_keypoint_covariance;
-    RecordResidualBlock(residual);
+    const std::string residual_id = RecordResidualBlock(residual);
+    RecordReplayResidual(
+        residual_id,
+        cost_function,
+        loss_function,
+        {frame_centers_[image.FrameId()].data(), point3D.xyz.data(), &scale});
 
     // 1-D MetricDepthError: anchors absolute scale via depth prior.
     if (options_.use_metric_depth_constraint) {
@@ -1183,7 +1305,12 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
       ResidualLedgerEntry residual = observation_record;
       residual.residual_type = "bata_constant_rig";
       residual.loss_bucket = geometry_loss_bucket;
-      RecordResidualBlock(residual);
+      const std::string residual_id = RecordResidualBlock(residual);
+      RecordReplayResidual(
+          residual_id,
+          cost_function,
+          loss_function,
+          {point3D.xyz.data(), frame_centers_[image.FrameId()].data(), &scale});
     } else {
       // If the cam_from_rig contains nan values, it needs to be re-estimated.
       // Initialize cams_in_rig_ if not already done.
@@ -1208,7 +1335,14 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
       ResidualLedgerEntry residual = observation_record;
       residual.residual_type = "bata_variable_rig";
       residual.loss_bucket = geometry_loss_bucket;
-      RecordResidualBlock(residual);
+      const std::string residual_id = RecordResidualBlock(residual);
+      RecordReplayResidual(residual_id,
+                           cost_function,
+                           loss_function,
+                           {point3D.xyz.data(),
+                            frame_centers_[image.FrameId()].data(),
+                            cams_in_rig_[sensor_id].data(),
+                            &scale});
     }
     if (!options_.use_metric_depth_constraint) {
       ResidualLedgerEntry skip = observation_record;
@@ -1365,7 +1499,13 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
                              point3D.xyz.data(),
                              &dmap_scales_[observation.image_id]);
   residual.loss_bucket = depth_loss_bucket;
-  RecordResidualBlock(residual);
+  const std::string residual_id = RecordResidualBlock(residual);
+  RecordReplayResidual(residual_id,
+                       metric_depth_cost,
+                       depth_loss,
+                       {frame_centers_[image.FrameId()].data(),
+                        point3D.xyz.data(),
+                        &dmap_scales_[observation.image_id]});
 }
 
 void GlobalPositioner::AddCamerasAndPointsToParameterGroups(

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <optional>
 #include <utility>
 
 namespace colmap {
@@ -24,6 +25,102 @@ Eigen::Vector3d RandVector3d(double low, double high) {
 GlobalPositioningTraceParameterBlockDescriptor TraceParameterBlock(
     std::string role, std::string kind, const uint64_t id) {
   return {std::move(role), std::move(kind), id};
+}
+
+std::vector<double> TraceVector3d(const Eigen::Vector3d& value) {
+  return {value.x(), value.y(), value.z()};
+}
+
+std::vector<double> TraceMatrix3dRowMajor(const Eigen::Matrix3d& value) {
+  std::vector<double> entries;
+  entries.reserve(9);
+  for (int row = 0; row < 3; ++row) {
+    for (int col = 0; col < 3; ++col) {
+      entries.push_back(value(row, col));
+    }
+  }
+  return entries;
+}
+
+std::vector<double> TraceQuaternionWxyz(const Eigen::Quaterniond& value) {
+  return {value.w(), value.x(), value.y(), value.z()};
+}
+
+std::string TraceLossFunctionType(const LossFunctionType type) {
+  switch (type) {
+    case LossFunctionType::TRIVIAL:
+      return "trivial";
+    case LossFunctionType::SOFT_L1:
+      return "soft_l1";
+    case LossFunctionType::CAUCHY:
+      return "cauchy";
+    case LossFunctionType::HUBER:
+      return "huber";
+  }
+  LOG(FATAL) << "Unhandled LossFunctionType: " << static_cast<int>(type);
+}
+
+GlobalPositioningTraceLossConfig TraceLossConfig(
+    const std::string& bucket,
+    const LossConfig& loss,
+    std::string source,
+    const double extra_weight = 1.0,
+    const std::optional<double> observation_count_weight = std::nullopt) {
+  GlobalPositioningTraceLossConfig trace_loss;
+  trace_loss.bucket = bucket;
+  trace_loss.type = TraceLossFunctionType(loss.type);
+  trace_loss.scale = loss.scale;
+  trace_loss.weight = loss.weight * extra_weight;
+  trace_loss.source = std::move(source);
+  trace_loss.observation_count_weight = observation_count_weight;
+  return trace_loss;
+}
+
+std::string TraceMetricDepthResidualType(
+    const MetricDepthResidualType residual_type) {
+  switch (residual_type) {
+    case MetricDepthResidualType::kLinear:
+      return "linear";
+    case MetricDepthResidualType::kLog:
+      return "log";
+    case MetricDepthResidualType::kLogLinear:
+      return "log_linear";
+  }
+  LOG(FATAL) << "Unhandled MetricDepthResidualType: "
+             << static_cast<int>(residual_type);
+}
+
+GlobalPositioningTraceFixedParameters TraceBataRefFrameFixedParameters(
+    const Eigen::Vector3d& cam_from_point3D_dir,
+    const std::optional<Eigen::Matrix3d>& keypoint_covariance_world) {
+  GlobalPositioningTraceFixedParameters fixed_parameters;
+  fixed_parameters.cam_from_point3D_dir = TraceVector3d(cam_from_point3D_dir);
+  if (keypoint_covariance_world.has_value()) {
+    fixed_parameters.keypoint_covariance_world_row_major =
+        TraceMatrix3dRowMajor(*keypoint_covariance_world);
+  }
+  return fixed_parameters;
+}
+
+GlobalPositioningTraceFixedParameters TraceBataConstantRigFixedParameters(
+    const Eigen::Vector3d& cam_from_point3D_dir,
+    const Eigen::Vector3d& cam_from_rig_dir) {
+  GlobalPositioningTraceFixedParameters fixed_parameters;
+  fixed_parameters.cam_from_point3D_dir = TraceVector3d(cam_from_point3D_dir);
+  fixed_parameters.cam_from_rig_dir = TraceVector3d(cam_from_rig_dir);
+  return fixed_parameters;
+}
+
+GlobalPositioningTraceFixedParameters TraceBataVariableRigFixedParameters(
+    const Eigen::Vector3d& cam_from_point3D_dir,
+    const Eigen::Quaterniond& rig_from_world_rotation) {
+  GlobalPositioningTraceFixedParameters fixed_parameters;
+  fixed_parameters.cam_from_point3D_dir = TraceVector3d(cam_from_point3D_dir);
+  fixed_parameters.rig_from_world_rotation_wxyz =
+      TraceQuaternionWxyz(rig_from_world_rotation);
+  fixed_parameters.world_from_rig_rotation_wxyz =
+      TraceQuaternionWxyz(rig_from_world_rotation.inverse());
+  return fixed_parameters;
 }
 
 MetricDepthOptions CreateMetricDepthOptions(
@@ -42,6 +139,32 @@ MetricDepthOptions CreateMetricDepthOptions(
     metric_depth_options.residual_type = MetricDepthResidualType::kLinear;
   }
   return metric_depth_options;
+}
+
+GlobalPositioningTraceFixedParameters TraceMetricDepthFixedParameters(
+    const Eigen::Quaterniond& camera_rotation,
+    const MetricDepthOptions& metric_depth_options) {
+  GlobalPositioningTraceFixedParameters fixed_parameters;
+  fixed_parameters.camera_rotation_wxyz = TraceQuaternionWxyz(camera_rotation);
+  fixed_parameters.metric_depth_use_log_scale =
+      metric_depth_options.use_log_scale;
+  fixed_parameters.metric_depth_residual_type =
+      TraceMetricDepthResidualType(metric_depth_options.residual_type);
+  fixed_parameters.metric_depth_zero_residual_behind =
+      metric_depth_options.zero_residual_behind;
+  fixed_parameters.metric_depth_log_linear_threshold =
+      metric_depth_options.log_linear_threshold;
+  return fixed_parameters;
+}
+
+GlobalPositioningTraceFixedParameters TraceScalePriorFixedParameters(
+    const bool use_log_scale_for_depth_map_scales,
+    const double scale_prior_stddev) {
+  GlobalPositioningTraceFixedParameters fixed_parameters;
+  fixed_parameters.scale_prior_target =
+      use_log_scale_for_depth_map_scales ? 0.0 : 1.0;
+  fixed_parameters.scale_prior_stddev = scale_prior_stddev;
+  return fixed_parameters;
 }
 
 // Per-observation depth outlier check. Returns true when the log-space
@@ -118,6 +241,75 @@ bool HasValidDepthPriorMetadata(const Image& image,
          image.depth_prior_validity[observation.point2D_idx] &&
          observation.point2D_idx < image.depth_priors.size() &&
          observation.point2D_idx < image.depth_prior_stddevs.size();
+}
+
+GlobalPositioningTraceLossConfig GeometryTraceLossConfig(
+    const GlobalPositionerOptions& options, const std::string& bucket) {
+  if (bucket == "geometry_uncalibrated_downweighted") {
+    return TraceLossConfig(bucket,
+                           options.loss,
+                           "GlobalPositionerOptions.loss+"
+                           "uncalibrated_loss_downweight",
+                           options.uncalibrated_loss_downweight);
+  }
+  if (bucket == "geometry_normal_trackstart") {
+    return TraceLossConfig(bucket,
+                           options.loss_normal_geometry_trackstart,
+                           "GlobalPositionerOptions."
+                           "loss_normal_geometry_trackstart");
+  }
+  if (bucket == "geometry_normal_inlier") {
+    return TraceLossConfig(bucket,
+                           options.loss_normal_geometry_inlier,
+                           "GlobalPositionerOptions."
+                           "loss_normal_geometry_inlier");
+  }
+  if (bucket == "geometry_normal_default" &&
+      options.use_metric_depth_constraint) {
+    return TraceLossConfig(bucket,
+                           options.loss_normal_geometry,
+                           "GlobalPositionerOptions.loss_normal_geometry");
+  }
+  if (bucket == "geometry_lc") {
+    return TraceLossConfig(bucket,
+                           options.loss_lc_geometry,
+                           "GlobalPositionerOptions.loss_lc_geometry");
+  }
+  return TraceLossConfig(bucket, options.loss, "GlobalPositionerOptions.loss");
+}
+
+GlobalPositioningTraceLossConfig DepthTraceLossConfig(
+    const GlobalPositionerOptions& options, const std::string& bucket) {
+  if (bucket == "depth_runtime_outlier_soft_fallback") {
+    return TraceLossConfig(bucket,
+                           options.loss_soft_outlier_fallback,
+                           "GlobalPositionerOptions."
+                           "loss_soft_outlier_fallback");
+  }
+  if (bucket == "depth_lc") {
+    return TraceLossConfig(
+        bucket, options.loss_lc_depth, "GlobalPositionerOptions.loss_lc_depth");
+  }
+  if (bucket == "depth_normal_trackstart") {
+    return TraceLossConfig(bucket,
+                           options.loss_normal_depth_trackstart,
+                           "GlobalPositionerOptions."
+                           "loss_normal_depth_trackstart");
+  }
+  if (bucket == "depth_normal_inlier") {
+    return TraceLossConfig(bucket,
+                           options.loss_normal_depth_inlier,
+                           "GlobalPositionerOptions.loss_normal_depth_inlier");
+  }
+  if (bucket == "depth_normal_external_outlier") {
+    return TraceLossConfig(bucket,
+                           options.loss_normal_depth_outlier,
+                           "GlobalPositionerOptions."
+                           "loss_normal_depth_outlier");
+  }
+  return TraceLossConfig(bucket,
+                         options.loss_normal_depth,
+                         "GlobalPositionerOptions.loss_normal_depth");
 }
 
 }  // namespace
@@ -557,6 +749,15 @@ void GlobalPositioner::AddPointToCameraConstraints(
       residual.image_id = image_id;
       residual.dmap_scale_image_id = image_id;
       residual.loss_bucket = "scale_prior";
+      residual.loss = TraceLossConfig("scale_prior",
+                                      options_.loss_scale_prior,
+                                      "GlobalPositionerOptions."
+                                      "loss_scale_prior+observation_count",
+                                      obs_count,
+                                      obs_count);
+      residual.fixed_parameters = TraceScalePriorFixedParameters(
+          options_.use_log_scale_for_depth_map_scales,
+          options_.scale_prior_stddev);
       tracer_->RecordResidual(
           residual,
           scale_prior_cost,
@@ -756,6 +957,7 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
     // cov_world = R^T diag(sigma^2) R.
     ceres::CostFunction* cost_function = nullptr;
     bool uses_keypoint_covariance = false;
+    std::optional<Eigen::Matrix3d> keypoint_covariance_world;
     if (observation.point2D_idx < image.angular_stddevs.size()) {
       const Eigen::Vector2d& angular_std =
           image.angular_stddevs[observation.point2D_idx];
@@ -774,6 +976,9 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
           BATAPairwiseDirectionCostFunctor>::Create(cov_world,
                                                     cam_from_point3D_dir);
       uses_keypoint_covariance = cost_function != nullptr;
+      if (uses_keypoint_covariance) {
+        keypoint_covariance_world = cov_world;
+      }
     }
     if (cost_function == nullptr) {
       cost_function =
@@ -789,7 +994,10 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
     GlobalPositioningResidualDescriptor residual = observation_record;
     residual.residual_type = "bata_ref_frame";
     residual.loss_bucket = geometry_loss_bucket;
+    residual.loss = GeometryTraceLossConfig(options_, geometry_loss_bucket);
     residual.uses_keypoint_covariance = uses_keypoint_covariance;
+    residual.fixed_parameters = TraceBataRefFrameFixedParameters(
+        cam_from_point3D_dir, keypoint_covariance_world);
     tracer_->RecordResidual(
         residual,
         cost_function,
@@ -833,6 +1041,9 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
       GlobalPositioningResidualDescriptor residual = observation_record;
       residual.residual_type = "bata_constant_rig";
       residual.loss_bucket = geometry_loss_bucket;
+      residual.loss = GeometryTraceLossConfig(options_, geometry_loss_bucket);
+      residual.fixed_parameters = TraceBataConstantRigFixedParameters(
+          cam_from_point3D_dir, cam_from_rig_dir);
       tracer_->RecordResidual(
           residual,
           cost_function,
@@ -850,10 +1061,11 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
         cams_in_rig_[sensor_id] = Eigen::Vector3d::Zero();
       }
 
+      const Eigen::Quaterniond rig_from_world_rotation =
+          image.FramePtr()->RigFromWorld().rotation();
       ceres::CostFunction* cost_function =
-          RigBATAPairwiseDirectionCostFunctor::Create(
-              cam_from_point3D_dir,
-              image.FramePtr()->RigFromWorld().rotation());
+          RigBATAPairwiseDirectionCostFunctor::Create(cam_from_point3D_dir,
+                                                      rig_from_world_rotation);
 
       problem_->AddResidualBlock(cost_function,
                                  loss_function,
@@ -865,6 +1077,9 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
       GlobalPositioningResidualDescriptor residual = observation_record;
       residual.residual_type = "bata_variable_rig";
       residual.loss_bucket = geometry_loss_bucket;
+      residual.loss = GeometryTraceLossConfig(options_, geometry_loss_bucket);
+      residual.fixed_parameters = TraceBataVariableRigFixedParameters(
+          cam_from_point3D_dir, rig_from_world_rotation);
       tracer_->RecordResidual(
           residual,
           cost_function,
@@ -961,11 +1176,13 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
   }
   dmap_scale_observation_counts_[observation.image_id]++;
 
+  const MetricDepthOptions metric_depth_options =
+      CreateMetricDepthOptions(options_);
   ceres::CostFunction* metric_depth_cost =
       MetricDepthError::Create(image.CamFromWorld().rotation(),
                                depth_prior,
                                depth_sigma,
-                               CreateMetricDepthOptions(options_));
+                               metric_depth_options);
 
   if (metric_depth_cost == nullptr) {
     tracer_->RecordSkip(residual, "metric_depth_cost_create_failed");
@@ -1033,6 +1250,9 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
                              point3D.xyz.data(),
                              &dmap_scales_[observation.image_id]);
   residual.loss_bucket = depth_loss_bucket;
+  residual.loss = DepthTraceLossConfig(options_, depth_loss_bucket);
+  residual.fixed_parameters = TraceMetricDepthFixedParameters(
+      image.CamFromWorld().rotation(), metric_depth_options);
   tracer_->RecordResidual(
       residual,
       metric_depth_cost,

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -8,7 +8,9 @@
 #include "colmap/util/misc.h"
 #include "colmap/util/threading.h"
 
+#include <algorithm>
 #include <cstdlib>
+#include <utility>
 
 namespace colmap {
 namespace {
@@ -88,6 +90,264 @@ bool IsLossConfigOverride(const LossConfig& loss_config) {
          loss_config.scale != 1.0 || loss_config.weight != 1.0;
 }
 
+bool IsTraceEnabled(const GlobalPositioningTraceOptions& options) {
+  return options.level != GlobalPositioningTraceLevel::kOff;
+}
+
+bool IsResidualLedgerTraceEnabled(
+    const GlobalPositioningTraceOptions& options) {
+  return static_cast<int>(options.level) >=
+         static_cast<int>(GlobalPositioningTraceLevel::kResidualLedger);
+}
+
+bool IsParameterSnapshotTraceEnabled(
+    const GlobalPositioningTraceOptions& options) {
+  return static_cast<int>(options.level) >=
+         static_cast<int>(GlobalPositioningTraceLevel::kParameterSnapshots);
+}
+
+using TraceAttrs = std::map<std::string, GlobalPositioningTraceValue>;
+using TraceValue = GlobalPositioningTraceValue;
+
+template <typename T>
+TraceValue TraceOptionalId(const std::optional<T>& value) {
+  if (!value.has_value()) {
+    return TraceValue::Null();
+  }
+  return TraceValue::UInt(static_cast<uint64_t>(*value));
+}
+
+TraceValue TraceOptionalDouble(const std::optional<double>& value) {
+  if (!value.has_value()) {
+    return TraceValue::Null();
+  }
+  return TraceValue::Double(*value);
+}
+
+std::optional<uint64_t> TraceSensorId(
+    const std::optional<sensor_t>& sensor_id) {
+  if (!sensor_id.has_value() || *sensor_id == kInvalidSensorId) {
+    return std::nullopt;
+  }
+  return static_cast<uint64_t>(sensor_id->id);
+}
+
+std::string DepthOutlierSource(
+    const std::set<std::pair<image_t, point2D_t>>& runtime_depth_outliers,
+    const Image& image,
+    const TrackElement& observation) {
+  if (runtime_depth_outliers.count(
+          {observation.image_id, observation.point2D_idx}) > 0) {
+    return "runtime_filter";
+  }
+  if (observation.point2D_idx < image.is_depth_outlier.size() &&
+      image.is_depth_outlier[observation.point2D_idx]) {
+    return "external_annotation";
+  }
+  return "none";
+}
+
+bool HasValidDepthPriorMetadata(const Image& image,
+                                const TrackElement& observation) {
+  return observation.point2D_idx < image.depth_prior_validity.size() &&
+         image.depth_prior_validity[observation.point2D_idx] &&
+         observation.point2D_idx < image.depth_priors.size() &&
+         observation.point2D_idx < image.depth_prior_stddevs.size();
+}
+
+void WriteTraceEvent(GlobalPositioningTraceRecorder* recorder,
+                     std::string event_type,
+                     std::string stage,
+                     TraceAttrs attrs = {}) {
+  if (recorder == nullptr) {
+    return;
+  }
+
+  GlobalPositioningTraceRecord record;
+  record.event_type = std::move(event_type);
+  record.stage = std::move(stage);
+  record.attrs = std::move(attrs);
+  recorder->WriteEvent(std::move(record));
+}
+
+void WriteParameterSnapshot(
+    GlobalPositioningTraceRecorder* recorder,
+    const int iteration,
+    const Reconstruction& reconstruction,
+    const std::unordered_map<frame_t, Eigen::Vector3d>& frame_centers,
+    const std::vector<double>& scales,
+    const std::map<image_t, double>& dmap_scales,
+    const std::unordered_map<sensor_t, Eigen::Vector3d>& cams_in_rig,
+    const int max_snapshotted_points) {
+  if (recorder == nullptr) {
+    return;
+  }
+
+  GlobalPositioningTraceParameterSnapshot snapshot;
+  snapshot.iteration = iteration;
+
+  std::vector<frame_t> frame_ids;
+  frame_ids.reserve(frame_centers.size());
+  for (const auto& [frame_id, center] : frame_centers) {
+    frame_ids.push_back(frame_id);
+  }
+  std::sort(frame_ids.begin(), frame_ids.end());
+  snapshot.frame_centers.shape = {frame_ids.size(), 3};
+  snapshot.frame_centers.ids.reserve(frame_ids.size());
+  snapshot.frame_centers.values.reserve(3 * frame_ids.size());
+  for (const frame_t frame_id : frame_ids) {
+    const Eigen::Vector3d& center = frame_centers.at(frame_id);
+    snapshot.frame_centers.ids.push_back(static_cast<uint64_t>(frame_id));
+    snapshot.frame_centers.values.push_back(center.x());
+    snapshot.frame_centers.values.push_back(center.y());
+    snapshot.frame_centers.values.push_back(center.z());
+  }
+
+  std::vector<point3D_t> point3D_ids;
+  point3D_ids.reserve(reconstruction.NumPoints3D());
+  for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
+    point3D_ids.push_back(point3D_id);
+  }
+  std::sort(point3D_ids.begin(), point3D_ids.end());
+  if (max_snapshotted_points >= 0 &&
+      point3D_ids.size() > static_cast<size_t>(max_snapshotted_points)) {
+    point3D_ids.resize(static_cast<size_t>(max_snapshotted_points));
+  }
+  snapshot.points3D.shape = {point3D_ids.size(), 3};
+  snapshot.points3D.ids.reserve(point3D_ids.size());
+  snapshot.points3D.values.reserve(3 * point3D_ids.size());
+  for (const point3D_t point3D_id : point3D_ids) {
+    const Eigen::Vector3d& xyz = reconstruction.Point3D(point3D_id).xyz;
+    snapshot.points3D.ids.push_back(static_cast<uint64_t>(point3D_id));
+    snapshot.points3D.values.push_back(xyz.x());
+    snapshot.points3D.values.push_back(xyz.y());
+    snapshot.points3D.values.push_back(xyz.z());
+  }
+
+  snapshot.scales.shape = {scales.size()};
+  snapshot.scales.ids.reserve(scales.size());
+  snapshot.scales.values.reserve(scales.size());
+  for (size_t scale_idx = 0; scale_idx < scales.size(); ++scale_idx) {
+    snapshot.scales.ids.push_back(static_cast<uint64_t>(scale_idx));
+    snapshot.scales.values.push_back(scales[scale_idx]);
+  }
+
+  if (!dmap_scales.empty()) {
+    snapshot.dmap_scales.emplace();
+    snapshot.dmap_scales->shape = {dmap_scales.size()};
+    snapshot.dmap_scales->ids.reserve(dmap_scales.size());
+    snapshot.dmap_scales->values.reserve(dmap_scales.size());
+    for (const auto& [image_id, scale] : dmap_scales) {
+      snapshot.dmap_scales->ids.push_back(static_cast<uint64_t>(image_id));
+      snapshot.dmap_scales->values.push_back(scale);
+    }
+  }
+
+  std::vector<sensor_t> sensor_ids;
+  sensor_ids.reserve(cams_in_rig.size());
+  for (const auto& [sensor_id, center] : cams_in_rig) {
+    sensor_ids.push_back(sensor_id);
+  }
+  std::sort(sensor_ids.begin(), sensor_ids.end());
+  if (!sensor_ids.empty()) {
+    snapshot.cams_in_rig.emplace();
+    snapshot.cams_in_rig->shape = {sensor_ids.size(), 3};
+    snapshot.cams_in_rig->ids.reserve(sensor_ids.size());
+    snapshot.cams_in_rig->values.reserve(3 * sensor_ids.size());
+    for (const sensor_t sensor_id : sensor_ids) {
+      const Eigen::Vector3d& cam_in_rig = cams_in_rig.at(sensor_id);
+      snapshot.cams_in_rig->ids.push_back(static_cast<uint64_t>(sensor_id.id));
+      snapshot.cams_in_rig->values.push_back(cam_in_rig.x());
+      snapshot.cams_in_rig->values.push_back(cam_in_rig.y());
+      snapshot.cams_in_rig->values.push_back(cam_in_rig.z());
+    }
+  }
+
+  recorder->WriteParameterSnapshot(snapshot);
+}
+
+class GlobalPositioningTraceIterationCallback
+    : public ceres::IterationCallback {
+ public:
+  GlobalPositioningTraceIterationCallback(
+      GlobalPositioningTraceRecorder* recorder,
+      const Reconstruction* reconstruction,
+      const std::unordered_map<frame_t, Eigen::Vector3d>* frame_centers,
+      const std::vector<double>* scales,
+      const std::map<image_t, double>* dmap_scales,
+      const std::unordered_map<sensor_t, Eigen::Vector3d>* cams_in_rig,
+      const int snapshot_every_n_iterations,
+      const int max_snapshotted_points,
+      const bool write_parameter_snapshots)
+      : recorder_(recorder),
+        reconstruction_(reconstruction),
+        frame_centers_(frame_centers),
+        scales_(scales),
+        dmap_scales_(dmap_scales),
+        cams_in_rig_(cams_in_rig),
+        snapshot_every_n_iterations_(snapshot_every_n_iterations),
+        max_snapshotted_points_(max_snapshotted_points),
+        write_parameter_snapshots_(write_parameter_snapshots) {}
+
+  ceres::CallbackReturnType operator()(
+      const ceres::IterationSummary& summary) override {
+    if (recorder_ != nullptr) {
+      recorder_->WriteIteration(summary);
+    }
+    if (write_parameter_snapshots_ &&
+        summary.iteration % snapshot_every_n_iterations_ == 0) {
+      WriteParameterSnapshot(recorder_,
+                             summary.iteration,
+                             *reconstruction_,
+                             *frame_centers_,
+                             *scales_,
+                             *dmap_scales_,
+                             *cams_in_rig_,
+                             max_snapshotted_points_);
+    }
+    return ceres::SOLVER_CONTINUE;
+  }
+
+ private:
+  GlobalPositioningTraceRecorder* recorder_ = nullptr;
+  const Reconstruction* reconstruction_ = nullptr;
+  const std::unordered_map<frame_t, Eigen::Vector3d>* frame_centers_ = nullptr;
+  const std::vector<double>* scales_ = nullptr;
+  const std::map<image_t, double>* dmap_scales_ = nullptr;
+  const std::unordered_map<sensor_t, Eigen::Vector3d>* cams_in_rig_ = nullptr;
+  int snapshot_every_n_iterations_ = 1;
+  int max_snapshotted_points_ = -1;
+  bool write_parameter_snapshots_ = false;
+};
+
+class GlobalPositioningTraceStatusGuard {
+ public:
+  explicit GlobalPositioningTraceStatusGuard(
+      GlobalPositioningTraceRecorder* recorder,
+      GlobalPositioningTraceRecorder** active_recorder)
+      : recorder_(recorder), active_recorder_(active_recorder) {}
+
+  ~GlobalPositioningTraceStatusGuard() {
+    if (active_recorder_ != nullptr) {
+      *active_recorder_ = nullptr;
+    }
+  }
+
+  void MarkFinished() {
+    if (recorder_ != nullptr) {
+      recorder_->MarkFinished("finished");
+      recorder_ = nullptr;
+    }
+    if (active_recorder_ != nullptr) {
+      *active_recorder_ = nullptr;
+    }
+  }
+
+ private:
+  GlobalPositioningTraceRecorder* recorder_ = nullptr;
+  GlobalPositioningTraceRecorder** active_recorder_ = nullptr;
+};
+
 }  // namespace
 
 GlobalPositioner::GlobalPositioner(const GlobalPositionerOptions& options)
@@ -108,64 +368,212 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
     return false;
   }
 
-  // TODO: extend rig branch in AddObservationToProblem to add MetricDepthError
-  // for non-ref images. Until then, fail loud on multi-camera rigs +
-  // use_metric_depth_constraint.
-  if (options_.use_metric_depth_constraint) {
-    for (const auto& [image_id, image] : reconstruction.Images()) {
-      THROW_CHECK(image.IsRefInFrame())
-          << "use_metric_depth_constraint=true is not yet supported with "
-             "multi-camera rigs. Image "
-          << image_id
-          << " is a non-ref sensor in its frame; its depth "
-             "residual would be silently dropped. Either disable "
-             "use_metric_depth_constraint or run on single-camera rigs.";
+  std::unique_ptr<GlobalPositioningTraceRecorder> trace_recorder;
+  if (IsTraceEnabled(options_.trace)) {
+    trace_recorder =
+        std::make_unique<GlobalPositioningTraceRecorder>(options_.trace);
+  }
+  trace_recorder_ = trace_recorder.get();
+
+  {
+    GlobalPositioningTraceStatusGuard trace_status(trace_recorder.get(),
+                                                   &trace_recorder_);
+    WriteTraceEvent(
+        trace_recorder.get(),
+        "run_started",
+        "solve",
+        {{"num_images", TraceValue::UInt(reconstruction.NumImages())},
+         {"num_points3D", TraceValue::UInt(reconstruction.NumPoints3D())},
+         {"num_frames", TraceValue::UInt(reconstruction.NumFrames())},
+         {"num_cameras", TraceValue::UInt(reconstruction.NumCameras())},
+         {"trace_level",
+          TraceValue::String(
+              GlobalPositioningTraceLevelToString(options_.trace.level))}});
+
+    // TODO: extend rig branch in AddObservationToProblem to add
+    // MetricDepthError for non-ref images. Until then, fail loud on
+    // multi-camera rigs + use_metric_depth_constraint.
+    if (options_.use_metric_depth_constraint) {
+      for (const auto& [image_id, image] : reconstruction.Images()) {
+        THROW_CHECK(image.IsRefInFrame())
+            << "use_metric_depth_constraint=true is not yet supported with "
+               "multi-camera rigs. Image "
+            << image_id
+            << " is a non-ref sensor in its frame; its depth "
+               "residual would be silently dropped. Either disable "
+               "use_metric_depth_constraint or run on single-camera rigs.";
+      }
     }
+
+    LOG(INFO) << "Setting up the global positioner problem";
+
+    WriteTraceEvent(
+        trace_recorder.get(), "problem_setup_started", "setup_problem");
+
+    // Setup the problem.
+    SetupProblem(pose_graph, reconstruction);
+
+    WriteTraceEvent(
+        trace_recorder.get(),
+        "problem_setup_finished",
+        "setup_problem",
+        {{"reserved_scale_capacity", TraceValue::UInt(scales_.capacity())}});
+
+    // Initialize camera translations to be random.
+    // Also, convert the camera pose translation to be the camera center.
+    InitializeRandomPositions(pose_graph, reconstruction);
+
+    WriteTraceEvent(
+        trace_recorder.get(),
+        "initialization_finished",
+        "initialization",
+        {{"num_frame_centers", TraceValue::UInt(frame_centers_.size())},
+         {"use_init", TraceValue::Bool(options_.use_init)},
+         {"generate_random_positions",
+          TraceValue::Bool(options_.generate_random_positions)},
+         {"generate_random_points",
+          TraceValue::Bool(options_.generate_random_points)}});
+
+    // No caller-supplied seed for dmap_scales_; derive one from per-image
+    // median observed z_est/depth_prior.
+    const bool initialize_dmap_scales =
+        options_.use_metric_depth_constraint && options_.use_init &&
+        !options_.initial_dmap_scales.has_value();
+    std::string dmap_scale_skip_reason;
+    if (initialize_dmap_scales) {
+      InitializeDepthMapScalesFromObservations(reconstruction);
+    } else if (!options_.use_metric_depth_constraint) {
+      dmap_scale_skip_reason = "metric_depth_disabled";
+    } else if (!options_.use_init) {
+      dmap_scale_skip_reason = "use_init_disabled";
+    } else {
+      dmap_scale_skip_reason = "initial_dmap_scales_provided";
+    }
+    WriteTraceEvent(
+        trace_recorder.get(),
+        "dmap_scale_initialization_finished",
+        "initialization",
+        {{"skipped", TraceValue::Bool(!initialize_dmap_scales)},
+         {"reason", TraceValue::String(dmap_scale_skip_reason)},
+         {"num_dmap_scales", TraceValue::UInt(dmap_scales_.size())}});
+
+    WriteTraceEvent(
+        trace_recorder.get(), "residual_build_started", "problem_build");
+
+    // Add the point to camera constraints to the problem.
+    AddPointToCameraConstraints(reconstruction);
+
+    WriteTraceEvent(
+        trace_recorder.get(),
+        "problem_built",
+        "problem_build",
+        {{"num_residual_blocks",
+          TraceValue::Int(problem_->NumResidualBlocks())},
+         {"num_parameter_blocks",
+          TraceValue::Int(problem_->NumParameterBlocks())},
+         {"num_scales", TraceValue::UInt(scales_.size())},
+         {"num_frame_centers", TraceValue::UInt(frame_centers_.size())},
+         {"num_dmap_scales", TraceValue::UInt(dmap_scales_.size())}});
+
+    if (options_.use_parameter_block_ordering) {
+      AddCamerasAndPointsToParameterGroups(reconstruction);
+    }
+
+    // Parameterize the variables, set image poses / tracks / scales to be
+    // constant if desired.
+    ParameterizeVariables(reconstruction);
+
+    WriteTraceEvent(
+        trace_recorder.get(),
+        "parameterization_finished",
+        "parameterization",
+        {{"optimize_positions", TraceValue::Bool(options_.optimize_positions)},
+         {"optimize_points", TraceValue::Bool(options_.optimize_points)},
+         {"optimize_scales", TraceValue::Bool(options_.optimize_scales)},
+         {"use_gpu_effective", TraceValue::Bool(use_gpu_effective_)}});
+
+    LOG(INFO) << "Solving the global positioner problem";
+
+    ceres::Solver::Summary summary;
+    options_.solver_options.num_threads =
+        GetEffectiveNumThreads(options_.solver_options.num_threads);
+    options_.solver_options.minimizer_progress_to_stdout = VLOG_IS_ON(2);
+
+    ceres::Solver::Options solver_options = options_.solver_options;
+    const bool trace_parameter_snapshots = ShouldTraceParameterSnapshots();
+    if (trace_parameter_snapshots) {
+      THROW_CHECK_GT(options_.trace.snapshot_every_n_iterations, 0)
+          << "Global positioning trace snapshot_every_n_iterations must be "
+             "positive when parameter snapshots are enabled.";
+      solver_options.update_state_every_iteration = true;
+    }
+    std::unique_ptr<GlobalPositioningTraceIterationCallback> trace_callback;
+    if (trace_recorder != nullptr) {
+      trace_callback =
+          std::make_unique<GlobalPositioningTraceIterationCallback>(
+              trace_recorder.get(),
+              &reconstruction,
+              &frame_centers_,
+              &scales_,
+              &dmap_scales_,
+              &cams_in_rig_,
+              options_.trace.snapshot_every_n_iterations,
+              options_.trace.max_snapshotted_points,
+              trace_parameter_snapshots);
+      solver_options.callbacks.push_back(trace_callback.get());
+    }
+
+    WriteTraceEvent(
+        trace_recorder.get(),
+        "solve_started",
+        "ceres_solve",
+        {{"max_num_iterations",
+          TraceValue::Int(solver_options.max_num_iterations)},
+         {"num_threads", TraceValue::Int(solver_options.num_threads)},
+         {"linear_solver_type",
+          TraceValue::String(ceres::LinearSolverTypeToString(
+              solver_options.linear_solver_type))},
+         {"preconditioner_type",
+          TraceValue::String(ceres::PreconditionerTypeToString(
+              solver_options.preconditioner_type))}});
+
+    ceres::Solve(solver_options, problem_.get(), &summary);
+
+    const bool is_solution_usable = summary.IsSolutionUsable();
+    WriteTraceEvent(
+        trace_recorder.get(),
+        "solve_finished",
+        "ceres_solve",
+        {{"is_solution_usable", TraceValue::Bool(is_solution_usable)},
+         {"termination_type",
+          TraceValue::String(
+              ceres::TerminationTypeToString(summary.termination_type))},
+         {"message", TraceValue::String(summary.message)},
+         {"initial_cost", TraceValue::Double(summary.initial_cost)},
+         {"final_cost", TraceValue::Double(summary.final_cost)},
+         {"num_successful_steps",
+          TraceValue::Int(summary.num_successful_steps)},
+         {"num_unsuccessful_steps",
+          TraceValue::Int(summary.num_unsuccessful_steps)},
+         {"total_time_sec",
+          TraceValue::Double(summary.total_time_in_seconds)}});
+
+    if (VLOG_IS_ON(2)) {
+      LOG(INFO) << summary.FullReport();
+    } else {
+      LOG(INFO) << summary.BriefReport();
+    }
+
+    ConvertBackResults(reconstruction);
+    WriteTraceEvent(
+        trace_recorder.get(),
+        "results_converted",
+        "convert_results",
+        {{"num_frame_centers", TraceValue::UInt(frame_centers_.size())},
+         {"num_cams_in_rig", TraceValue::UInt(cams_in_rig_.size())}});
+    trace_status.MarkFinished();
+    return is_solution_usable;
   }
-
-  LOG(INFO) << "Setting up the global positioner problem";
-
-  // Setup the problem.
-  SetupProblem(pose_graph, reconstruction);
-
-  // Initialize camera translations to be random.
-  // Also, convert the camera pose translation to be the camera center.
-  InitializeRandomPositions(pose_graph, reconstruction);
-
-  // No caller-supplied seed for dmap_scales_; derive one from per-image
-  // median observed z_est/depth_prior.
-  if (options_.use_metric_depth_constraint && options_.use_init &&
-      !options_.initial_dmap_scales.has_value()) {
-    InitializeDepthMapScalesFromObservations(reconstruction);
-  }
-
-  // Add the point to camera constraints to the problem.
-  AddPointToCameraConstraints(reconstruction);
-
-  if (options_.use_parameter_block_ordering) {
-    AddCamerasAndPointsToParameterGroups(reconstruction);
-  }
-
-  // Parameterize the variables, set image poses / tracks / scales to be
-  // constant if desired
-  ParameterizeVariables(reconstruction);
-
-  LOG(INFO) << "Solving the global positioner problem";
-
-  ceres::Solver::Summary summary;
-  options_.solver_options.num_threads =
-      GetEffectiveNumThreads(options_.solver_options.num_threads);
-  options_.solver_options.minimizer_progress_to_stdout = VLOG_IS_ON(2);
-  ceres::Solve(options_.solver_options, problem_.get(), &summary);
-
-  if (VLOG_IS_ON(2)) {
-    LOG(INFO) << summary.FullReport();
-  } else {
-    LOG(INFO) << summary.BriefReport();
-  }
-
-  ConvertBackResults(reconstruction);
-  return summary.IsSolutionUsable();
 }
 
 void GlobalPositioner::SetupProblem(const PoseGraph& pose_graph,
@@ -179,6 +587,7 @@ void GlobalPositioner::SetupProblem(const PoseGraph& pose_graph,
   frame_centers_.clear();
   cams_in_rig_.clear();
   per_image_scale_losses_.clear();
+  ResetResidualLedger();
 
   // Reserve to avoid pointer-invalidating reallocs.
   scales_.clear();
@@ -188,6 +597,131 @@ void GlobalPositioner::SetupProblem(const PoseGraph& pose_graph,
     total_observations += point3D.track.lc_elements.size();
   }
   scales_.reserve(total_observations);
+  scale_observations_.reserve(total_observations);
+}
+
+bool GlobalPositioner::ShouldTraceResidualLedger() const {
+  return trace_recorder_ != nullptr &&
+         IsResidualLedgerTraceEnabled(options_.trace);
+}
+
+bool GlobalPositioner::ShouldTraceParameterSnapshots() const {
+  return trace_recorder_ != nullptr &&
+         IsParameterSnapshotTraceEnabled(options_.trace);
+}
+
+void GlobalPositioner::ResetResidualLedger() {
+  residual_bucket_counts_.clear();
+  scale_observations_.clear();
+}
+
+void GlobalPositioner::RecordScaleObservation(const size_t scale_index,
+                                              const point3D_t point3D_id,
+                                              const TrackElement& observation,
+                                              const bool is_lc_observation) {
+  if (!ShouldTraceResidualLedger()) {
+    return;
+  }
+  if (scale_observations_.size() <= scale_index) {
+    scale_observations_.resize(scale_index + 1);
+  }
+  scale_observations_[scale_index] = {
+      point3D_id,
+      observation.image_id,
+      observation.point2D_idx,
+      is_lc_observation,
+  };
+}
+
+void GlobalPositioner::RecordResidualBlock(const ResidualLedgerEntry& entry) {
+  if (!ShouldTraceResidualLedger()) {
+    return;
+  }
+
+  GlobalPositioningTraceRecord record;
+  record.event_type = "residual_added";
+  record.stage = "problem_build";
+  record.attrs = {
+      {"residual_id",
+       TraceValue::String(trace_recorder_->AllocateResidualId())},
+      {"residual_type", TraceValue::String(entry.residual_type)},
+      {"point3D_id", TraceOptionalId(entry.point3D_id)},
+      {"image_id", TraceOptionalId(entry.image_id)},
+      {"point2D_idx", TraceOptionalId(entry.point2D_idx)},
+      {"frame_id", TraceOptionalId(entry.frame_id)},
+      {"camera_id", TraceOptionalId(entry.camera_id)},
+      {"sensor_id", TraceOptionalId(TraceSensorId(entry.sensor_id))},
+      {"is_lc_observation", TraceValue::Bool(entry.is_lc_observation)},
+      {"is_ref_in_frame", TraceValue::Bool(entry.is_ref_in_frame)},
+      {"camera_has_prior_focal_length",
+       TraceValue::Bool(entry.camera_has_prior_focal_length)},
+      {"loss_bucket", TraceValue::String(entry.loss_bucket)},
+      {"uses_keypoint_covariance",
+       TraceValue::Bool(entry.uses_keypoint_covariance)},
+      {"has_depth_prior", TraceValue::Bool(entry.has_depth_prior)},
+      {"depth_prior", TraceOptionalDouble(entry.depth_prior)},
+      {"depth_sigma", TraceOptionalDouble(entry.depth_sigma)},
+      {"dmap_scale_image_id", TraceOptionalId(entry.dmap_scale_image_id)},
+      {"depth_outlier_source", TraceValue::String(entry.depth_outlier_source)},
+  };
+  trace_recorder_->WriteResidualBlock(std::move(record));
+  ++residual_bucket_counts_[entry.residual_type + "|" + entry.loss_bucket];
+}
+
+void GlobalPositioner::RecordResidualSkip(const ResidualLedgerEntry& entry,
+                                          const std::string& skip_reason) {
+  if (!ShouldTraceResidualLedger()) {
+    return;
+  }
+
+  GlobalPositioningTraceRecord record;
+  record.event_type = "residual_skipped";
+  record.stage = "problem_build";
+  record.attrs = {
+      {"residual_type", TraceValue::String(entry.residual_type)},
+      {"skip_reason", TraceValue::String(skip_reason)},
+      {"point3D_id", TraceOptionalId(entry.point3D_id)},
+      {"image_id", TraceOptionalId(entry.image_id)},
+      {"point2D_idx", TraceOptionalId(entry.point2D_idx)},
+      {"frame_id", TraceOptionalId(entry.frame_id)},
+      {"camera_id", TraceOptionalId(entry.camera_id)},
+      {"sensor_id", TraceOptionalId(TraceSensorId(entry.sensor_id))},
+      {"is_lc_observation", TraceValue::Bool(entry.is_lc_observation)},
+      {"is_ref_in_frame", TraceValue::Bool(entry.is_ref_in_frame)},
+      {"camera_has_prior_focal_length",
+       TraceValue::Bool(entry.camera_has_prior_focal_length)},
+      {"loss_bucket", TraceValue::String(entry.loss_bucket)},
+      {"uses_keypoint_covariance",
+       TraceValue::Bool(entry.uses_keypoint_covariance)},
+      {"has_depth_prior", TraceValue::Bool(entry.has_depth_prior)},
+      {"depth_prior", TraceOptionalDouble(entry.depth_prior)},
+      {"depth_sigma", TraceOptionalDouble(entry.depth_sigma)},
+      {"dmap_scale_image_id", TraceOptionalId(entry.dmap_scale_image_id)},
+      {"depth_outlier_source", TraceValue::String(entry.depth_outlier_source)},
+  };
+  trace_recorder_->WriteResidualSkip(std::move(record));
+}
+
+void GlobalPositioner::RecordResidualBucketSummaries() {
+  if (!ShouldTraceResidualLedger()) {
+    return;
+  }
+
+  for (const auto& [key, count] : residual_bucket_counts_) {
+    const size_t separator = key.find('|');
+    GlobalPositioningTraceRecord record;
+    record.event_type = "residual_bucket_summary";
+    record.stage = "problem_build";
+    record.attrs = {
+        {"residual_type", TraceValue::String(key.substr(0, separator))},
+        {"loss_bucket",
+         TraceValue::String(separator == std::string::npos
+                                ? "none"
+                                : key.substr(separator + 1))},
+        {"count", TraceValue::UInt(count)},
+    };
+    trace_recorder_->WriteResidualBucketSummary(std::move(record));
+  }
 }
 
 void GlobalPositioner::InitializeRandomPositions(
@@ -301,6 +835,36 @@ void GlobalPositioner::AddPointToCameraConstraints(
   for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
     if (NumRegularObservationsForMinViewGate(point3D.track) <
         static_cast<size_t>(options_.min_num_view_per_track)) {
+      if (ShouldTraceResidualLedger()) {
+        for (const auto& observation : point3D.track.Elements()) {
+          ResidualLedgerEntry skip;
+          skip.residual_type = "bata_ref_frame";
+          skip.point3D_id = point3D_id;
+          skip.image_id = observation.image_id;
+          skip.point2D_idx = observation.point2D_idx;
+          RecordResidualSkip(skip, "track_min_view_gate");
+          if (options_.use_metric_depth_constraint) {
+            skip.residual_type = "metric_depth";
+            RecordResidualSkip(skip, "track_min_view_gate");
+          }
+        }
+        for (const auto& observation : point3D.track.lc_elements) {
+          ResidualLedgerEntry skip;
+          skip.residual_type = "bata_ref_frame";
+          skip.point3D_id = point3D_id;
+          skip.image_id = observation.image_id;
+          skip.point2D_idx = observation.point2D_idx;
+          skip.is_lc_observation = true;
+          const std::string skip_reason = options_.use_lc_observations
+                                              ? "track_min_view_gate"
+                                              : "lc_observation_disabled";
+          RecordResidualSkip(skip, skip_reason);
+          if (options_.use_metric_depth_constraint) {
+            skip.residual_type = "metric_depth";
+            RecordResidualSkip(skip, skip_reason);
+          }
+        }
+      }
       continue;
     }
 
@@ -325,7 +889,15 @@ void GlobalPositioner::AddPointToCameraConstraints(
       ceres::CostFunction* scale_prior_cost =
           CovarianceWeightedCostFunctor<NormalPriorCostFunctor<1>>::Create(
               cov_1x1, prior_vec);
-      if (scale_prior_cost == nullptr) continue;
+      if (scale_prior_cost == nullptr) {
+        ResidualLedgerEntry skip;
+        skip.residual_type = "scale_prior";
+        skip.image_id = image_id;
+        skip.dmap_scale_image_id = image_id;
+        skip.loss_bucket = "scale_prior";
+        RecordResidualSkip(skip, "scale_prior_cost_create_failed");
+        continue;
+      }
 
       ceres::LossFunction* obs_count_scaled_loss = nullptr;
       if (cached_loss_scale_prior_) {
@@ -341,8 +913,16 @@ void GlobalPositioner::AddPointToCameraConstraints(
 
       problem_->AddResidualBlock(
           scale_prior_cost, obs_count_scaled_loss, &scale);
+
+      ResidualLedgerEntry residual;
+      residual.residual_type = "scale_prior";
+      residual.image_id = image_id;
+      residual.dmap_scale_image_id = image_id;
+      residual.loss_bucket = "scale_prior";
+      RecordResidualBlock(residual);
     }
   }
+  RecordResidualBucketSummaries();
   VLOG(2) << "GP: residual blocks=" << problem_->NumResidualBlocks()
           << ", parameter blocks=" << problem_->NumParameterBlocks()
           << ", scales=" << scales_.size()
@@ -377,6 +957,20 @@ void GlobalPositioner::AddPoint3DToProblem(point3D_t point3D_id,
                               reconstruction,
                               /*is_lc_observation=*/true);
     }
+  } else if (ShouldTraceResidualLedger()) {
+    for (const auto& observation : point3D.track.lc_elements) {
+      ResidualLedgerEntry skip;
+      skip.residual_type = "bata_ref_frame";
+      skip.point3D_id = point3D_id;
+      skip.image_id = observation.image_id;
+      skip.point2D_idx = observation.point2D_idx;
+      skip.is_lc_observation = true;
+      RecordResidualSkip(skip, "lc_observation_disabled");
+      if (options_.use_metric_depth_constraint) {
+        skip.residual_type = "metric_depth";
+        RecordResidualSkip(skip, "lc_observation_disabled");
+      }
+    }
   }
 }
 
@@ -386,14 +980,69 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                                Reconstruction& reconstruction,
                                                bool is_lc_observation) {
   Point3D& point3D = reconstruction.Point3D(point3D_id);
-  if (!reconstruction.ExistsImage(observation.image_id)) return;
+  if (!reconstruction.ExistsImage(observation.image_id)) {
+    ResidualLedgerEntry skip;
+    skip.residual_type = "bata_ref_frame";
+    skip.point3D_id = point3D_id;
+    skip.image_id = observation.image_id;
+    skip.point2D_idx = observation.point2D_idx;
+    skip.is_lc_observation = is_lc_observation;
+    RecordResidualSkip(skip, "missing_image");
+    if (options_.use_metric_depth_constraint) {
+      skip.residual_type = "metric_depth";
+      RecordResidualSkip(skip, "missing_image");
+    }
+    return;
+  }
 
   Image& image = reconstruction.Image(observation.image_id);
-  if (!image.HasPose()) return;
+  Camera& camera = reconstruction.Camera(image.CameraId());
+  ResidualLedgerEntry observation_record;
+  observation_record.point3D_id = point3D_id;
+  observation_record.image_id = observation.image_id;
+  observation_record.point2D_idx = observation.point2D_idx;
+  observation_record.frame_id = image.FrameId();
+  observation_record.camera_id = image.CameraId();
+  observation_record.sensor_id = camera.SensorId();
+  observation_record.is_lc_observation = is_lc_observation;
+  observation_record.is_ref_in_frame = image.IsRefInFrame();
+  observation_record.camera_has_prior_focal_length =
+      camera.has_prior_focal_length;
+  observation_record.has_depth_prior =
+      HasValidDepthPriorMetadata(image, observation);
+  if (observation_record.has_depth_prior) {
+    observation_record.depth_prior =
+        image.depth_priors[observation.point2D_idx];
+    observation_record.depth_sigma =
+        image.depth_prior_stddevs[observation.point2D_idx];
+  }
+  observation_record.depth_outlier_source =
+      DepthOutlierSource(depth_outliers_, image, observation);
+  if (options_.use_metric_depth_constraint) {
+    observation_record.dmap_scale_image_id = observation.image_id;
+  }
+
+  if (!image.HasPose()) {
+    observation_record.residual_type =
+        image.IsRefInFrame() ? "bata_ref_frame" : "bata_variable_rig";
+    RecordResidualSkip(observation_record, "image_without_pose");
+    if (options_.use_metric_depth_constraint) {
+      observation_record.residual_type = "metric_depth";
+      RecordResidualSkip(observation_record, "image_without_pose");
+    }
+    return;
+  }
 
   const std::optional<Eigen::Vector2d> cam_point =
       image.CameraPtr()->CamFromImg(image.Point2D(observation.point2D_idx).xy);
   if (!cam_point.has_value()) {
+    observation_record.residual_type =
+        image.IsRefInFrame() ? "bata_ref_frame" : "bata_variable_rig";
+    RecordResidualSkip(observation_record, "invalid_keypoint_projection");
+    if (options_.use_metric_depth_constraint) {
+      observation_record.residual_type = "metric_depth";
+      RecordResidualSkip(observation_record, "invalid_keypoint_projection");
+    }
     LOG(WARNING) << "Ignoring feature because it failed to project: point3D_id="
                  << point3D_id << ", image_id=" << observation.image_id
                  << ", feature_id=" << observation.point2D_idx;
@@ -407,6 +1056,9 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   CHECK_GE(scales_.capacity(), scales_.size())
       << "Not enough capacity was reserved for the scales.";
   double& scale = scales_.emplace_back(1);
+  const size_t scale_index = scales_.size() - 1;
+  RecordScaleObservation(
+      scale_index, point3D_id, observation, is_lc_observation);
 
   if (!options_.generate_scales && random_initialization) {
     const Eigen::Vector3d cam_from_point3D_translation =
@@ -419,10 +1071,15 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   // For calibrated and uncalibrated cameras, use different loss
   // functions
   // Down weight the uncalibrated cameras
-  Camera& camera = reconstruction.Camera(image.CameraId());
   ceres::LossFunction* loss_function =
       (camera.has_prior_focal_length) ? loss_function_ptcam_calibrated_.get()
                                       : loss_function_ptcam_uncalibrated_.get();
+  std::string geometry_loss_bucket =
+      camera.has_prior_focal_length
+          ? "geometry_calibrated"
+          : (options_.apply_uncalibrated_loss_downweight
+                 ? "geometry_uncalibrated_downweighted"
+                 : "geometry_normal_default");
 
   // Geometry-loss cascade. Per-observation route:
   //   is_lc                         -> cached_loss_lc_geometry_
@@ -431,14 +1088,18 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   //   else                          -> cached_loss_normal_geometry_
   if (is_lc_observation && cached_loss_lc_geometry_) {
     loss_function = cached_loss_lc_geometry_.get();
+    geometry_loss_bucket = "geometry_lc";
   } else if (options_.use_metric_depth_constraint) {
     ceres::LossFunction* cascade = nullptr;
     if (observation.is_track_anchor) {
       cascade = cached_loss_normal_geometry_trackstart_.get();
+      geometry_loss_bucket = "geometry_normal_trackstart";
     } else if (observation.is_inlier) {
       cascade = cached_loss_normal_geometry_inlier_.get();
+      geometry_loss_bucket = "geometry_normal_inlier";
     } else {
       cascade = cached_loss_normal_geometry_.get();
+      geometry_loss_bucket = "geometry_normal_default";
     }
     if (cascade != nullptr) {
       loss_function = cascade;
@@ -451,6 +1112,7 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
     // when angular_stddevs is populated; otherwise bare BATA functor.
     // cov_world = R^T diag(sigma^2) R.
     ceres::CostFunction* cost_function = nullptr;
+    bool uses_keypoint_covariance = false;
     if (observation.point2D_idx < image.angular_stddevs.size()) {
       const Eigen::Vector2d& angular_std =
           image.angular_stddevs[observation.point2D_idx];
@@ -468,6 +1130,7 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
       cost_function = CovarianceWeightedCostFunctor<
           BATAPairwiseDirectionCostFunctor>::Create(cov_world,
                                                     cam_from_point3D_dir);
+      uses_keypoint_covariance = cost_function != nullptr;
     }
     if (cost_function == nullptr) {
       cost_function =
@@ -480,10 +1143,20 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                point3D.xyz.data(),
                                &scale);
 
+    ResidualLedgerEntry residual = observation_record;
+    residual.residual_type = "bata_ref_frame";
+    residual.loss_bucket = geometry_loss_bucket;
+    residual.uses_keypoint_covariance = uses_keypoint_covariance;
+    RecordResidualBlock(residual);
+
     // 1-D MetricDepthError: anchors absolute scale via depth prior.
     if (options_.use_metric_depth_constraint) {
       AddMetricDepthResidual(
           point3D_id, observation, is_lc_observation, reconstruction);
+    } else {
+      ResidualLedgerEntry skip = observation_record;
+      skip.residual_type = "metric_depth";
+      RecordResidualSkip(skip, "metric_depth_disabled");
     }
   } else {
     // If the image is part of a camera rig, use the RigBATA error.
@@ -506,6 +1179,11 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                  point3D.xyz.data(),
                                  frame_centers_[image.FrameId()].data(),
                                  &scale);
+
+      ResidualLedgerEntry residual = observation_record;
+      residual.residual_type = "bata_constant_rig";
+      residual.loss_bucket = geometry_loss_bucket;
+      RecordResidualBlock(residual);
     } else {
       // If the cam_from_rig contains nan values, it needs to be re-estimated.
       // Initialize cams_in_rig_ if not already done.
@@ -526,6 +1204,16 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
                                  frame_centers_[image.FrameId()].data(),
                                  cams_in_rig_[sensor_id].data(),
                                  &scale);
+
+      ResidualLedgerEntry residual = observation_record;
+      residual.residual_type = "bata_variable_rig";
+      residual.loss_bucket = geometry_loss_bucket;
+      RecordResidualBlock(residual);
+    }
+    if (!options_.use_metric_depth_constraint) {
+      ResidualLedgerEntry skip = observation_record;
+      skip.residual_type = "metric_depth";
+      RecordResidualSkip(skip, "metric_depth_disabled");
     }
   }
 
@@ -536,11 +1224,37 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
                                               const TrackElement& observation,
                                               bool is_lc_observation,
                                               Reconstruction& reconstruction) {
-  if (!reconstruction.ExistsImage(observation.image_id)) return;
+  if (!reconstruction.ExistsImage(observation.image_id)) {
+    ResidualLedgerEntry skip;
+    skip.residual_type = "metric_depth";
+    skip.point3D_id = point3D_id;
+    skip.image_id = observation.image_id;
+    skip.point2D_idx = observation.point2D_idx;
+    skip.is_lc_observation = is_lc_observation;
+    RecordResidualSkip(skip, "missing_image");
+    return;
+  }
   const Image& image = reconstruction.Image(observation.image_id);
+  const Camera& camera = reconstruction.Camera(image.CameraId());
+
+  ResidualLedgerEntry residual;
+  residual.residual_type = "metric_depth";
+  residual.point3D_id = point3D_id;
+  residual.image_id = observation.image_id;
+  residual.point2D_idx = observation.point2D_idx;
+  residual.frame_id = image.FrameId();
+  residual.camera_id = image.CameraId();
+  residual.sensor_id = camera.SensorId();
+  residual.is_lc_observation = is_lc_observation;
+  residual.is_ref_in_frame = image.IsRefInFrame();
+  residual.camera_has_prior_focal_length = camera.has_prior_focal_length;
+  residual.dmap_scale_image_id = observation.image_id;
+  residual.depth_outlier_source =
+      DepthOutlierSource(depth_outliers_, image, observation);
 
   if (observation.point2D_idx >= image.depth_prior_validity.size() ||
       !image.depth_prior_validity[observation.point2D_idx]) {
+    RecordResidualSkip(residual, "missing_depth_validity");
     return;
   }
   THROW_CHECK_LT(observation.point2D_idx, image.depth_priors.size());
@@ -548,8 +1262,18 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
 
   const double depth_prior = image.depth_priors[observation.point2D_idx];
   const double depth_sigma = image.depth_prior_stddevs[observation.point2D_idx];
+  residual.has_depth_prior = true;
+  residual.depth_prior = depth_prior;
+  residual.depth_sigma = depth_sigma;
 
-  if (depth_prior <= 0.0 || depth_sigma <= 1e-9) return;
+  if (depth_prior <= 0.0) {
+    RecordResidualSkip(residual, "invalid_depth_prior");
+    return;
+  }
+  if (depth_sigma <= 1e-9) {
+    RecordResidualSkip(residual, "invalid_depth_sigma");
+    return;
+  }
 
   // Lazy-insert dmap_scales_ on first valid observation per image.
   if (dmap_scales_.find(observation.image_id) == dmap_scales_.end()) {
@@ -575,7 +1299,10 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
                                depth_sigma,
                                CreateMetricDepthOptions(options_));
 
-  if (metric_depth_cost == nullptr) return;
+  if (metric_depth_cost == nullptr) {
+    RecordResidualSkip(residual, "metric_depth_cost_create_failed");
+    return;
+  }
 
   // Outlier dual routing:
   //   depth_outliers_ = runtime geometry-driven filter
@@ -596,12 +1323,15 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
   //   TrackElement::is_depth_outlier -> cached_loss_normal_depth_outlier_
   //   else              -> cached_loss_normal_depth_
   ceres::LossFunction* depth_loss = nullptr;
+  std::string depth_loss_bucket = "none";
   const std::pair<image_t, point2D_t> obs_key{observation.image_id,
                                               observation.point2D_idx};
   if (depth_outliers_.count(obs_key) > 0) {
     if (is_lc_observation) {
       // LC outlier: skip depth residual entirely.
       delete metric_depth_cost;
+      residual.loss_bucket = "depth_lc";
+      RecordResidualSkip(residual, "runtime_lc_depth_outlier_skipped");
       return;
     }
     // Non-LC outlier: soft fallback (HuberLoss(1)).
@@ -610,16 +1340,22 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
           options_.loss_soft_outlier_fallback.CreateLossFunction();
     }
     depth_loss = soft_outlier_fallback_loss_.get();
+    depth_loss_bucket = "depth_runtime_outlier_soft_fallback";
   } else if (is_lc_observation) {
     depth_loss = cached_loss_lc_depth_.get();
+    depth_loss_bucket = "depth_lc";
   } else if (observation.is_track_anchor) {
     depth_loss = cached_loss_normal_depth_trackstart_.get();
+    depth_loss_bucket = "depth_normal_trackstart";
   } else if (observation.is_inlier) {
     depth_loss = cached_loss_normal_depth_inlier_.get();
+    depth_loss_bucket = "depth_normal_inlier";
   } else if (observation.is_depth_outlier) {
     depth_loss = cached_loss_normal_depth_outlier_.get();
+    depth_loss_bucket = "depth_normal_external_outlier";
   } else {
     depth_loss = cached_loss_normal_depth_.get();
+    depth_loss_bucket = "depth_normal_default";
   }
 
   Point3D& point3D = reconstruction.Point3D(point3D_id);
@@ -628,6 +1364,8 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
                              frame_centers_[image.FrameId()].data(),
                              point3D.xyz.data(),
                              &dmap_scales_[observation.image_id]);
+  residual.loss_bucket = depth_loss_bucket;
+  RecordResidualBlock(residual);
 }
 
 void GlobalPositioner::AddCamerasAndPointsToParameterGroups(
@@ -679,6 +1417,7 @@ void GlobalPositioner::AddCamerasAndPointsToParameterGroups(
 void GlobalPositioner::ParameterizeVariables(Reconstruction& reconstruction) {
   // For the global positioning, do not set any camera to be constant for easier
   // convergence
+  use_gpu_effective_ = false;
 
   // Initialize cams_in_rig_ with random values if optimizing positions.
   if (options_.optimize_positions) {
@@ -777,6 +1516,7 @@ void GlobalPositioner::ParameterizeVariables(Reconstruction& reconstruction) {
 #endif
 
   if (cuda_solver_enabled) {
+    use_gpu_effective_ = true;
     const std::vector<int> gpu_indices = CSVToVector<int>(options_.gpu_index);
     THROW_CHECK_GT(gpu_indices.size(), 0);
     SetBestCudaDevice(gpu_indices[0]);

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -2,6 +2,7 @@
 
 #include "colmap/estimators/ceres_loss.h"
 #include "colmap/estimators/global_positioning_trace.h"
+#include "colmap/estimators/global_positioning_tracer.h"
 #include "colmap/scene/pose_graph.h"
 #include "colmap/scene/reconstruction.h"
 
@@ -123,14 +124,6 @@ struct GlobalPositionerOptions {
   }
 };
 
-struct GlobalPositioningResidualReplayEntry {
-  std::string residual_id;
-  const ceres::CostFunction* cost_function = nullptr;
-  const ceres::LossFunction* loss_function = nullptr;
-  size_t residual_dimension = 0;
-  std::vector<const double*> parameter_blocks;
-};
-
 class GlobalPositioner {
  public:
   explicit GlobalPositioner(const GlobalPositionerOptions& options);
@@ -240,54 +233,10 @@ class GlobalPositioner {
   // Owned here because problem_ uses DO_NOT_TAKE_OWNERSHIP.
   std::vector<std::unique_ptr<ceres::LossFunction>> per_image_scale_losses_;
 
-  struct ResidualLedgerEntry {
-    std::string residual_type;
-    std::optional<point3D_t> point3D_id;
-    std::optional<image_t> image_id;
-    std::optional<point2D_t> point2D_idx;
-    std::optional<frame_t> frame_id;
-    std::optional<camera_t> camera_id;
-    std::optional<sensor_t> sensor_id;
-    bool is_lc_observation = false;
-    bool is_ref_in_frame = false;
-    bool camera_has_prior_focal_length = false;
-    std::string loss_bucket = "none";
-    bool uses_keypoint_covariance = false;
-    bool has_depth_prior = false;
-    std::optional<double> depth_prior;
-    std::optional<double> depth_sigma;
-    std::optional<image_t> dmap_scale_image_id;
-    std::string depth_outlier_source = "none";
-  };
+  const std::vector<GlobalPositioningResidualReplayEntry>&
+  ResidualReplayEntriesForTest() const;
 
-  struct ScaleObservationMetadata {
-    point3D_t point3D_id = kInvalidPoint3DId;
-    image_t image_id = kInvalidImageId;
-    point2D_t point2D_idx = kInvalidPoint2DIdx;
-    bool is_lc_observation = false;
-  };
-
-  bool ShouldTraceResidualLedger() const;
-  bool ShouldTraceParameterSnapshots() const;
-  bool ShouldTraceResidualValues() const;
-  void ResetResidualLedger();
-  void RecordScaleObservation(size_t scale_index,
-                              point3D_t point3D_id,
-                              const TrackElement& observation,
-                              bool is_lc_observation);
-  std::string RecordResidualBlock(const ResidualLedgerEntry& entry);
-  void RecordReplayResidual(const std::string& residual_id,
-                            const ceres::CostFunction* cost_function,
-                            const ceres::LossFunction* loss_function,
-                            std::vector<const double*> parameter_blocks);
-  void RecordResidualSkip(const ResidualLedgerEntry& entry,
-                          const std::string& skip_reason);
-  void RecordResidualBucketSummaries();
-
-  GlobalPositioningTraceRecorder* trace_recorder_ = nullptr;
-  std::map<std::string, uint64_t> residual_bucket_counts_;
-  std::vector<ScaleObservationMetadata> scale_observations_;
-  std::vector<GlobalPositioningResidualReplayEntry> residual_replay_entries_;
+  std::unique_ptr<GlobalPositioningTracer> tracer_;
 };
 
 // Solve global positioning using point-to-camera constraints.

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -123,6 +123,14 @@ struct GlobalPositionerOptions {
   }
 };
 
+struct GlobalPositioningResidualReplayEntry {
+  std::string residual_id;
+  const ceres::CostFunction* cost_function = nullptr;
+  const ceres::LossFunction* loss_function = nullptr;
+  size_t residual_dimension = 0;
+  std::vector<const double*> parameter_blocks;
+};
+
 class GlobalPositioner {
  public:
   explicit GlobalPositioner(const GlobalPositionerOptions& options);
@@ -261,12 +269,17 @@ class GlobalPositioner {
 
   bool ShouldTraceResidualLedger() const;
   bool ShouldTraceParameterSnapshots() const;
+  bool ShouldTraceResidualValues() const;
   void ResetResidualLedger();
   void RecordScaleObservation(size_t scale_index,
                               point3D_t point3D_id,
                               const TrackElement& observation,
                               bool is_lc_observation);
-  void RecordResidualBlock(const ResidualLedgerEntry& entry);
+  std::string RecordResidualBlock(const ResidualLedgerEntry& entry);
+  void RecordReplayResidual(const std::string& residual_id,
+                            const ceres::CostFunction* cost_function,
+                            const ceres::LossFunction* loss_function,
+                            std::vector<const double*> parameter_blocks);
   void RecordResidualSkip(const ResidualLedgerEntry& entry,
                           const std::string& skip_reason);
   void RecordResidualBucketSummaries();
@@ -274,6 +287,7 @@ class GlobalPositioner {
   GlobalPositioningTraceRecorder* trace_recorder_ = nullptr;
   std::map<std::string, uint64_t> residual_bucket_counts_;
   std::vector<ScaleObservationMetadata> scale_observations_;
+  std::vector<GlobalPositioningResidualReplayEntry> residual_replay_entries_;
 };
 
 // Solve global positioning using point-to-camera constraints.

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "colmap/estimators/ceres_loss.h"
+#include "colmap/estimators/global_positioning_trace.h"
 #include "colmap/scene/pose_graph.h"
 #include "colmap/scene/reconstruction.h"
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
@@ -11,6 +13,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include <ceres/ceres.h>
 
@@ -57,6 +60,9 @@ struct GlobalPositionerOptions {
 
   // The options for the solver
   ceres::Solver::Options solver_options;
+
+  // Optional file-backed diagnostics for global positioning.
+  GlobalPositioningTraceOptions trace;
 
   // Add per-observation MetricDepthError residual alongside BATA.
   bool use_metric_depth_constraint = false;
@@ -178,6 +184,7 @@ class GlobalPositioner {
   void ConvertBackResults(Reconstruction& reconstruction);
 
   GlobalPositionerOptions options_;
+  bool use_gpu_effective_ = false;
 
   std::unique_ptr<ceres::Problem> problem_;
 
@@ -224,6 +231,49 @@ class GlobalPositioner {
   // Per-image ScaledLoss wrappers created in the scale-prior loop.
   // Owned here because problem_ uses DO_NOT_TAKE_OWNERSHIP.
   std::vector<std::unique_ptr<ceres::LossFunction>> per_image_scale_losses_;
+
+  struct ResidualLedgerEntry {
+    std::string residual_type;
+    std::optional<point3D_t> point3D_id;
+    std::optional<image_t> image_id;
+    std::optional<point2D_t> point2D_idx;
+    std::optional<frame_t> frame_id;
+    std::optional<camera_t> camera_id;
+    std::optional<sensor_t> sensor_id;
+    bool is_lc_observation = false;
+    bool is_ref_in_frame = false;
+    bool camera_has_prior_focal_length = false;
+    std::string loss_bucket = "none";
+    bool uses_keypoint_covariance = false;
+    bool has_depth_prior = false;
+    std::optional<double> depth_prior;
+    std::optional<double> depth_sigma;
+    std::optional<image_t> dmap_scale_image_id;
+    std::string depth_outlier_source = "none";
+  };
+
+  struct ScaleObservationMetadata {
+    point3D_t point3D_id = kInvalidPoint3DId;
+    image_t image_id = kInvalidImageId;
+    point2D_t point2D_idx = kInvalidPoint2DIdx;
+    bool is_lc_observation = false;
+  };
+
+  bool ShouldTraceResidualLedger() const;
+  bool ShouldTraceParameterSnapshots() const;
+  void ResetResidualLedger();
+  void RecordScaleObservation(size_t scale_index,
+                              point3D_t point3D_id,
+                              const TrackElement& observation,
+                              bool is_lc_observation);
+  void RecordResidualBlock(const ResidualLedgerEntry& entry);
+  void RecordResidualSkip(const ResidualLedgerEntry& entry,
+                          const std::string& skip_reason);
+  void RecordResidualBucketSummaries();
+
+  GlobalPositioningTraceRecorder* trace_recorder_ = nullptr;
+  std::map<std::string, uint64_t> residual_bucket_counts_;
+  std::vector<ScaleObservationMetadata> scale_observations_;
 };
 
 // Solve global positioning using point-to-camera constraints.

--- a/src/colmap/estimators/global_positioning_residual_evaluation.cc
+++ b/src/colmap/estimators/global_positioning_residual_evaluation.cc
@@ -1,0 +1,215 @@
+#include "colmap/estimators/global_positioning_residual_evaluation.h"
+
+#include "colmap/util/misc.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+namespace colmap {
+
+GlobalPositioningTraceResidualValues EvaluateGlobalPositioningResiduals(
+    const GlobalPositioningResidualEvaluationOptions& options) {
+  GlobalPositioningTraceResidualValues residual_values;
+  residual_values.iteration = options.iteration;
+  residual_values.residual_ids.reserve(options.replay_entries.size());
+  residual_values.residual_dims.reserve(options.replay_entries.size());
+  residual_values.residual_offsets.reserve(options.replay_entries.size());
+  residual_values.evaluation_success.resize(options.replay_entries.size(),
+                                            false);
+  residual_values.raw_costs.resize(options.replay_entries.size(),
+                                   std::numeric_limits<double>::quiet_NaN());
+  residual_values.robust_costs.resize(options.replay_entries.size(),
+                                      std::numeric_limits<double>::quiet_NaN());
+  residual_values.loss_rho_values.resize(
+      options.replay_entries.size() * 3,
+      std::numeric_limits<double>::quiet_NaN());
+  residual_values.has_raw_jacobians = options.write_raw_jacobians;
+  if (options.write_raw_jacobians) {
+    residual_values.parameter_block_sizes.reserve(
+        options.replay_entries.size());
+    residual_values.raw_jacobian_offsets.reserve(options.replay_entries.size());
+    residual_values.parameter_blocks.reserve(options.replay_entries.size());
+    residual_values.parameter_block_is_constant.reserve(
+        options.replay_entries.size());
+    residual_values.parameter_block_lower_bounds.reserve(
+        options.replay_entries.size());
+  }
+
+  size_t total_scalar_residuals = 0;
+  size_t total_jacobian_scalars = 0;
+  for (const GlobalPositioningResidualReplayEntry& entry :
+       options.replay_entries) {
+    THROW_CHECK(!entry.residual_id.empty())
+        << "Residual replay entry has an empty residual id.";
+    THROW_CHECK(entry.cost_function != nullptr)
+        << "Residual replay entry " << entry.residual_id
+        << " has a null cost function.";
+    THROW_CHECK_EQ(entry.residual_dimension,
+                   static_cast<size_t>(entry.cost_function->num_residuals()))
+        << "Residual replay entry " << entry.residual_id
+        << " residual dimension does not match the Ceres cost function.";
+    const std::vector<int>& cost_function_parameter_block_sizes =
+        entry.cost_function->parameter_block_sizes();
+    THROW_CHECK_EQ(entry.parameter_block_sizes.size(),
+                   cost_function_parameter_block_sizes.size())
+        << "Residual replay entry " << entry.residual_id
+        << " parameter-block size count does not match the Ceres cost "
+           "function.";
+    THROW_CHECK_EQ(entry.parameter_blocks.size(),
+                   entry.parameter_block_sizes.size())
+        << "Residual replay entry " << entry.residual_id
+        << " parameter-block pointer count does not match the stored block "
+           "sizes.";
+    THROW_CHECK_EQ(entry.parameter_block_descriptors.size(),
+                   entry.parameter_block_sizes.size())
+        << "Residual replay entry " << entry.residual_id
+        << " parameter-block descriptor count does not match the stored block "
+           "sizes.";
+    for (size_t block_idx = 0; block_idx < entry.parameter_blocks.size();
+         ++block_idx) {
+      THROW_CHECK(entry.parameter_blocks[block_idx] != nullptr)
+          << "Residual replay entry " << entry.residual_id
+          << " has a null parameter block pointer at index " << block_idx
+          << ".";
+      THROW_CHECK_EQ(entry.parameter_block_sizes[block_idx],
+                     cost_function_parameter_block_sizes[block_idx])
+          << "Residual replay entry " << entry.residual_id
+          << " parameter block size at index " << block_idx
+          << " does not match the Ceres cost function.";
+      THROW_CHECK_GT(entry.parameter_block_sizes[block_idx], 0)
+          << "Residual replay entry " << entry.residual_id
+          << " parameter block size at index " << block_idx
+          << " must be positive.";
+      THROW_CHECK(!entry.parameter_block_descriptors[block_idx].role.empty())
+          << "Residual replay entry " << entry.residual_id
+          << " parameter block descriptor at index " << block_idx
+          << " has an empty role.";
+      THROW_CHECK(!entry.parameter_block_descriptors[block_idx].kind.empty())
+          << "Residual replay entry " << entry.residual_id
+          << " parameter block descriptor at index " << block_idx
+          << " has an empty kind.";
+    }
+
+    residual_values.residual_ids.push_back(entry.residual_id);
+    residual_values.residual_dims.push_back(entry.residual_dimension);
+    residual_values.residual_offsets.push_back(total_scalar_residuals);
+    total_scalar_residuals += entry.residual_dimension;
+    if (options.write_raw_jacobians) {
+      std::vector<size_t> parameter_block_sizes;
+      std::vector<size_t> raw_jacobian_offsets;
+      std::vector<bool> parameter_block_is_constant;
+      std::vector<std::vector<double>> parameter_block_lower_bounds;
+      parameter_block_sizes.reserve(entry.parameter_block_sizes.size());
+      raw_jacobian_offsets.reserve(entry.parameter_block_sizes.size());
+      parameter_block_is_constant.reserve(entry.parameter_block_sizes.size());
+      parameter_block_lower_bounds.reserve(entry.parameter_block_sizes.size());
+      for (size_t block_idx = 0; block_idx < entry.parameter_block_sizes.size();
+           ++block_idx) {
+        const int parameter_block_size = entry.parameter_block_sizes[block_idx];
+        parameter_block_sizes.push_back(
+            static_cast<size_t>(parameter_block_size));
+        raw_jacobian_offsets.push_back(total_jacobian_scalars);
+        parameter_block_is_constant.push_back(
+            options.problem.IsParameterBlockConstant(
+                entry.parameter_blocks[block_idx]));
+        std::vector<double> lower_bounds;
+        lower_bounds.reserve(static_cast<size_t>(parameter_block_size));
+        for (int parameter_idx = 0; parameter_idx < parameter_block_size;
+             ++parameter_idx) {
+          lower_bounds.push_back(options.problem.GetParameterLowerBound(
+              entry.parameter_blocks[block_idx], parameter_idx));
+        }
+        parameter_block_lower_bounds.push_back(std::move(lower_bounds));
+        total_jacobian_scalars += entry.residual_dimension *
+                                  static_cast<size_t>(parameter_block_size);
+      }
+      residual_values.parameter_block_sizes.push_back(
+          std::move(parameter_block_sizes));
+      residual_values.raw_jacobian_offsets.push_back(
+          std::move(raw_jacobian_offsets));
+      residual_values.parameter_blocks.push_back(
+          entry.parameter_block_descriptors);
+      residual_values.parameter_block_is_constant.push_back(
+          std::move(parameter_block_is_constant));
+      residual_values.parameter_block_lower_bounds.push_back(
+          std::move(parameter_block_lower_bounds));
+    }
+  }
+  residual_values.raw_residuals.resize(
+      total_scalar_residuals, std::numeric_limits<double>::quiet_NaN());
+  if (options.write_raw_jacobians) {
+    residual_values.raw_jacobians.resize(
+        total_jacobian_scalars, std::numeric_limits<double>::quiet_NaN());
+  }
+
+  for (size_t entry_idx = 0; entry_idx < options.replay_entries.size();
+       ++entry_idx) {
+    const GlobalPositioningResidualReplayEntry& entry =
+        options.replay_entries[entry_idx];
+    std::vector<double> raw_jacobian_workspace;
+    std::vector<double*> raw_jacobian_blocks;
+    if (options.write_raw_jacobians) {
+      size_t workspace_offset = 0;
+      for (const int parameter_block_size : entry.parameter_block_sizes) {
+        workspace_offset += entry.residual_dimension *
+                            static_cast<size_t>(parameter_block_size);
+      }
+      raw_jacobian_workspace.assign(workspace_offset,
+                                    std::numeric_limits<double>::quiet_NaN());
+      raw_jacobian_blocks.reserve(entry.parameter_block_sizes.size());
+      workspace_offset = 0;
+      for (const int parameter_block_size : entry.parameter_block_sizes) {
+        raw_jacobian_blocks.push_back(raw_jacobian_workspace.data() +
+                                      workspace_offset);
+        workspace_offset += entry.residual_dimension *
+                            static_cast<size_t>(parameter_block_size);
+      }
+    }
+
+    double* raw_residuals = residual_values.raw_residuals.data() +
+                            residual_values.residual_offsets[entry_idx];
+    const bool evaluation_success = entry.cost_function->Evaluate(
+        entry.parameter_blocks.data(),
+        raw_residuals,
+        options.write_raw_jacobians ? raw_jacobian_blocks.data() : nullptr);
+    residual_values.evaluation_success[entry_idx] = evaluation_success;
+    if (!evaluation_success) {
+      continue;
+    }
+    if (options.write_raw_jacobians) {
+      for (size_t block_idx = 0; block_idx < entry.parameter_block_sizes.size();
+           ++block_idx) {
+        const size_t jacobian_size =
+            entry.residual_dimension *
+            static_cast<size_t>(entry.parameter_block_sizes[block_idx]);
+        std::copy_n(
+            raw_jacobian_blocks[block_idx],
+            jacobian_size,
+            residual_values.raw_jacobians.data() +
+                residual_values.raw_jacobian_offsets[entry_idx][block_idx]);
+      }
+    }
+
+    double squared_norm = 0.0;
+    for (size_t residual_idx = 0; residual_idx < entry.residual_dimension;
+         ++residual_idx) {
+      squared_norm += raw_residuals[residual_idx] * raw_residuals[residual_idx];
+    }
+
+    const double raw_cost = 0.5 * squared_norm;
+    residual_values.raw_costs[entry_idx] = raw_cost;
+    double rho[3] = {squared_norm, 1.0, 0.0};
+    if (entry.loss_function != nullptr) {
+      entry.loss_function->Evaluate(squared_norm, rho);
+    }
+    residual_values.loss_rho_values[3 * entry_idx] = rho[0];
+    residual_values.loss_rho_values[3 * entry_idx + 1] = rho[1];
+    residual_values.loss_rho_values[3 * entry_idx + 2] = rho[2];
+    residual_values.robust_costs[entry_idx] = 0.5 * rho[0];
+  }
+
+  return residual_values;
+}
+
+}  // namespace colmap

--- a/src/colmap/estimators/global_positioning_residual_evaluation.h
+++ b/src/colmap/estimators/global_positioning_residual_evaluation.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "colmap/estimators/global_positioning_trace.h"
+#include "colmap/estimators/global_positioning_tracer.h"
+
+#include <vector>
+
+#include <ceres/ceres.h>
+
+namespace colmap {
+
+struct GlobalPositioningResidualEvaluationOptions {
+  const ceres::Problem& problem;
+  int iteration = 0;
+  const std::vector<GlobalPositioningResidualReplayEntry>& replay_entries;
+  bool write_raw_jacobians = false;
+};
+
+GlobalPositioningTraceResidualValues EvaluateGlobalPositioningResiduals(
+    const GlobalPositioningResidualEvaluationOptions& options);
+
+}  // namespace colmap

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -1058,12 +1058,15 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
       residual_values_dir / "iter_000000_raw_costs_f64.bin";
   const std::filesystem::path robust_costs_path =
       residual_values_dir / "iter_000000_robust_costs_f64.bin";
+  const std::filesystem::path loss_rho_values_path =
+      residual_values_dir / "iter_000000_loss_rho_values_f64.bin";
   const std::filesystem::path raw_jacobians_path =
       residual_values_dir / "iter_000000_raw_jacobians_f64.bin";
   ASSERT_TRUE(ExistsFile(metadata_path));
   ASSERT_TRUE(ExistsFile(raw_residuals_path));
   ASSERT_TRUE(ExistsFile(raw_costs_path));
   ASSERT_TRUE(ExistsFile(robust_costs_path));
+  ASSERT_TRUE(ExistsFile(loss_rho_values_path));
   ASSERT_FALSE(ExistsFile(raw_jacobians_path));
 
   const std::string manifest = ReadFileForTest(trace_dir / "manifest.json");
@@ -1078,6 +1081,7 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
                           "\"residual_dims\"",
                           "\"residual_offsets\"",
                           "\"evaluation_success\"",
+                          "\"loss_rho_layout\"",
                           "\"artifacts\""}) {
     EXPECT_NE(metadata.find(key), std::string::npos)
         << "Missing residual-values metadata key: " << key;
@@ -1086,6 +1090,12 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
             std::string::npos);
   EXPECT_NE(metadata.find("iter_000000_raw_costs_f64.bin"), std::string::npos);
   EXPECT_NE(metadata.find("iter_000000_robust_costs_f64.bin"),
+            std::string::npos);
+  EXPECT_NE(metadata.find("iter_000000_loss_rho_values_f64.bin"),
+            std::string::npos);
+  EXPECT_NE(metadata.find("\"loss_rho_values\": {"), std::string::npos);
+  EXPECT_NE(metadata.find("\"shape\": ["), std::string::npos);
+  EXPECT_NE(metadata.find("\"residual_block_major/rho0_rho1_rho2\""),
             std::string::npos);
   EXPECT_NE(metadata.find("\"has_raw_jacobians\": false"), std::string::npos);
   EXPECT_EQ(metadata.find("\"raw_jacobians\": {"), std::string::npos);
@@ -1153,6 +1163,9 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
             static_cast<uintmax_t>(*num_residual_blocks) * sizeof(double));
   EXPECT_EQ(std::filesystem::file_size(robust_costs_path),
             static_cast<uintmax_t>(*num_residual_blocks) * sizeof(double));
+  EXPECT_EQ(std::filesystem::file_size(loss_rho_values_path),
+            static_cast<uintmax_t>(*num_residual_blocks) * 3u *
+                sizeof(double));
 
   const std::vector<double> raw_residuals = ReadDoubleSidecarForTest(
       raw_residuals_path, static_cast<size_t>(*total_scalar_residuals));
@@ -1160,6 +1173,9 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
       raw_costs_path, static_cast<size_t>(*num_residual_blocks));
   const std::vector<double> robust_costs = ReadDoubleSidecarForTest(
       robust_costs_path, static_cast<size_t>(*num_residual_blocks));
+  const std::vector<double> loss_rho_values =
+      ReadDoubleSidecarForTest(loss_rho_values_path,
+                               static_cast<size_t>(*num_residual_blocks) * 3u);
 
   size_t expected_offset = 0;
   double robust_cost_sum = 0.0;
@@ -1175,7 +1191,12 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
     }
     ASSERT_TRUE(std::isfinite(raw_costs[i]));
     ASSERT_TRUE(std::isfinite(robust_costs[i]));
+    ASSERT_TRUE(std::isfinite(loss_rho_values[3 * i]));
+    ASSERT_TRUE(std::isfinite(loss_rho_values[3 * i + 1]));
+    ASSERT_TRUE(std::isfinite(loss_rho_values[3 * i + 2]));
     EXPECT_NEAR(raw_costs[i], 0.5 * squared_norm, 1e-12)
+        << metadata_residual_ids[i];
+    EXPECT_NEAR(robust_costs[i], 0.5 * loss_rho_values[3 * i], 1e-12)
         << metadata_residual_ids[i];
 
     robust_cost_sum += robust_costs[i];

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -467,8 +467,25 @@ uint64_t ReadRawLedgerRecordCountForTest(const std::filesystem::path& path) {
   THROW_CHECK_FILE_OPEN(file, path);
   EXPECT_EQ(ReadBinaryPrefixForTest(path, 8), "GPTRLGR1");
   file.seekg(8, std::ios::beg);
-  EXPECT_EQ(ReadRawLittleEndianForTest<uint32_t>(file, path), 1);
+  EXPECT_EQ(ReadRawLittleEndianForTest<uint32_t>(file, path), 2);
   return ReadRawLittleEndianForTest<uint64_t>(file, path);
+}
+
+std::tuple<uint32_t, uint64_t, uint64_t> ReadRawPointIndexIdentityForTest(
+    const std::filesystem::path& path) {
+  std::ifstream file(path, std::ios::binary);
+  THROW_CHECK_FILE_OPEN(file, path);
+  EXPECT_EQ(ReadBinaryPrefixForTest(path, 8), "GPTRIDX1");
+  file.seekg(8, std::ios::beg);
+  EXPECT_EQ(ReadRawLittleEndianForTest<uint32_t>(file, path), 2);
+  EXPECT_GT(ReadRawLittleEndianForTest<uint64_t>(file, path), uint64_t{0});
+  const uint32_t ledger_version =
+      ReadRawLittleEndianForTest<uint32_t>(file, path);
+  const uint64_t ledger_count =
+      ReadRawLittleEndianForTest<uint64_t>(file, path);
+  const uint64_t ledger_size =
+      ReadRawLittleEndianForTest<uint64_t>(file, path);
+  return {ledger_version, ledger_count, ledger_size};
 }
 
 std::pair<uint64_t, uint64_t> ReadRawArrayHeaderForTest(
@@ -1118,7 +1135,6 @@ TEST(GlobalPositioning, ParameterSnapshotsTraceWritesMetadataAndSidecars) {
   options.trace.level = GlobalPositioningTraceLevel::kParameterSnapshots;
   options.trace.output_path = trace_dir;
   options.trace.snapshot_every_n_iterations = 1;
-  options.trace.max_snapshotted_points = 2;
 
   TestableGlobalPositioner positioner(options);
   ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
@@ -1161,7 +1177,8 @@ TEST(GlobalPositioning, ParameterSnapshotsTraceWritesMetadataAndSidecars) {
             positioner.NumFrameCenters() * 3 * sizeof(double));
 
   const uintmax_t points3D_size = std::filesystem::file_size(points3D_path);
-  EXPECT_LE(points3D_size, 2u * 3u * sizeof(double));
+  EXPECT_EQ(points3D_size,
+            data.reconstruction.NumPoints3D() * 3u * sizeof(double));
   EXPECT_EQ(points3D_size % (3u * sizeof(double)), 0u);
 
   const uintmax_t scales_size = std::filesystem::file_size(scales_path);
@@ -1223,7 +1240,6 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
   options.trace.level = GlobalPositioningTraceLevel::kResidualValues;
   options.trace.output_path = trace_dir;
   options.trace.snapshot_every_n_iterations = 1;
-  options.trace.max_snapshotted_points = -1;
 
   TestableGlobalPositioner positioner(options);
   ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
@@ -1434,7 +1450,6 @@ TEST(GlobalPositioning, ResidualJacobiansTraceWritesMetadataAndSidecars) {
   options.trace.level = GlobalPositioningTraceLevel::kResidualJacobians;
   options.trace.output_path = trace_dir;
   options.trace.snapshot_every_n_iterations = 1;
-  options.trace.max_snapshotted_points = -1;
 
   TestableGlobalPositioner positioner(options);
   ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
@@ -1581,7 +1596,6 @@ TEST(GlobalPositioning, LowerTraceLevelsDoNotCreateResidualValues) {
     options.trace.level = level;
     options.trace.output_path = trace_dir;
     options.trace.snapshot_every_n_iterations = 1;
-    options.trace.max_snapshotted_points = 2;
 
     TestableGlobalPositioner positioner(options);
     ASSERT_TRUE(positioner.Solve(data.pose_graph, reconstruction))
@@ -1785,6 +1799,42 @@ TEST(GlobalPositioning, ResidualLedgerTraceWritesBlocksAndMatchesProblemBuilt) {
   ASSERT_TRUE(expected_num_residual_blocks.has_value());
   EXPECT_EQ(CountJsonlRecordsForTest(residual_blocks),
             static_cast<size_t>(*expected_num_residual_blocks));
+}
+
+TEST(GlobalPositioning, ResidualLedgerTraceCanDisableLegacyJsonlBlocks) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  const std::filesystem::path trace_dir = CreateTestDir() / "gp_trace";
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.trace.level = GlobalPositioningTraceLevel::kResidualLedger;
+  options.trace.output_path = trace_dir;
+  options.trace.write_legacy_jsonl = false;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  EXPECT_FALSE(ExistsFile(trace_dir / "residual_blocks.jsonl"));
+  EXPECT_FALSE(ExistsFile(trace_dir / "residual_skips.jsonl"));
+  const std::filesystem::path raw_binary_dir = trace_dir / "raw_binary";
+  ASSERT_TRUE(ExistsFile(raw_binary_dir / "manifest.json"));
+  const std::filesystem::path raw_ledger_path =
+      raw_binary_dir / "static" / "residual_ledger.bin";
+  const std::filesystem::path raw_point_index_path =
+      raw_binary_dir / "static" / "residual_point_index.bin";
+  ASSERT_TRUE(ExistsFile(raw_ledger_path));
+  ASSERT_TRUE(
+      ExistsFile(raw_point_index_path));
+  const uint64_t ledger_count = ReadRawLedgerRecordCountForTest(raw_ledger_path);
+  EXPECT_GT(ledger_count, uint64_t{0});
+  const auto [indexed_ledger_version, indexed_ledger_count, indexed_ledger_size] =
+      ReadRawPointIndexIdentityForTest(raw_point_index_path);
+  EXPECT_EQ(indexed_ledger_version, uint32_t{2});
+  EXPECT_EQ(indexed_ledger_count, ledger_count);
+  EXPECT_EQ(indexed_ledger_size, std::filesystem::file_size(raw_ledger_path));
+  const std::string manifest =
+      ReadFileForTest(raw_binary_dir / "manifest.json");
+  EXPECT_NE(manifest.find("\"write_legacy_jsonl\": false"), std::string::npos);
 }
 
 TEST(GlobalPositioning, ResidualLedgerTraceWritesReplayDescriptorsAndLoss) {

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -47,6 +47,7 @@
 #include <limits>
 #include <optional>
 #include <sstream>
+#include <tuple>
 
 #include <ceres/loss_function.h>
 #include <gtest/gtest.h>
@@ -429,6 +430,97 @@ std::string ReadFileForTest(const std::filesystem::path& path) {
                      std::istreambuf_iterator<char>());
 }
 
+std::string ReadBinaryPrefixForTest(const std::filesystem::path& path,
+                                    const size_t size) {
+  std::ifstream file(path, std::ios::binary);
+  THROW_CHECK_FILE_OPEN(file, path);
+  std::string prefix(size, '\0');
+  file.read(prefix.data(), static_cast<std::streamsize>(size));
+  THROW_CHECK_EQ(static_cast<size_t>(file.gcount()), size)
+      << "Could not read binary prefix from " << path;
+  return prefix;
+}
+
+template <typename T>
+T ReadRawLittleEndianForTest(std::ifstream& file,
+                             const std::filesystem::path& path) {
+  const T value = ReadBinaryLittleEndian<T>(&file);
+  THROW_CHECK(file.good()) << "Could not read raw binary trace value from "
+                           << path;
+  return value;
+}
+
+std::string ReadRawStringForTest(std::ifstream& file,
+                                 const std::filesystem::path& path) {
+  const uint32_t size = ReadRawLittleEndianForTest<uint32_t>(file, path);
+  std::string value(size, '\0');
+  if (size > 0) {
+    file.read(value.data(), static_cast<std::streamsize>(size));
+    THROW_CHECK(file.good())
+        << "Could not read raw binary trace string from " << path;
+  }
+  return value;
+}
+
+uint64_t ReadRawLedgerRecordCountForTest(const std::filesystem::path& path) {
+  std::ifstream file(path, std::ios::binary);
+  THROW_CHECK_FILE_OPEN(file, path);
+  EXPECT_EQ(ReadBinaryPrefixForTest(path, 8), "GPTRLGR1");
+  file.seekg(8, std::ios::beg);
+  EXPECT_EQ(ReadRawLittleEndianForTest<uint32_t>(file, path), 1);
+  return ReadRawLittleEndianForTest<uint64_t>(file, path);
+}
+
+std::pair<uint64_t, uint64_t> ReadRawArrayHeaderForTest(
+    const std::filesystem::path& path, const std::string& expected_name) {
+  std::ifstream file(path, std::ios::binary);
+  THROW_CHECK_FILE_OPEN(file, path);
+  EXPECT_EQ(ReadBinaryPrefixForTest(path, 8), "GPTRARR1");
+  file.seekg(8, std::ios::beg);
+  EXPECT_EQ(ReadRawLittleEndianForTest<uint32_t>(file, path), 1);
+  const uint64_t rows = ReadRawLittleEndianForTest<uint64_t>(file, path);
+  const uint64_t cols = ReadRawLittleEndianForTest<uint64_t>(file, path);
+  EXPECT_EQ(ReadRawStringForTest(file, path), expected_name);
+  return {rows, cols};
+}
+
+std::tuple<uint32_t, int64_t, uint64_t, uint64_t, bool>
+ReadRawResidualValuesHeaderForTest(const std::filesystem::path& path,
+                                   const bool expect_raw_jacobians) {
+  std::ifstream file(path, std::ios::binary);
+  THROW_CHECK_FILE_OPEN(file, path);
+  EXPECT_EQ(ReadBinaryPrefixForTest(path, 8), "GPTRRSV1");
+  file.seekg(8, std::ios::beg);
+  const uint32_t version = ReadRawLittleEndianForTest<uint32_t>(file, path);
+  EXPECT_TRUE(version == 1 || version == 2);
+  const int64_t iteration = ReadRawLittleEndianForTest<int64_t>(file, path);
+  const uint64_t num_residual_blocks =
+      ReadRawLittleEndianForTest<uint64_t>(file, path);
+  const uint64_t total_scalar_residuals =
+      ReadRawLittleEndianForTest<uint64_t>(file, path);
+  char has_loss_rho = 0;
+  file.read(&has_loss_rho, 1);
+  THROW_CHECK(file.good())
+      << "Could not read raw binary residual-values loss-rho flag from "
+      << path;
+  EXPECT_EQ(has_loss_rho, 1);
+  bool has_raw_jacobians = false;
+  if (version >= 2) {
+    char has_raw_jacobians_byte = 0;
+    file.read(&has_raw_jacobians_byte, 1);
+    THROW_CHECK(file.good())
+        << "Could not read raw binary residual-values Jacobian flag from "
+        << path;
+    has_raw_jacobians = has_raw_jacobians_byte != 0;
+  }
+  EXPECT_EQ(has_raw_jacobians, expect_raw_jacobians);
+  return {version,
+          iteration,
+          num_residual_blocks,
+          total_scalar_residuals,
+          has_raw_jacobians};
+}
+
 size_t CountJsonlRecordsForTest(const std::string& text) {
   size_t count = 0;
   std::istringstream stream(text);
@@ -459,6 +551,55 @@ bool ContainsJsonStringValueForTest(const std::string& text,
     pos += key_token.size();
   }
   return false;
+}
+
+std::optional<std::string> FindJsonlRecordWithStringValueForTest(
+    const std::string& text, const std::string& key, const std::string& value) {
+  std::istringstream stream(text);
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (ContainsJsonStringValueForTest(line, key, value)) {
+      return line;
+    }
+  }
+  return std::nullopt;
+}
+
+void ExpectEveryResidualBlockHasReplayLedgerFieldsForTest(
+    const std::string& residual_blocks) {
+  std::istringstream stream(residual_blocks);
+  std::string line;
+  size_t count = 0;
+  while (std::getline(stream, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    ++count;
+    EXPECT_NE(line.find("\"replay_schema_version\":1"), std::string::npos)
+        << line;
+    EXPECT_NE(line.find("\"parameter_blocks\":[{"), std::string::npos) << line;
+    EXPECT_NE(line.find("\"role\":"), std::string::npos) << line;
+    EXPECT_NE(line.find("\"kind\":"), std::string::npos) << line;
+    EXPECT_NE(line.find("\"id\":"), std::string::npos) << line;
+    EXPECT_NE(line.find("\"size\":"), std::string::npos) << line;
+    EXPECT_NE(line.find("\"loss\":{\"bucket\":"), std::string::npos) << line;
+    EXPECT_NE(line.find("\"type\":"), std::string::npos) << line;
+    EXPECT_NE(line.find("\"scale\":"), std::string::npos) << line;
+    EXPECT_NE(line.find("\"weight\":"), std::string::npos) << line;
+    EXPECT_NE(line.find("\"fixed_parameters_status\":\"serialized\""),
+              std::string::npos)
+        << line;
+    EXPECT_NE(line.find("\"fixed_parameters\":{"), std::string::npos) << line;
+    EXPECT_EQ(line.find("\"fixed_parameters_status\":"
+                        "\"deferred_not_serialized\""),
+              std::string::npos)
+        << line;
+    EXPECT_EQ(line.find("\"fixed_parameters_missing\":["), std::string::npos)
+        << line;
+    EXPECT_EQ(line.find("\"fixed_parameters_todo\":"), std::string::npos)
+        << line;
+  }
+  EXPECT_GT(count, 0u);
 }
 
 std::optional<int64_t> FindEventAttrIntForTest(const std::string& events,
@@ -1026,6 +1167,48 @@ TEST(GlobalPositioning, ParameterSnapshotsTraceWritesMetadataAndSidecars) {
   const uintmax_t scales_size = std::filesystem::file_size(scales_path);
   EXPECT_GT(scales_size, 0u);
   EXPECT_EQ(scales_size % sizeof(double), 0u);
+
+  const std::filesystem::path raw_binary_dir = trace_dir / "raw_binary";
+  ASSERT_TRUE(ExistsFile(raw_binary_dir / "manifest.json"));
+  ASSERT_TRUE(ExistsFile(raw_binary_dir / "static" / "residual_ledger.bin"));
+  ASSERT_TRUE(ExistsFile(raw_binary_dir / "iterations" / "iter_000000" /
+                         "frame_centers.bin"));
+  ASSERT_TRUE(ExistsFile(raw_binary_dir / "iterations" / "iter_000000" /
+                         "point_xyz.bin"));
+  ASSERT_TRUE(
+      ExistsFile(raw_binary_dir / "iterations" / "iter_000000" / "scales.bin"));
+  EXPECT_EQ(ReadRawLedgerRecordCountForTest(raw_binary_dir / "static" /
+                                            "residual_ledger.bin"),
+            CountJsonlRecordsForTest(
+                ReadFileForTest(trace_dir / "residual_blocks.jsonl")));
+  EXPECT_EQ(ReadRawArrayHeaderForTest(raw_binary_dir / "iterations" /
+                                          "iter_000000" / "frame_centers.bin",
+                                      "frame_centers"),
+            std::make_pair(static_cast<uint64_t>(positioner.NumFrameCenters()),
+                           uint64_t{3}));
+  EXPECT_EQ(ReadRawArrayHeaderForTest(
+                raw_binary_dir / "iterations" / "iter_000000" / "point_xyz.bin",
+                "point_xyz")
+                .second,
+            uint64_t{3});
+  EXPECT_GT(ReadRawArrayHeaderForTest(
+                raw_binary_dir / "iterations" / "iter_000000" / "scales.bin",
+                "scales")
+                .first,
+            uint64_t{0});
+
+  const std::string raw_manifest =
+      ReadFileForTest(raw_binary_dir / "manifest.json");
+  EXPECT_NE(raw_manifest.find("\"storage_format\": "
+                              "\"global_positioning_raw_binary_v1\""),
+            std::string::npos);
+  EXPECT_NE(raw_manifest.find("\"residual_ledger\": "
+                              "\"static/residual_ledger.bin\""),
+            std::string::npos);
+  EXPECT_NE(raw_manifest.find("\"frame_centers\": \"frame_centers.bin\""),
+            std::string::npos);
+  EXPECT_NE(raw_manifest.find("\"point_xyz\": \"point_xyz.bin\""),
+            std::string::npos);
 }
 
 TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
@@ -1040,7 +1223,7 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
   options.trace.level = GlobalPositioningTraceLevel::kResidualValues;
   options.trace.output_path = trace_dir;
   options.trace.snapshot_every_n_iterations = 1;
-  options.trace.max_snapshotted_points = 2;
+  options.trace.max_snapshotted_points = -1;
 
   TestableGlobalPositioner positioner(options);
   ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
@@ -1164,8 +1347,30 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
   EXPECT_EQ(std::filesystem::file_size(robust_costs_path),
             static_cast<uintmax_t>(*num_residual_blocks) * sizeof(double));
   EXPECT_EQ(std::filesystem::file_size(loss_rho_values_path),
-            static_cast<uintmax_t>(*num_residual_blocks) * 3u *
-                sizeof(double));
+            static_cast<uintmax_t>(*num_residual_blocks) * 3u * sizeof(double));
+
+  const std::filesystem::path raw_binary_dir = trace_dir / "raw_binary";
+  ASSERT_TRUE(ExistsFile(raw_binary_dir / "manifest.json"));
+  ASSERT_TRUE(ExistsFile(raw_binary_dir / "static" / "residual_ledger.bin"));
+  ASSERT_TRUE(ExistsFile(raw_binary_dir / "iterations" / "iter_000000" /
+                         "residual_values.bin"));
+  EXPECT_EQ(ReadRawLedgerRecordCountForTest(raw_binary_dir / "static" /
+                                            "residual_ledger.bin"),
+            static_cast<uint64_t>(*num_residual_blocks));
+  EXPECT_EQ(
+      ReadRawResidualValuesHeaderForTest(
+          raw_binary_dir / "iterations" / "iter_000000" / "residual_values.bin",
+          /*expect_raw_jacobians=*/false),
+      std::make_tuple(uint32_t{1},
+                      int64_t{0},
+                      static_cast<uint64_t>(*num_residual_blocks),
+                      static_cast<uint64_t>(*total_scalar_residuals),
+                      false));
+  const std::string raw_manifest =
+      ReadFileForTest(raw_binary_dir / "manifest.json");
+  EXPECT_NE(raw_manifest.find("\"residual_values\": "
+                              "\"residual_values.bin\""),
+            std::string::npos);
 
   const std::vector<double> raw_residuals = ReadDoubleSidecarForTest(
       raw_residuals_path, static_cast<size_t>(*total_scalar_residuals));
@@ -1173,9 +1378,8 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
       raw_costs_path, static_cast<size_t>(*num_residual_blocks));
   const std::vector<double> robust_costs = ReadDoubleSidecarForTest(
       robust_costs_path, static_cast<size_t>(*num_residual_blocks));
-  const std::vector<double> loss_rho_values =
-      ReadDoubleSidecarForTest(loss_rho_values_path,
-                               static_cast<size_t>(*num_residual_blocks) * 3u);
+  const std::vector<double> loss_rho_values = ReadDoubleSidecarForTest(
+      loss_rho_values_path, static_cast<size_t>(*num_residual_blocks) * 3u);
 
   size_t expected_offset = 0;
   double robust_cost_sum = 0.0;
@@ -1230,7 +1434,7 @@ TEST(GlobalPositioning, ResidualJacobiansTraceWritesMetadataAndSidecars) {
   options.trace.level = GlobalPositioningTraceLevel::kResidualJacobians;
   options.trace.output_path = trace_dir;
   options.trace.snapshot_every_n_iterations = 1;
-  options.trace.max_snapshotted_points = 2;
+  options.trace.max_snapshotted_points = -1;
 
   TestableGlobalPositioner positioner(options);
   ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
@@ -1291,11 +1495,15 @@ TEST(GlobalPositioning, ResidualJacobiansTraceWritesMetadataAndSidecars) {
 
   const std::optional<int64_t> num_residual_blocks =
       FindJsonIntForTest(metadata, "num_residual_blocks");
+  const std::optional<int64_t> total_scalar_residuals =
+      FindJsonIntForTest(metadata, "total_scalar_residuals");
   const std::optional<int64_t> total_jacobian_scalars =
       FindJsonIntForTest(metadata, "total_jacobian_scalars");
   ASSERT_TRUE(num_residual_blocks.has_value());
+  ASSERT_TRUE(total_scalar_residuals.has_value());
   ASSERT_TRUE(total_jacobian_scalars.has_value());
   ASSERT_GT(*num_residual_blocks, 0);
+  ASSERT_GT(*total_scalar_residuals, 0);
   ASSERT_GT(*total_jacobian_scalars, 0);
 
   std::vector<size_t> expected_parameter_block_sizes;
@@ -1322,6 +1530,18 @@ TEST(GlobalPositioning, ResidualJacobiansTraceWritesMetadataAndSidecars) {
             expected_raw_jacobian_offsets);
   EXPECT_EQ(std::filesystem::file_size(raw_jacobians_path),
             static_cast<uintmax_t>(*total_jacobian_scalars) * sizeof(double));
+
+  const std::filesystem::path raw_binary_residual_values_path =
+      trace_dir / "raw_binary" / "iterations" / "iter_000000" /
+      "residual_values.bin";
+  ASSERT_TRUE(ExistsFile(raw_binary_residual_values_path));
+  EXPECT_EQ(ReadRawResidualValuesHeaderForTest(raw_binary_residual_values_path,
+                                               /*expect_raw_jacobians=*/true),
+            std::make_tuple(uint32_t{2},
+                            int64_t{0},
+                            static_cast<uint64_t>(*num_residual_blocks),
+                            static_cast<uint64_t>(*total_scalar_residuals),
+                            true));
 
   const std::vector<bool> evaluation_success =
       FindJsonBoolArrayForTest(metadata, "evaluation_success");
@@ -1551,6 +1771,7 @@ TEST(GlobalPositioning, ResidualLedgerTraceWritesBlocksAndMatchesProblemBuilt) {
   ASSERT_TRUE(ExistsFile(residual_blocks_path));
 
   const std::string residual_blocks = ReadFileForTest(residual_blocks_path);
+  ExpectEveryResidualBlockHasReplayLedgerFieldsForTest(residual_blocks);
   EXPECT_TRUE(ContainsJsonStringValueForTest(
       residual_blocks, "residual_type", "bata_ref_frame"));
   EXPECT_TRUE(ContainsJsonStringValueForTest(
@@ -1564,6 +1785,69 @@ TEST(GlobalPositioning, ResidualLedgerTraceWritesBlocksAndMatchesProblemBuilt) {
   ASSERT_TRUE(expected_num_residual_blocks.has_value());
   EXPECT_EQ(CountJsonlRecordsForTest(residual_blocks),
             static_cast<size_t>(*expected_num_residual_blocks));
+}
+
+TEST(GlobalPositioning, ResidualLedgerTraceWritesReplayDescriptorsAndLoss) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  StampGtDepthPriors(data.reconstruction);
+
+  const std::filesystem::path trace_dir =
+      CreateTestDir() / "gp_residual_ledger_replay_fields";
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  options.trace.level = GlobalPositioningTraceLevel::kResidualLedger;
+  options.trace.output_path = trace_dir;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  const std::string residual_blocks =
+      ReadFileForTest(trace_dir / "residual_blocks.jsonl");
+  ExpectEveryResidualBlockHasReplayLedgerFieldsForTest(residual_blocks);
+
+  const std::optional<std::string> bata_ref_frame =
+      FindJsonlRecordWithStringValueForTest(
+          residual_blocks, "residual_type", "bata_ref_frame");
+  ASSERT_TRUE(bata_ref_frame.has_value());
+  EXPECT_NE(bata_ref_frame->find("\"role\":\"frame_center\""),
+            std::string::npos);
+  EXPECT_NE(bata_ref_frame->find("\"role\":\"point3D\""), std::string::npos);
+  EXPECT_NE(bata_ref_frame->find("\"role\":\"bata_scale\""), std::string::npos);
+  EXPECT_NE(bata_ref_frame->find("\"loss\":{\"bucket\":\"geometry_"),
+            std::string::npos);
+  EXPECT_NE(bata_ref_frame->find("\"cam_from_point3D_dir\""),
+            std::string::npos);
+
+  const std::optional<std::string> metric_depth =
+      FindJsonlRecordWithStringValueForTest(
+          residual_blocks, "residual_type", "metric_depth");
+  ASSERT_TRUE(metric_depth.has_value());
+  EXPECT_NE(metric_depth->find("\"role\":\"dmap_scale\""), std::string::npos);
+  EXPECT_NE(metric_depth->find("\"loss\":{\"bucket\":\"depth_"),
+            std::string::npos);
+  EXPECT_NE(metric_depth->find("\"camera_rotation_wxyz\""), std::string::npos);
+  EXPECT_NE(metric_depth->find("\"metric_depth_use_log_scale\""),
+            std::string::npos);
+  EXPECT_NE(metric_depth->find("\"metric_depth_residual_type\""),
+            std::string::npos);
+  EXPECT_NE(metric_depth->find("\"metric_depth_zero_residual_behind\""),
+            std::string::npos);
+  EXPECT_NE(metric_depth->find("\"metric_depth_log_linear_threshold\""),
+            std::string::npos);
+
+  const std::optional<std::string> scale_prior =
+      FindJsonlRecordWithStringValueForTest(
+          residual_blocks, "residual_type", "scale_prior");
+  ASSERT_TRUE(scale_prior.has_value());
+  EXPECT_NE(scale_prior->find("\"role\":\"dmap_scale\""), std::string::npos);
+  EXPECT_NE(scale_prior->find("\"loss\":{\"bucket\":\"scale_prior\""),
+            std::string::npos);
+  EXPECT_NE(scale_prior->find("\"observation_count_weight\":"),
+            std::string::npos);
+  EXPECT_NE(scale_prior->find("\"scale_prior_target\""), std::string::npos);
+  EXPECT_NE(scale_prior->find("\"scale_prior_stddev\""), std::string::npos);
 }
 
 TEST(GlobalPositioning, ResidualLedgerTraceCanForceBataConstantRigFamily) {
@@ -1585,8 +1869,13 @@ TEST(GlobalPositioning, ResidualLedgerTraceCanForceBataConstantRigFamily) {
 
   const std::string residual_blocks =
       ReadFileForTest(trace_dir / "residual_blocks.jsonl");
-  EXPECT_TRUE(ContainsJsonStringValueForTest(
-      residual_blocks, "residual_type", "bata_constant_rig"));
+  ExpectEveryResidualBlockHasReplayLedgerFieldsForTest(residual_blocks);
+  const std::optional<std::string> constant_rig =
+      FindJsonlRecordWithStringValueForTest(
+          residual_blocks, "residual_type", "bata_constant_rig");
+  ASSERT_TRUE(constant_rig.has_value());
+  EXPECT_NE(constant_rig->find("\"cam_from_point3D_dir\""), std::string::npos);
+  EXPECT_NE(constant_rig->find("\"cam_from_rig_dir\""), std::string::npos);
 }
 
 TEST(GlobalPositioning, ResidualLedgerTraceCanForceBataVariableRigFamily) {
@@ -1609,8 +1898,16 @@ TEST(GlobalPositioning, ResidualLedgerTraceCanForceBataVariableRigFamily) {
 
   const std::string residual_blocks =
       ReadFileForTest(trace_dir / "residual_blocks.jsonl");
-  EXPECT_TRUE(ContainsJsonStringValueForTest(
-      residual_blocks, "residual_type", "bata_variable_rig"));
+  ExpectEveryResidualBlockHasReplayLedgerFieldsForTest(residual_blocks);
+  const std::optional<std::string> variable_rig =
+      FindJsonlRecordWithStringValueForTest(
+          residual_blocks, "residual_type", "bata_variable_rig");
+  ASSERT_TRUE(variable_rig.has_value());
+  EXPECT_NE(variable_rig->find("\"cam_from_point3D_dir\""), std::string::npos);
+  EXPECT_NE(variable_rig->find("\"rig_from_world_rotation_wxyz\""),
+            std::string::npos);
+  EXPECT_NE(variable_rig->find("\"world_from_rig_rotation_wxyz\""),
+            std::string::npos);
 }
 
 TEST(GlobalPositioning, ResidualLedgerTraceWritesMissingDepthPriorSkip) {

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -336,10 +336,12 @@ class TestableGlobalPositioner : public GlobalPositioner {
   using GlobalPositioner::GlobalPositioner;
   size_t NumScales() const { return scales_.size(); }
   size_t NumFrameCenters() const { return frame_centers_.size(); }
-  size_t NumReplayEntries() const { return residual_replay_entries_.size(); }
+  size_t NumReplayEntries() const {
+    return ResidualReplayEntriesForTest().size();
+  }
   const std::vector<GlobalPositioningResidualReplayEntry>&
   ResidualReplayEntries() const {
-    return residual_replay_entries_;
+    return ResidualReplayEntriesForTest();
   }
   void SetupOnlyForTest(const PoseGraph& pose_graph,
                         Reconstruction& reconstruction) {

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -35,9 +35,15 @@
 #include "colmap/scene/pose_graph.h"
 #include "colmap/scene/reconstruction_matchers.h"
 #include "colmap/scene/synthetic.h"
+#include "colmap/util/file.h"
 #include "colmap/util/testing.h"
 
+#include <cctype>
 #include <cmath>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <sstream>
 
 #include <ceres/loss_function.h>
 #include <gtest/gtest.h>
@@ -384,6 +390,113 @@ GlobalPositionerOptions BaselineGpOptions() {
   return options;
 }
 
+std::string ReadFileForTest(const std::filesystem::path& path) {
+  std::ifstream file(path);
+  THROW_CHECK_FILE_OPEN(file, path);
+  return std::string((std::istreambuf_iterator<char>(file)),
+                     std::istreambuf_iterator<char>());
+}
+
+size_t CountJsonlRecordsForTest(const std::string& text) {
+  size_t count = 0;
+  std::istringstream stream(text);
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (!line.empty()) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+bool ContainsJsonStringValueForTest(const std::string& text,
+                                    const std::string& key,
+                                    const std::string& value) {
+  const std::string key_token = "\"" + key + "\"";
+  const std::string value_token = "\"" + value + "\"";
+  size_t pos = 0;
+  while ((pos = text.find(key_token, pos)) != std::string::npos) {
+    const size_t colon = text.find(':', pos + key_token.size());
+    const size_t line_end = text.find('\n', pos);
+    const size_t search_end =
+        line_end == std::string::npos ? text.size() : line_end;
+    if (colon != std::string::npos && colon < search_end &&
+        text.find(value_token, colon) < search_end) {
+      return true;
+    }
+    pos += key_token.size();
+  }
+  return false;
+}
+
+std::optional<int64_t> FindEventAttrIntForTest(const std::string& events,
+                                               const std::string& event_type,
+                                               const std::string& attr_key) {
+  std::istringstream stream(events);
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (!ContainsJsonStringValueForTest(line, "event_type", event_type)) {
+      continue;
+    }
+    const std::string key_token = "\"" + attr_key + "\"";
+    const size_t key_pos = line.find(key_token);
+    if (key_pos == std::string::npos) {
+      continue;
+    }
+    size_t value_begin = line.find(':', key_pos + key_token.size());
+    if (value_begin == std::string::npos) {
+      continue;
+    }
+    ++value_begin;
+    while (value_begin < line.size() &&
+           std::isspace(static_cast<unsigned char>(line[value_begin]))) {
+      ++value_begin;
+    }
+    size_t value_end = value_begin;
+    if (value_end < line.size() && line[value_end] == '-') {
+      ++value_end;
+    }
+    while (value_end < line.size() &&
+           std::isdigit(static_cast<unsigned char>(line[value_end]))) {
+      ++value_end;
+    }
+    if (value_end > value_begin) {
+      return std::stoll(line.substr(value_begin, value_end - value_begin));
+    }
+  }
+  return std::nullopt;
+}
+
+void ExpectContainsAllSnapshotMetadataKeysForTest(const std::string& metadata) {
+  for (const char* key : {"\"iteration\"",
+                          "\"frame_ids\"",
+                          "\"frame_centers_world_shape\"",
+                          "\"point3D_ids\"",
+                          "\"points3D_world_shape\"",
+                          "\"bata_residual_ids\"",
+                          "\"bata_scales_shape\"",
+                          "\"dmap_image_ids\"",
+                          "\"dmap_scales_stored_shape\"",
+                          "\"coordinate_convention\""}) {
+    EXPECT_NE(metadata.find(key), std::string::npos)
+        << "Missing snapshot metadata key: " << key;
+  }
+}
+
+std::optional<TrackElement> FindFirstValidDepthObservationForTest(
+    const Reconstruction& reconstruction) {
+  for (const auto& [_, point3D] : reconstruction.Points3D()) {
+    for (const TrackElement& observation : point3D.track.Elements()) {
+      const Image& image = reconstruction.Image(observation.image_id);
+      if (observation.point2D_idx < image.depth_prior_validity.size() &&
+          image.depth_prior_validity[observation.point2D_idx]) {
+        return observation;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 // Sum of valid track elements across tracks long enough to be added by
 // ``AddPointToCameraConstraints`` (i.e. ``track.Length() >=
 // min_num_view_per_track``).
@@ -461,6 +574,154 @@ void KeepSingleRegularPlusLcPoint(Reconstruction& reconstruction) {
 }
 
 }  // namespace
+
+TEST(GlobalPositioning, DefaultTraceDisabledWritesNoFiles) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  const std::filesystem::path trace_dir = CreateTestDir() / "gp_trace";
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  ASSERT_EQ(options.trace.level, GlobalPositioningTraceLevel::kOff);
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+  EXPECT_FALSE(ExistsPath(trace_dir));
+}
+
+TEST(GlobalPositioning, SummaryTraceWritesLifecycleAndIterationFiles) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  const std::filesystem::path trace_dir = CreateTestDir() / "gp_trace";
+  ASSERT_TRUE(std::filesystem::create_directories(trace_dir / "snapshots"));
+  {
+    std::ofstream residual_blocks(trace_dir / "residual_blocks.jsonl");
+    ASSERT_TRUE(residual_blocks.is_open());
+    residual_blocks << "stale";
+    std::ofstream residual_skips(trace_dir / "residual_skips.jsonl");
+    ASSERT_TRUE(residual_skips.is_open());
+    residual_skips << "stale";
+    std::ofstream snapshot(trace_dir / "snapshots" / "iter_000000.json");
+    ASSERT_TRUE(snapshot.is_open());
+    snapshot << "stale";
+  }
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.trace.level = GlobalPositioningTraceLevel::kSummary;
+  options.trace.output_path = trace_dir;
+  options.trace.run_label = "gp_test";
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  const std::filesystem::path manifest_path = trace_dir / "manifest.json";
+  const std::filesystem::path events_path = trace_dir / "events.jsonl";
+  const std::filesystem::path iteration_path =
+      trace_dir / "iteration_metrics.jsonl";
+  ASSERT_TRUE(ExistsFile(manifest_path));
+  ASSERT_TRUE(ExistsFile(events_path));
+  ASSERT_TRUE(ExistsFile(iteration_path));
+  EXPECT_FALSE(ExistsFile(trace_dir / "residual_blocks.jsonl"));
+  EXPECT_FALSE(ExistsFile(trace_dir / "residual_skips.jsonl"));
+  EXPECT_FALSE(ExistsDir(trace_dir / "snapshots"));
+
+  const std::string manifest = ReadFileForTest(manifest_path);
+  EXPECT_NE(manifest.find("\"status\": \"finished\""), std::string::npos);
+  EXPECT_NE(manifest.find("\"trace_level\": \"summary\""), std::string::npos);
+
+  const std::string events = ReadFileForTest(events_path);
+  EXPECT_NE(events.find("\"event_type\":\"run_started\""), std::string::npos);
+  EXPECT_NE(events.find("\"event_type\":\"problem_built\""), std::string::npos);
+  EXPECT_NE(events.find("\"event_type\":\"solve_started\""), std::string::npos);
+  EXPECT_NE(events.find("\"event_type\":\"solve_finished\""),
+            std::string::npos);
+  EXPECT_NE(events.find("\"event_type\":\"results_converted\""),
+            std::string::npos);
+  EXPECT_NE(events.find("\"num_residual_blocks\""), std::string::npos);
+
+  const std::string iterations = ReadFileForTest(iteration_path);
+  EXPECT_NE(iterations.find("\"event_type\":\"ceres_iteration\""),
+            std::string::npos);
+  EXPECT_NE(iterations.find("\"cost\""), std::string::npos);
+  EXPECT_NE(iterations.find("\"gradient_max_norm\""), std::string::npos);
+}
+
+TEST(GlobalPositioning, TraceOutputPathFileFailsLoudly) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  const std::filesystem::path trace_path = CreateTestDir() / "gp_trace_file";
+  {
+    std::ofstream file(trace_path);
+    ASSERT_TRUE(file.is_open());
+    file << "not a directory";
+  }
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.trace.level = GlobalPositioningTraceLevel::kSummary;
+  options.trace.output_path = trace_path;
+
+  TestableGlobalPositioner positioner(options);
+  EXPECT_ANY_THROW(positioner.Solve(data.pose_graph, data.reconstruction));
+}
+
+TEST(GlobalPositioning, ParameterSnapshotsTraceWritesMetadataAndSidecars) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  const std::filesystem::path trace_dir = CreateTestDir() / "gp_snapshots";
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.trace.level = GlobalPositioningTraceLevel::kParameterSnapshots;
+  options.trace.output_path = trace_dir;
+  options.trace.snapshot_every_n_iterations = 1;
+  options.trace.max_snapshotted_points = 2;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  const std::filesystem::path snapshot_dir = trace_dir / "snapshots";
+  ASSERT_TRUE(ExistsDir(snapshot_dir));
+  size_t snapshot_metadata_count = 0;
+  for (const std::filesystem::directory_entry& entry :
+       std::filesystem::directory_iterator(snapshot_dir)) {
+    if (entry.path().extension() == ".json") {
+      ++snapshot_metadata_count;
+    }
+  }
+  EXPECT_EQ(snapshot_metadata_count,
+            CountJsonlRecordsForTest(
+                ReadFileForTest(trace_dir / "iteration_metrics.jsonl")));
+
+  const std::filesystem::path metadata_path = snapshot_dir / "iter_000000.json";
+  const std::filesystem::path frame_centers_path =
+      snapshot_dir / "iter_000000_frame_centers_f64.bin";
+  const std::filesystem::path points3D_path =
+      snapshot_dir / "iter_000000_points3D_f64.bin";
+  const std::filesystem::path scales_path =
+      snapshot_dir / "iter_000000_scales_f64.bin";
+  ASSERT_TRUE(ExistsFile(metadata_path));
+  ASSERT_TRUE(ExistsFile(frame_centers_path));
+  ASSERT_TRUE(ExistsFile(points3D_path));
+  ASSERT_TRUE(ExistsFile(scales_path));
+
+  const std::string metadata = ReadFileForTest(metadata_path);
+  ExpectContainsAllSnapshotMetadataKeysForTest(metadata);
+  EXPECT_NE(metadata.find("iter_000000_frame_centers_f64.bin"),
+            std::string::npos);
+  EXPECT_NE(metadata.find("iter_000000_points3D_f64.bin"), std::string::npos);
+  EXPECT_NE(metadata.find("iter_000000_scales_f64.bin"), std::string::npos);
+  EXPECT_NE(metadata.find("world"), std::string::npos);
+  EXPECT_NE(metadata.find("cam_from_world.translation"), std::string::npos);
+
+  EXPECT_EQ(std::filesystem::file_size(frame_centers_path),
+            positioner.NumFrameCenters() * 3 * sizeof(double));
+
+  const uintmax_t points3D_size = std::filesystem::file_size(points3D_path);
+  EXPECT_LE(points3D_size, 2u * 3u * sizeof(double));
+  EXPECT_EQ(points3D_size % (3u * sizeof(double)), 0u);
+
+  const uintmax_t scales_size = std::filesystem::file_size(scales_path);
+  EXPECT_GT(scales_size, 0u);
+  EXPECT_EQ(scales_size % sizeof(double), 0u);
+}
 
 TEST(GlobalPositioning, MetricDepthConstraintConverges) {
   SetPRNGSeed(0);
@@ -618,6 +879,76 @@ void StampGtDepthPriors(Reconstruction& reconstruction) {
       }
     }
   }
+}
+
+TEST(GlobalPositioning, ResidualLedgerTraceWritesBlocksAndMatchesProblemBuilt) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  StampGtDepthPriors(data.reconstruction);
+
+  const std::filesystem::path trace_dir =
+      CreateTestDir() / "gp_residual_ledger";
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  options.trace.level = GlobalPositioningTraceLevel::kResidualLedger;
+  options.trace.output_path = trace_dir;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  const std::filesystem::path residual_blocks_path =
+      trace_dir / "residual_blocks.jsonl";
+  ASSERT_TRUE(ExistsFile(residual_blocks_path));
+
+  const std::string residual_blocks = ReadFileForTest(residual_blocks_path);
+  EXPECT_TRUE(ContainsJsonStringValueForTest(
+      residual_blocks, "residual_type", "bata_ref_frame"));
+  EXPECT_TRUE(ContainsJsonStringValueForTest(
+      residual_blocks, "residual_type", "metric_depth"));
+  EXPECT_TRUE(ContainsJsonStringValueForTest(
+      residual_blocks, "residual_type", "scale_prior"));
+
+  const std::string events = ReadFileForTest(trace_dir / "events.jsonl");
+  const std::optional<int64_t> expected_num_residual_blocks =
+      FindEventAttrIntForTest(events, "problem_built", "num_residual_blocks");
+  ASSERT_TRUE(expected_num_residual_blocks.has_value());
+  EXPECT_EQ(CountJsonlRecordsForTest(residual_blocks),
+            static_cast<size_t>(*expected_num_residual_blocks));
+}
+
+TEST(GlobalPositioning, ResidualLedgerTraceWritesMissingDepthPriorSkip) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  StampGtDepthPriors(data.reconstruction);
+
+  const std::optional<TrackElement> observation =
+      FindFirstValidDepthObservationForTest(data.reconstruction);
+  ASSERT_TRUE(observation.has_value());
+
+  Image& image = data.reconstruction.Image(observation->image_id);
+  ASSERT_LT(observation->point2D_idx, image.depth_prior_validity.size());
+  image.depth_prior_validity[observation->point2D_idx] = false;
+
+  const std::filesystem::path trace_dir = CreateTestDir() / "gp_residual_skip";
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  options.trace.level = GlobalPositioningTraceLevel::kResidualLedger;
+  options.trace.output_path = trace_dir;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  const std::filesystem::path residual_skips_path =
+      trace_dir / "residual_skips.jsonl";
+  ASSERT_TRUE(ExistsFile(residual_skips_path));
+
+  const std::string residual_skips = ReadFileForTest(residual_skips_path);
+  EXPECT_TRUE(ContainsJsonStringValueForTest(
+      residual_skips, "event_type", "residual_skipped"));
+  EXPECT_TRUE(ContainsJsonStringValueForTest(
+      residual_skips, "skip_reason", "missing_depth_validity"));
 }
 
 TEST(GlobalPositioning, FilterDepthOutliersRoutesSoftFallback) {

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -35,13 +35,16 @@
 #include "colmap/scene/pose_graph.h"
 #include "colmap/scene/reconstruction_matchers.h"
 #include "colmap/scene/synthetic.h"
+#include "colmap/util/endian.h"
 #include "colmap/util/file.h"
 #include "colmap/util/testing.h"
 
+#include <algorithm>
 #include <cctype>
 #include <cmath>
 #include <fstream>
 #include <iterator>
+#include <limits>
 #include <optional>
 #include <sstream>
 
@@ -321,6 +324,8 @@ TEST(MetricDepthError, SmoothLogLinearTransitionC1Continuity) {
 // paths. These tests verify both directions of the gate by counting BATA
 // residual blocks added during ``Solve``.
 
+void StampGtDepthPriors(Reconstruction& reconstruction);
+
 namespace {
 
 // Test-only subclass exposing ``scales_`` (one entry per BATA residual
@@ -331,6 +336,11 @@ class TestableGlobalPositioner : public GlobalPositioner {
   using GlobalPositioner::GlobalPositioner;
   size_t NumScales() const { return scales_.size(); }
   size_t NumFrameCenters() const { return frame_centers_.size(); }
+  size_t NumReplayEntries() const { return residual_replay_entries_.size(); }
+  const std::vector<GlobalPositioningResidualReplayEntry>&
+  ResidualReplayEntries() const {
+    return residual_replay_entries_;
+  }
   void SetupOnlyForTest(const PoseGraph& pose_graph,
                         Reconstruction& reconstruction) {
     SetupProblem(pose_graph, reconstruction);
@@ -351,16 +361,19 @@ struct GpTestData {
   DatabaseCache database_cache;
 };
 
-GpTestData BuildGpTestData() {
+GpTestData BuildGpTestData(const int num_rigs = 1,
+                           const int num_cameras_per_rig = 1,
+                           const int num_frames_per_rig = 5,
+                           const int num_points3D = 30) {
   GpTestData data;
   const auto database_path = CreateTestDir() / "database.db";
   data.database = Database::Open(database_path);
 
   SyntheticDatasetOptions synthetic_dataset_options;
-  synthetic_dataset_options.num_rigs = 1;
-  synthetic_dataset_options.num_cameras_per_rig = 1;
-  synthetic_dataset_options.num_frames_per_rig = 5;
-  synthetic_dataset_options.num_points3D = 30;
+  synthetic_dataset_options.num_rigs = num_rigs;
+  synthetic_dataset_options.num_cameras_per_rig = num_cameras_per_rig;
+  synthetic_dataset_options.num_frames_per_rig = num_frames_per_rig;
+  synthetic_dataset_options.num_points3D = num_points3D;
   synthetic_dataset_options.two_view_geometry_has_relative_pose = true;
   SynthesizeDataset(
       synthetic_dataset_options, &data.gt_reconstruction, data.database.get());
@@ -377,6 +390,23 @@ GpTestData BuildGpTestData() {
         Rigid3d(frame.RigFromWorld().rotation(), Eigen::Vector3d::Zero()));
   }
   return data;
+}
+
+void ForceNonRefRigTranslationsUnknownForTest(Reconstruction& reconstruction) {
+  std::vector<rig_t> rig_ids;
+  rig_ids.reserve(reconstruction.NumRigs());
+  for (const auto& [rig_id, _] : reconstruction.Rigs()) {
+    rig_ids.push_back(rig_id);
+  }
+
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  for (const rig_t rig_id : rig_ids) {
+    Rig& rig = reconstruction.Rig(rig_id);
+    for (auto& [_, sensor_from_rig] : rig.NonRefSensors()) {
+      ASSERT_TRUE(sensor_from_rig.has_value());
+      sensor_from_rig->translation() = Eigen::Vector3d(nan, nan, nan);
+    }
+  }
 }
 
 GlobalPositionerOptions BaselineGpOptions() {
@@ -465,6 +495,272 @@ std::optional<int64_t> FindEventAttrIntForTest(const std::string& events,
     }
   }
   return std::nullopt;
+}
+
+std::optional<int64_t> FindJsonIntForTest(const std::string& text,
+                                          const std::string& key) {
+  const std::string key_token = "\"" + key + "\"";
+  const size_t key_pos = text.find(key_token);
+  if (key_pos == std::string::npos) {
+    return std::nullopt;
+  }
+  size_t value_begin = text.find(':', key_pos + key_token.size());
+  if (value_begin == std::string::npos) {
+    return std::nullopt;
+  }
+  ++value_begin;
+  while (value_begin < text.size() &&
+         std::isspace(static_cast<unsigned char>(text[value_begin]))) {
+    ++value_begin;
+  }
+  size_t value_end = value_begin;
+  if (value_end < text.size() && text[value_end] == '-') {
+    ++value_end;
+  }
+  while (value_end < text.size() &&
+         std::isdigit(static_cast<unsigned char>(text[value_end]))) {
+    ++value_end;
+  }
+  if (value_end == value_begin) {
+    return std::nullopt;
+  }
+  return std::stoll(text.substr(value_begin, value_end - value_begin));
+}
+
+std::optional<double> FindJsonDoubleForTest(const std::string& text,
+                                            const std::string& key) {
+  const std::string key_token = "\"" + key + "\"";
+  const size_t key_pos = text.find(key_token);
+  if (key_pos == std::string::npos) {
+    return std::nullopt;
+  }
+  size_t value_begin = text.find(':', key_pos + key_token.size());
+  if (value_begin == std::string::npos) {
+    return std::nullopt;
+  }
+  ++value_begin;
+  while (value_begin < text.size() &&
+         std::isspace(static_cast<unsigned char>(text[value_begin]))) {
+    ++value_begin;
+  }
+  size_t value_end = value_begin;
+  while (value_end < text.size()) {
+    const char c = text[value_end];
+    if (!(std::isdigit(static_cast<unsigned char>(c)) || c == '-' || c == '+' ||
+          c == '.' || c == 'e' || c == 'E')) {
+      break;
+    }
+    ++value_end;
+  }
+  if (value_end == value_begin) {
+    return std::nullopt;
+  }
+  return std::stod(text.substr(value_begin, value_end - value_begin));
+}
+
+std::optional<std::string> FindJsonStringForTest(const std::string& text,
+                                                 const std::string& key) {
+  const std::string key_token = "\"" + key + "\"";
+  const size_t key_pos = text.find(key_token);
+  if (key_pos == std::string::npos) {
+    return std::nullopt;
+  }
+  size_t value_begin = text.find(':', key_pos + key_token.size());
+  if (value_begin == std::string::npos) {
+    return std::nullopt;
+  }
+  ++value_begin;
+  while (value_begin < text.size() &&
+         std::isspace(static_cast<unsigned char>(text[value_begin]))) {
+    ++value_begin;
+  }
+  if (value_begin >= text.size() || text[value_begin] != '"') {
+    return std::nullopt;
+  }
+  ++value_begin;
+  std::string value;
+  for (size_t i = value_begin; i < text.size(); ++i) {
+    if (text[i] == '\\' && i + 1 < text.size()) {
+      value.push_back(text[i + 1]);
+      ++i;
+    } else if (text[i] == '"') {
+      return value;
+    } else {
+      value.push_back(text[i]);
+    }
+  }
+  return std::nullopt;
+}
+
+std::string ExtractJsonArrayForTest(const std::string& text,
+                                    const std::string& key) {
+  const std::string key_token = "\"" + key + "\"";
+  const size_t key_pos = text.find(key_token);
+  THROW_CHECK_NE(key_pos, std::string::npos) << "Missing JSON key: " << key;
+  const size_t colon = text.find(':', key_pos + key_token.size());
+  THROW_CHECK_NE(colon, std::string::npos) << "Missing JSON colon for: " << key;
+  const size_t array_begin = text.find('[', colon);
+  THROW_CHECK_NE(array_begin, std::string::npos)
+      << "Missing JSON array for: " << key;
+
+  bool in_string = false;
+  bool escaped = false;
+  int depth = 0;
+  for (size_t i = array_begin; i < text.size(); ++i) {
+    const char c = text[i];
+    if (in_string) {
+      if (escaped) {
+        escaped = false;
+      } else if (c == '\\') {
+        escaped = true;
+      } else if (c == '"') {
+        in_string = false;
+      }
+      continue;
+    }
+    if (c == '"') {
+      in_string = true;
+    } else if (c == '[') {
+      ++depth;
+    } else if (c == ']') {
+      --depth;
+      if (depth == 0) {
+        return text.substr(array_begin, i - array_begin + 1);
+      }
+    }
+  }
+  THROW_CHECK(false) << "Unterminated JSON array for: " << key;
+  return "";
+}
+
+std::vector<std::string> FindJsonStringArrayForTest(const std::string& text,
+                                                    const std::string& key) {
+  const std::string array = ExtractJsonArrayForTest(text, key);
+  std::vector<std::string> values;
+  bool in_string = false;
+  bool escaped = false;
+  std::string value;
+  for (size_t i = 1; i + 1 < array.size(); ++i) {
+    const char c = array[i];
+    if (!in_string) {
+      if (c == '"') {
+        in_string = true;
+        value.clear();
+      }
+      continue;
+    }
+    if (escaped) {
+      value.push_back(c);
+      escaped = false;
+    } else if (c == '\\') {
+      escaped = true;
+    } else if (c == '"') {
+      values.push_back(value);
+      in_string = false;
+    } else {
+      value.push_back(c);
+    }
+  }
+  THROW_CHECK(!in_string) << "Unterminated JSON string array for: " << key;
+  return values;
+}
+
+std::vector<size_t> FindJsonSizeArrayForTest(const std::string& text,
+                                             const std::string& key) {
+  const std::string array = ExtractJsonArrayForTest(text, key);
+  std::vector<size_t> values;
+  size_t pos = 1;
+  while (pos + 1 < array.size()) {
+    while (pos + 1 < array.size() &&
+           !std::isdigit(static_cast<unsigned char>(array[pos]))) {
+      ++pos;
+    }
+    if (pos + 1 >= array.size()) {
+      break;
+    }
+    size_t end = pos;
+    while (end < array.size() &&
+           std::isdigit(static_cast<unsigned char>(array[end]))) {
+      ++end;
+    }
+    values.push_back(
+        static_cast<size_t>(std::stoull(array.substr(pos, end - pos))));
+    pos = end;
+  }
+  return values;
+}
+
+std::vector<bool> FindJsonBoolArrayForTest(const std::string& text,
+                                           const std::string& key) {
+  const std::string array = ExtractJsonArrayForTest(text, key);
+  std::vector<bool> values;
+  size_t pos = 1;
+  while (pos + 1 < array.size()) {
+    while (pos + 1 < array.size() &&
+           std::isspace(static_cast<unsigned char>(array[pos]))) {
+      ++pos;
+    }
+    if (array.compare(pos, 4, "true") == 0) {
+      values.push_back(true);
+      pos += 4;
+    } else if (array.compare(pos, 5, "false") == 0) {
+      values.push_back(false);
+      pos += 5;
+    } else {
+      ++pos;
+    }
+  }
+  return values;
+}
+
+std::vector<std::string> ResidualIdsFromBlocksJsonlForTest(
+    const std::string& residual_blocks) {
+  std::vector<std::string> residual_ids;
+  std::istringstream stream(residual_blocks);
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    std::optional<std::string> residual_id =
+        FindJsonStringForTest(line, "residual_id");
+    THROW_CHECK(residual_id.has_value())
+        << "Residual block record missing residual_id: " << line;
+    residual_ids.push_back(*residual_id);
+  }
+  return residual_ids;
+}
+
+std::optional<double> FindIterationMetricDoubleForTest(
+    const std::string& iteration_metrics,
+    const int64_t iteration,
+    const std::string& key) {
+  std::istringstream stream(iteration_metrics);
+  std::string line;
+  while (std::getline(stream, line)) {
+    if (!ContainsJsonStringValueForTest(
+            line, "event_type", "ceres_iteration")) {
+      continue;
+    }
+    const std::optional<int64_t> line_iteration =
+        FindJsonIntForTest(line, "iteration");
+    if (!line_iteration.has_value() || *line_iteration != iteration) {
+      continue;
+    }
+    return FindJsonDoubleForTest(line, key);
+  }
+  return std::nullopt;
+}
+
+std::vector<double> ReadDoubleSidecarForTest(const std::filesystem::path& path,
+                                             const size_t expected_count) {
+  std::ifstream file(path, std::ios::binary);
+  THROW_CHECK_FILE_OPEN(file, path);
+  std::vector<double> values(expected_count);
+  ReadBinaryLittleEndian<double>(&file, &values);
+  THROW_CHECK(file.good() || file.eof())
+      << "Failed while reading binary sidecar: " << path;
+  return values;
 }
 
 void ExpectContainsAllSnapshotMetadataKeysForTest(const std::string& metadata) {
@@ -593,6 +889,8 @@ TEST(GlobalPositioning, SummaryTraceWritesLifecycleAndIterationFiles) {
   GpTestData data = BuildGpTestData();
   const std::filesystem::path trace_dir = CreateTestDir() / "gp_trace";
   ASSERT_TRUE(std::filesystem::create_directories(trace_dir / "snapshots"));
+  ASSERT_TRUE(
+      std::filesystem::create_directories(trace_dir / "residual_values"));
   {
     std::ofstream residual_blocks(trace_dir / "residual_blocks.jsonl");
     ASSERT_TRUE(residual_blocks.is_open());
@@ -603,6 +901,10 @@ TEST(GlobalPositioning, SummaryTraceWritesLifecycleAndIterationFiles) {
     std::ofstream snapshot(trace_dir / "snapshots" / "iter_000000.json");
     ASSERT_TRUE(snapshot.is_open());
     snapshot << "stale";
+    std::ofstream residual_values(trace_dir / "residual_values" /
+                                  "iter_000000.json");
+    ASSERT_TRUE(residual_values.is_open());
+    residual_values << "stale";
   }
 
   GlobalPositionerOptions options = BaselineGpOptions();
@@ -623,6 +925,7 @@ TEST(GlobalPositioning, SummaryTraceWritesLifecycleAndIterationFiles) {
   EXPECT_FALSE(ExistsFile(trace_dir / "residual_blocks.jsonl"));
   EXPECT_FALSE(ExistsFile(trace_dir / "residual_skips.jsonl"));
   EXPECT_FALSE(ExistsDir(trace_dir / "snapshots"));
+  EXPECT_FALSE(ExistsDir(trace_dir / "residual_values"));
 
   const std::string manifest = ReadFileForTest(manifest_path);
   EXPECT_NE(manifest.find("\"status\": \"finished\""), std::string::npos);
@@ -721,6 +1024,200 @@ TEST(GlobalPositioning, ParameterSnapshotsTraceWritesMetadataAndSidecars) {
   const uintmax_t scales_size = std::filesystem::file_size(scales_path);
   EXPECT_GT(scales_size, 0u);
   EXPECT_EQ(scales_size % sizeof(double), 0u);
+}
+
+TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  StampGtDepthPriors(data.reconstruction);
+  const std::filesystem::path trace_dir =
+      CreateTestDir() / "gp_residual_values";
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  options.trace.level = GlobalPositioningTraceLevel::kResidualValues;
+  options.trace.output_path = trace_dir;
+  options.trace.snapshot_every_n_iterations = 1;
+  options.trace.max_snapshotted_points = 2;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+  EXPECT_GT(positioner.NumReplayEntries(), 0u);
+
+  const std::filesystem::path residual_values_dir =
+      trace_dir / "residual_values";
+  ASSERT_TRUE(ExistsDir(residual_values_dir));
+
+  const std::filesystem::path metadata_path =
+      residual_values_dir / "iter_000000.json";
+  const std::filesystem::path raw_residuals_path =
+      residual_values_dir / "iter_000000_raw_residuals_f64.bin";
+  const std::filesystem::path raw_costs_path =
+      residual_values_dir / "iter_000000_raw_costs_f64.bin";
+  const std::filesystem::path robust_costs_path =
+      residual_values_dir / "iter_000000_robust_costs_f64.bin";
+  ASSERT_TRUE(ExistsFile(metadata_path));
+  ASSERT_TRUE(ExistsFile(raw_residuals_path));
+  ASSERT_TRUE(ExistsFile(raw_costs_path));
+  ASSERT_TRUE(ExistsFile(robust_costs_path));
+
+  const std::string manifest = ReadFileForTest(trace_dir / "manifest.json");
+  EXPECT_NE(manifest.find("\"trace_level\": \"residual_values\""),
+            std::string::npos);
+
+  const std::string metadata = ReadFileForTest(metadata_path);
+  for (const char* key : {"\"num_residual_blocks\"",
+                          "\"total_scalar_residuals\"",
+                          "\"residual_ids\"",
+                          "\"residual_dims\"",
+                          "\"residual_offsets\"",
+                          "\"evaluation_success\"",
+                          "\"artifacts\""}) {
+    EXPECT_NE(metadata.find(key), std::string::npos)
+        << "Missing residual-values metadata key: " << key;
+  }
+  EXPECT_NE(metadata.find("iter_000000_raw_residuals_f64.bin"),
+            std::string::npos);
+  EXPECT_NE(metadata.find("iter_000000_raw_costs_f64.bin"), std::string::npos);
+  EXPECT_NE(metadata.find("iter_000000_robust_costs_f64.bin"),
+            std::string::npos);
+
+  const std::optional<int64_t> num_residual_blocks =
+      FindJsonIntForTest(metadata, "num_residual_blocks");
+  const std::optional<int64_t> total_scalar_residuals =
+      FindJsonIntForTest(metadata, "total_scalar_residuals");
+  ASSERT_TRUE(num_residual_blocks.has_value());
+  ASSERT_TRUE(total_scalar_residuals.has_value());
+  ASSERT_GT(*num_residual_blocks, 0);
+  ASSERT_GE(*total_scalar_residuals, *num_residual_blocks);
+  ASSERT_EQ(positioner.NumReplayEntries(),
+            static_cast<size_t>(*num_residual_blocks));
+
+  const std::string residual_blocks =
+      ReadFileForTest(trace_dir / "residual_blocks.jsonl");
+  EXPECT_EQ(CountJsonlRecordsForTest(residual_blocks),
+            static_cast<size_t>(*num_residual_blocks));
+  const std::vector<std::string> block_residual_ids =
+      ResidualIdsFromBlocksJsonlForTest(residual_blocks);
+  const std::vector<std::string> metadata_residual_ids =
+      FindJsonStringArrayForTest(metadata, "residual_ids");
+  EXPECT_EQ(metadata_residual_ids, block_residual_ids);
+
+  std::vector<std::string> replay_residual_ids;
+  replay_residual_ids.reserve(positioner.ResidualReplayEntries().size());
+  for (const GlobalPositioningResidualReplayEntry& entry :
+       positioner.ResidualReplayEntries()) {
+    EXPECT_FALSE(entry.residual_id.empty());
+    ASSERT_NE(entry.cost_function, nullptr) << entry.residual_id;
+    EXPECT_GT(entry.residual_dimension, 0u) << entry.residual_id;
+    EXPECT_EQ(entry.residual_dimension,
+              static_cast<size_t>(entry.cost_function->num_residuals()))
+        << entry.residual_id;
+    EXPECT_EQ(entry.parameter_blocks.size(),
+              entry.cost_function->parameter_block_sizes().size())
+        << entry.residual_id;
+    for (const double* parameter_block : entry.parameter_blocks) {
+      EXPECT_NE(parameter_block, nullptr) << entry.residual_id;
+    }
+    replay_residual_ids.push_back(entry.residual_id);
+  }
+  EXPECT_EQ(replay_residual_ids, metadata_residual_ids);
+
+  const std::vector<size_t> residual_dims =
+      FindJsonSizeArrayForTest(metadata, "residual_dims");
+  const std::vector<size_t> residual_offsets =
+      FindJsonSizeArrayForTest(metadata, "residual_offsets");
+  const std::vector<bool> evaluation_success =
+      FindJsonBoolArrayForTest(metadata, "evaluation_success");
+  ASSERT_EQ(residual_dims.size(), static_cast<size_t>(*num_residual_blocks));
+  ASSERT_EQ(residual_offsets.size(), static_cast<size_t>(*num_residual_blocks));
+  ASSERT_EQ(evaluation_success.size(),
+            static_cast<size_t>(*num_residual_blocks));
+  EXPECT_TRUE(std::all_of(evaluation_success.begin(),
+                          evaluation_success.end(),
+                          [](const bool success) { return success; }));
+
+  EXPECT_EQ(std::filesystem::file_size(raw_residuals_path),
+            static_cast<uintmax_t>(*total_scalar_residuals) * sizeof(double));
+  EXPECT_EQ(std::filesystem::file_size(raw_costs_path),
+            static_cast<uintmax_t>(*num_residual_blocks) * sizeof(double));
+  EXPECT_EQ(std::filesystem::file_size(robust_costs_path),
+            static_cast<uintmax_t>(*num_residual_blocks) * sizeof(double));
+
+  const std::vector<double> raw_residuals = ReadDoubleSidecarForTest(
+      raw_residuals_path, static_cast<size_t>(*total_scalar_residuals));
+  const std::vector<double> raw_costs = ReadDoubleSidecarForTest(
+      raw_costs_path, static_cast<size_t>(*num_residual_blocks));
+  const std::vector<double> robust_costs = ReadDoubleSidecarForTest(
+      robust_costs_path, static_cast<size_t>(*num_residual_blocks));
+
+  size_t expected_offset = 0;
+  double robust_cost_sum = 0.0;
+  for (size_t i = 0; i < residual_dims.size(); ++i) {
+    EXPECT_EQ(residual_offsets[i], expected_offset);
+    ASSERT_LE(residual_offsets[i] + residual_dims[i], raw_residuals.size());
+
+    double squared_norm = 0.0;
+    for (size_t j = 0; j < residual_dims[i]; ++j) {
+      const double residual = raw_residuals[residual_offsets[i] + j];
+      ASSERT_TRUE(std::isfinite(residual));
+      squared_norm += residual * residual;
+    }
+    ASSERT_TRUE(std::isfinite(raw_costs[i]));
+    ASSERT_TRUE(std::isfinite(robust_costs[i]));
+    EXPECT_NEAR(raw_costs[i], 0.5 * squared_norm, 1e-12)
+        << metadata_residual_ids[i];
+
+    robust_cost_sum += robust_costs[i];
+    expected_offset += residual_dims[i];
+  }
+  EXPECT_EQ(expected_offset, static_cast<size_t>(*total_scalar_residuals));
+
+  const std::optional<int64_t> iteration =
+      FindJsonIntForTest(metadata, "iteration");
+  ASSERT_TRUE(iteration.has_value());
+  const std::optional<double> ceres_iteration_cost =
+      FindIterationMetricDoubleForTest(
+          ReadFileForTest(trace_dir / "iteration_metrics.jsonl"),
+          *iteration,
+          "cost");
+  ASSERT_TRUE(ceres_iteration_cost.has_value());
+  EXPECT_NEAR(robust_cost_sum,
+              *ceres_iteration_cost,
+              std::max(1e-9, std::abs(*ceres_iteration_cost) * 1e-12));
+}
+
+TEST(GlobalPositioning, LowerTraceLevelsDoNotCreateResidualValues) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  const std::vector<std::pair<GlobalPositioningTraceLevel, std::string>>
+      lower_levels = {
+          {GlobalPositioningTraceLevel::kSummary, "summary"},
+          {GlobalPositioningTraceLevel::kResidualLedger, "residual_ledger"},
+          {GlobalPositioningTraceLevel::kParameterSnapshots,
+           "parameter_snapshots"},
+      };
+
+  for (const auto& [level, label] : lower_levels) {
+    Reconstruction reconstruction = data.reconstruction;
+    StampGtDepthPriors(reconstruction);
+    const std::filesystem::path trace_dir =
+        CreateTestDir() / ("gp_no_residual_values_" + label);
+
+    GlobalPositionerOptions options = BaselineGpOptions();
+    options.use_metric_depth_constraint = true;
+    options.trace.level = level;
+    options.trace.output_path = trace_dir;
+    options.trace.snapshot_every_n_iterations = 1;
+    options.trace.max_snapshotted_points = 2;
+
+    TestableGlobalPositioner positioner(options);
+    ASSERT_TRUE(positioner.Solve(data.pose_graph, reconstruction))
+        << "trace level: " << label;
+    EXPECT_EQ(positioner.NumReplayEntries(), 0u) << "trace level: " << label;
+    EXPECT_FALSE(ExistsDir(trace_dir / "residual_values"))
+        << "trace level: " << label;
+  }
 }
 
 TEST(GlobalPositioning, MetricDepthConstraintConverges) {
@@ -915,6 +1412,53 @@ TEST(GlobalPositioning, ResidualLedgerTraceWritesBlocksAndMatchesProblemBuilt) {
   ASSERT_TRUE(expected_num_residual_blocks.has_value());
   EXPECT_EQ(CountJsonlRecordsForTest(residual_blocks),
             static_cast<size_t>(*expected_num_residual_blocks));
+}
+
+TEST(GlobalPositioning, ResidualLedgerTraceCanForceBataConstantRigFamily) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData(/*num_rigs=*/1,
+                                    /*num_cameras_per_rig=*/2,
+                                    /*num_frames_per_rig=*/4,
+                                    /*num_points3D=*/40);
+
+  const std::filesystem::path trace_dir =
+      CreateTestDir() / "gp_constant_rig_family";
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.trace.level = GlobalPositioningTraceLevel::kResidualLedger;
+  options.trace.output_path = trace_dir;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  const std::string residual_blocks =
+      ReadFileForTest(trace_dir / "residual_blocks.jsonl");
+  EXPECT_TRUE(ContainsJsonStringValueForTest(
+      residual_blocks, "residual_type", "bata_constant_rig"));
+}
+
+TEST(GlobalPositioning, ResidualLedgerTraceCanForceBataVariableRigFamily) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData(/*num_rigs=*/1,
+                                    /*num_cameras_per_rig=*/2,
+                                    /*num_frames_per_rig=*/4,
+                                    /*num_points3D=*/40);
+  ForceNonRefRigTranslationsUnknownForTest(data.reconstruction);
+
+  const std::filesystem::path trace_dir =
+      CreateTestDir() / "gp_variable_rig_family";
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.trace.level = GlobalPositioningTraceLevel::kResidualLedger;
+  options.trace.output_path = trace_dir;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  const std::string residual_blocks =
+      ReadFileForTest(trace_dir / "residual_blocks.jsonl");
+  EXPECT_TRUE(ContainsJsonStringValueForTest(
+      residual_blocks, "residual_type", "bata_variable_rig"));
 }
 
 TEST(GlobalPositioning, ResidualLedgerTraceWritesMissingDepthPriorSkip) {

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -1058,10 +1058,13 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
       residual_values_dir / "iter_000000_raw_costs_f64.bin";
   const std::filesystem::path robust_costs_path =
       residual_values_dir / "iter_000000_robust_costs_f64.bin";
+  const std::filesystem::path raw_jacobians_path =
+      residual_values_dir / "iter_000000_raw_jacobians_f64.bin";
   ASSERT_TRUE(ExistsFile(metadata_path));
   ASSERT_TRUE(ExistsFile(raw_residuals_path));
   ASSERT_TRUE(ExistsFile(raw_costs_path));
   ASSERT_TRUE(ExistsFile(robust_costs_path));
+  ASSERT_FALSE(ExistsFile(raw_jacobians_path));
 
   const std::string manifest = ReadFileForTest(trace_dir / "manifest.json");
   EXPECT_NE(manifest.find("\"trace_level\": \"residual_values\""),
@@ -1070,6 +1073,7 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
   const std::string metadata = ReadFileForTest(metadata_path);
   for (const char* key : {"\"num_residual_blocks\"",
                           "\"total_scalar_residuals\"",
+                          "\"has_raw_jacobians\"",
                           "\"residual_ids\"",
                           "\"residual_dims\"",
                           "\"residual_offsets\"",
@@ -1082,6 +1086,10 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
             std::string::npos);
   EXPECT_NE(metadata.find("iter_000000_raw_costs_f64.bin"), std::string::npos);
   EXPECT_NE(metadata.find("iter_000000_robust_costs_f64.bin"),
+            std::string::npos);
+  EXPECT_NE(metadata.find("\"has_raw_jacobians\": false"), std::string::npos);
+  EXPECT_EQ(metadata.find("\"raw_jacobians\": {"), std::string::npos);
+  EXPECT_EQ(metadata.find("iter_000000_raw_jacobians_f64.bin"),
             std::string::npos);
 
   const std::optional<int64_t> num_residual_blocks =
@@ -1187,6 +1195,127 @@ TEST(GlobalPositioning, ResidualValuesTraceWritesMetadataAndSidecars) {
   EXPECT_NEAR(robust_cost_sum,
               *ceres_iteration_cost,
               std::max(1e-9, std::abs(*ceres_iteration_cost) * 1e-12));
+}
+
+TEST(GlobalPositioning, ResidualJacobiansTraceWritesMetadataAndSidecars) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  StampGtDepthPriors(data.reconstruction);
+  const std::filesystem::path trace_dir =
+      CreateTestDir() / "gp_residual_jacobians";
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  options.trace.level = GlobalPositioningTraceLevel::kResidualJacobians;
+  options.trace.output_path = trace_dir;
+  options.trace.snapshot_every_n_iterations = 1;
+  options.trace.max_snapshotted_points = 2;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+  EXPECT_GT(positioner.NumReplayEntries(), 0u);
+
+  const std::filesystem::path residual_values_dir =
+      trace_dir / "residual_values";
+  ASSERT_TRUE(ExistsDir(residual_values_dir));
+
+  const std::filesystem::path metadata_path =
+      residual_values_dir / "iter_000000.json";
+  const std::filesystem::path raw_jacobians_path =
+      residual_values_dir / "iter_000000_raw_jacobians_f64.bin";
+  ASSERT_TRUE(ExistsFile(metadata_path));
+  ASSERT_TRUE(ExistsFile(raw_jacobians_path));
+
+  const std::string manifest = ReadFileForTest(trace_dir / "manifest.json");
+  EXPECT_NE(manifest.find("\"trace_level\": \"residual_jacobians\""),
+            std::string::npos);
+
+  const std::string metadata = ReadFileForTest(metadata_path);
+  for (const char* key : {"\"has_raw_jacobians\"",
+                          "\"total_jacobian_scalars\"",
+                          "\"parameter_block_sizes\"",
+                          "\"raw_jacobian_offsets\"",
+                          "\"parameter_blocks\"",
+                          "\"parameter_block_is_constant\"",
+                          "\"parameter_block_lower_bounds\"",
+                          "\"raw_jacobian_layout\"",
+                          "\"jacobian_domain\"",
+                          "\"loss_applied_to_jacobians\"",
+                          "\"manifold_applied_to_jacobians\"",
+                          "\"constant_parameter_blocks_included\"",
+                          "\"raw_jacobians\""}) {
+    EXPECT_NE(metadata.find(key), std::string::npos)
+        << "Missing residual-jacobians metadata key: " << key;
+  }
+  EXPECT_NE(metadata.find("\"has_raw_jacobians\": true"), std::string::npos);
+  EXPECT_NE(
+      metadata.find("\"raw_jacobian_layout\": "
+                    "\"residual_block_major/parameter_block_major/row_major\""),
+      std::string::npos);
+  EXPECT_NE(metadata.find("\"jacobian_domain\": "
+                          "\"raw_cost_function_ambient_parameters\""),
+            std::string::npos);
+  EXPECT_NE(metadata.find("\"loss_applied_to_jacobians\": false"),
+            std::string::npos);
+  EXPECT_NE(metadata.find("\"manifold_applied_to_jacobians\": false"),
+            std::string::npos);
+  EXPECT_NE(metadata.find("\"constant_parameter_blocks_included\": true"),
+            std::string::npos);
+  EXPECT_NE(metadata.find("iter_000000_raw_jacobians_f64.bin"),
+            std::string::npos);
+  EXPECT_NE(metadata.find("\"role\":\"frame_center\""), std::string::npos);
+  EXPECT_NE(metadata.find("\"role\":\"point3D\""), std::string::npos);
+  EXPECT_NE(metadata.find("\"role\":\"bata_scale\""), std::string::npos);
+  EXPECT_NE(metadata.find("\"role\":\"dmap_scale\""), std::string::npos);
+
+  const std::optional<int64_t> num_residual_blocks =
+      FindJsonIntForTest(metadata, "num_residual_blocks");
+  const std::optional<int64_t> total_jacobian_scalars =
+      FindJsonIntForTest(metadata, "total_jacobian_scalars");
+  ASSERT_TRUE(num_residual_blocks.has_value());
+  ASSERT_TRUE(total_jacobian_scalars.has_value());
+  ASSERT_GT(*num_residual_blocks, 0);
+  ASSERT_GT(*total_jacobian_scalars, 0);
+
+  std::vector<size_t> expected_parameter_block_sizes;
+  std::vector<size_t> expected_raw_jacobian_offsets;
+  size_t expected_jacobian_scalars = 0;
+  for (const GlobalPositioningResidualReplayEntry& entry :
+       positioner.ResidualReplayEntries()) {
+    ASSERT_EQ(entry.parameter_blocks.size(), entry.parameter_block_sizes.size())
+        << entry.residual_id;
+    for (const int parameter_block_size : entry.parameter_block_sizes) {
+      expected_parameter_block_sizes.push_back(
+          static_cast<size_t>(parameter_block_size));
+      expected_raw_jacobian_offsets.push_back(expected_jacobian_scalars);
+      expected_jacobian_scalars +=
+          entry.residual_dimension * static_cast<size_t>(parameter_block_size);
+    }
+  }
+
+  EXPECT_EQ(static_cast<size_t>(*total_jacobian_scalars),
+            expected_jacobian_scalars);
+  EXPECT_EQ(FindJsonSizeArrayForTest(metadata, "parameter_block_sizes"),
+            expected_parameter_block_sizes);
+  EXPECT_EQ(FindJsonSizeArrayForTest(metadata, "raw_jacobian_offsets"),
+            expected_raw_jacobian_offsets);
+  EXPECT_EQ(std::filesystem::file_size(raw_jacobians_path),
+            static_cast<uintmax_t>(*total_jacobian_scalars) * sizeof(double));
+
+  const std::vector<bool> evaluation_success =
+      FindJsonBoolArrayForTest(metadata, "evaluation_success");
+  ASSERT_EQ(evaluation_success.size(),
+            static_cast<size_t>(*num_residual_blocks));
+  EXPECT_TRUE(std::all_of(evaluation_success.begin(),
+                          evaluation_success.end(),
+                          [](const bool success) { return success; }));
+
+  const std::vector<double> raw_jacobians = ReadDoubleSidecarForTest(
+      raw_jacobians_path, static_cast<size_t>(*total_jacobian_scalars));
+  EXPECT_TRUE(std::all_of(
+      raw_jacobians.begin(), raw_jacobians.end(), [](const double value) {
+        return std::isfinite(value);
+      }));
 }
 
 TEST(GlobalPositioning, LowerTraceLevelsDoNotCreateResidualValues) {

--- a/src/colmap/estimators/global_positioning_trace.cc
+++ b/src/colmap/estimators/global_positioning_trace.cc
@@ -1,0 +1,639 @@
+#include "colmap/estimators/global_positioning_trace.h"
+
+#include "colmap/util/endian.h"
+#include "colmap/util/file.h"
+#include "colmap/util/logging.h"
+
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <system_error>
+#include <utility>
+
+#include <ceres/types.h>
+
+namespace colmap {
+namespace {
+
+constexpr int kSchemaVersion = 1;
+
+int64_t UnixNowNs() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::system_clock::now().time_since_epoch())
+      .count();
+}
+
+int64_t SteadyNowNs() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+std::string JsonEscape(const std::string& value) {
+  std::ostringstream stream;
+  stream << '"';
+  for (const char c : value) {
+    switch (c) {
+      case '"':
+        stream << "\\\"";
+        break;
+      case '\\':
+        stream << "\\\\";
+        break;
+      case '\b':
+        stream << "\\b";
+        break;
+      case '\f':
+        stream << "\\f";
+        break;
+      case '\n':
+        stream << "\\n";
+        break;
+      case '\r':
+        stream << "\\r";
+        break;
+      case '\t':
+        stream << "\\t";
+        break;
+      default:
+        if (static_cast<unsigned char>(c) < 0x20) {
+          stream << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+                 << static_cast<int>(static_cast<unsigned char>(c)) << std::dec
+                 << std::setfill(' ');
+        } else {
+          stream << c;
+        }
+    }
+  }
+  stream << '"';
+  return stream.str();
+}
+
+std::string JsonDouble(const double value) {
+  if (!std::isfinite(value)) {
+    if (std::isnan(value)) {
+      return JsonEscape("nan");
+    }
+    return JsonEscape(value < 0 ? "-inf" : "inf");
+  }
+  std::ostringstream stream;
+  stream << std::setprecision(std::numeric_limits<double>::max_digits10)
+         << value;
+  return stream.str();
+}
+
+std::string JsonValue(const GlobalPositioningTraceValue& value) {
+  switch (value.type) {
+    case GlobalPositioningTraceValue::Type::kNull:
+      return "null";
+    case GlobalPositioningTraceValue::Type::kBool:
+      return value.bool_value ? "true" : "false";
+    case GlobalPositioningTraceValue::Type::kInt:
+      return std::to_string(value.int_value);
+    case GlobalPositioningTraceValue::Type::kUInt:
+      return std::to_string(value.uint_value);
+    case GlobalPositioningTraceValue::Type::kDouble:
+      return JsonDouble(value.double_value);
+    case GlobalPositioningTraceValue::Type::kString:
+      return JsonEscape(value.string_value);
+    case GlobalPositioningTraceValue::Type::kStringArray: {
+      std::ostringstream stream;
+      stream << "[";
+      for (size_t i = 0; i < value.string_array_value.size(); ++i) {
+        if (i > 0) {
+          stream << ",";
+        }
+        stream << JsonEscape(value.string_array_value[i]);
+      }
+      stream << "]";
+      return stream.str();
+    }
+  }
+  return "null";
+}
+
+std::string JsonAttrs(
+    const std::map<std::string, GlobalPositioningTraceValue>& attrs) {
+  std::ostringstream stream;
+  stream << "{";
+  bool first = true;
+  for (const auto& [key, value] : attrs) {
+    if (!first) {
+      stream << ",";
+    }
+    first = false;
+    stream << JsonEscape(key) << ":" << JsonValue(value);
+  }
+  stream << "}";
+  return stream.str();
+}
+
+std::string MakeRunId(const int64_t created_at_unix_ns,
+                      const std::string& run_label) {
+  std::ostringstream stream;
+  stream << created_at_unix_ns;
+  if (!run_label.empty()) {
+    stream << "_" << run_label;
+  }
+  return stream.str();
+}
+
+bool IsResidualLedgerLevel(const GlobalPositioningTraceLevel level) {
+  return static_cast<int>(level) >=
+         static_cast<int>(GlobalPositioningTraceLevel::kResidualLedger);
+}
+
+bool IsParameterSnapshotsLevel(const GlobalPositioningTraceLevel level) {
+  return static_cast<int>(level) >=
+         static_cast<int>(GlobalPositioningTraceLevel::kParameterSnapshots);
+}
+
+std::string IterationPrefix(const int iteration) {
+  std::ostringstream stream;
+  stream << "iter_" << std::setw(6) << std::setfill('0') << iteration;
+  return stream.str();
+}
+
+uint64_t ShapeElementCount(const std::vector<size_t>& shape) {
+  uint64_t count = 1;
+  for (const size_t dim : shape) {
+    count *= static_cast<uint64_t>(dim);
+  }
+  return count;
+}
+
+std::string JsonUInt64Array(const std::vector<uint64_t>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << values[i];
+  }
+  stream << "]";
+  return stream.str();
+}
+
+std::string JsonSizeArray(const std::vector<size_t>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << values[i];
+  }
+  stream << "]";
+  return stream.str();
+}
+
+void ValidateSnapshotArray(const std::string& name,
+                           const GlobalPositioningTraceSnapshotArray& array) {
+  THROW_CHECK(!array.shape.empty())
+      << "Snapshot array " << name << " must declare a non-empty shape.";
+  THROW_CHECK_EQ(ShapeElementCount(array.shape), array.values.size())
+      << "Snapshot array " << name
+      << " shape does not match flattened value count.";
+  THROW_CHECK_EQ(array.shape.front(), array.ids.size())
+      << "Snapshot array " << name
+      << " first shape dimension must match the number of IDs.";
+}
+
+void WriteSnapshotSidecar(const std::filesystem::path& path,
+                          const GlobalPositioningTraceSnapshotArray& array) {
+  std::ofstream sidecar_stream(
+      path, std::ios::binary | std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(sidecar_stream, path);
+  for (const double value : array.values) {
+    WriteBinaryLittleEndian<double>(&sidecar_stream, value);
+  }
+  THROW_CHECK(sidecar_stream.good())
+      << "Failed while writing global positioning snapshot sidecar: " << path;
+}
+
+void WriteSnapshotArtifactMetadata(
+    std::ostream& stream,
+    const std::string& name,
+    const GlobalPositioningTraceSnapshotArray& array,
+    const std::string& filename) {
+  stream << "    " << JsonEscape(name) << ": {\n"
+         << "      \"file\": " << JsonEscape(filename) << ",\n"
+         << "      \"dtype\": \"float64\",\n"
+         << "      \"byte_order\": \"little_endian\",\n"
+         << "      \"ids\": " << JsonUInt64Array(array.ids) << ",\n"
+         << "      \"shape\": " << JsonSizeArray(array.shape) << "\n"
+         << "    }";
+}
+
+void RemoveTraceArtifactIfExists(const std::filesystem::path& path) {
+  std::error_code error;
+  std::filesystem::remove_all(path, error);
+  THROW_CHECK(!error) << "Failed to remove stale global positioning trace "
+                         "artifact: "
+                      << path << " error: " << error.message();
+}
+
+}  // namespace
+
+std::string GlobalPositioningTraceLevelToString(
+    const GlobalPositioningTraceLevel level) {
+  switch (level) {
+    case GlobalPositioningTraceLevel::kOff:
+      return "off";
+    case GlobalPositioningTraceLevel::kSummary:
+      return "summary";
+    case GlobalPositioningTraceLevel::kResidualLedger:
+      return "residual_ledger";
+    case GlobalPositioningTraceLevel::kParameterSnapshots:
+      return "parameter_snapshots";
+    case GlobalPositioningTraceLevel::kResidualValues:
+      return "residual_values";
+  }
+  return "unknown";
+}
+
+GlobalPositioningTraceValue GlobalPositioningTraceValue::Null() {
+  return GlobalPositioningTraceValue{};
+}
+
+GlobalPositioningTraceValue GlobalPositioningTraceValue::Bool(
+    const bool value) {
+  GlobalPositioningTraceValue trace_value;
+  trace_value.type = Type::kBool;
+  trace_value.bool_value = value;
+  return trace_value;
+}
+
+GlobalPositioningTraceValue GlobalPositioningTraceValue::Int(
+    const int64_t value) {
+  GlobalPositioningTraceValue trace_value;
+  trace_value.type = Type::kInt;
+  trace_value.int_value = value;
+  return trace_value;
+}
+
+GlobalPositioningTraceValue GlobalPositioningTraceValue::UInt(
+    const uint64_t value) {
+  GlobalPositioningTraceValue trace_value;
+  trace_value.type = Type::kUInt;
+  trace_value.uint_value = value;
+  return trace_value;
+}
+
+GlobalPositioningTraceValue GlobalPositioningTraceValue::Double(
+    const double value) {
+  GlobalPositioningTraceValue trace_value;
+  trace_value.type = Type::kDouble;
+  trace_value.double_value = value;
+  return trace_value;
+}
+
+GlobalPositioningTraceValue GlobalPositioningTraceValue::String(
+    std::string value) {
+  GlobalPositioningTraceValue trace_value;
+  trace_value.type = Type::kString;
+  trace_value.string_value = std::move(value);
+  return trace_value;
+}
+
+GlobalPositioningTraceValue GlobalPositioningTraceValue::StringArray(
+    std::vector<std::string> value) {
+  GlobalPositioningTraceValue trace_value;
+  trace_value.type = Type::kStringArray;
+  trace_value.string_array_value = std::move(value);
+  return trace_value;
+}
+
+GlobalPositioningTraceRecorder::GlobalPositioningTraceRecorder(
+    const GlobalPositioningTraceOptions& options)
+    : options_(options), created_at_unix_ns_(UnixNowNs()) {
+  THROW_CHECK(options_.level != GlobalPositioningTraceLevel::kOff);
+  THROW_CHECK(!options_.output_path.empty())
+      << "Global positioning trace output_path must be set when tracing is "
+         "enabled.";
+  THROW_CHECK(!ExistsFile(options_.output_path))
+      << "Global positioning trace output_path points to a file: "
+      << options_.output_path;
+  if (!ExistsDir(options_.output_path)) {
+    CreateDirIfNotExists(options_.output_path, /*recursive=*/true);
+  }
+  THROW_CHECK(ExistsDir(options_.output_path))
+      << "Global positioning trace output_path is not a directory: "
+      << options_.output_path;
+
+  RemoveTraceArtifactIfExists(options_.output_path / "manifest.json");
+  RemoveTraceArtifactIfExists(options_.output_path / "events.jsonl");
+  RemoveTraceArtifactIfExists(options_.output_path / "iteration_metrics.jsonl");
+  RemoveTraceArtifactIfExists(options_.output_path / "residual_blocks.jsonl");
+  RemoveTraceArtifactIfExists(options_.output_path / "residual_skips.jsonl");
+  RemoveTraceArtifactIfExists(options_.output_path / "snapshots");
+
+  run_id_ = MakeRunId(created_at_unix_ns_, options_.run_label);
+
+  events_stream_.open(options_.output_path / "events.jsonl",
+                      std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(events_stream_, options_.output_path / "events.jsonl");
+  iteration_metrics_stream_.open(
+      options_.output_path / "iteration_metrics.jsonl",
+      std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(iteration_metrics_stream_,
+                        options_.output_path / "iteration_metrics.jsonl");
+
+  if (IsResidualLedgerEnabled()) {
+    residual_blocks_stream_.open(options_.output_path / "residual_blocks.jsonl",
+                                 std::ios::out | std::ios::trunc);
+    THROW_CHECK_FILE_OPEN(residual_blocks_stream_,
+                          options_.output_path / "residual_blocks.jsonl");
+    residual_skips_stream_.open(options_.output_path / "residual_skips.jsonl",
+                                std::ios::out | std::ios::trunc);
+    THROW_CHECK_FILE_OPEN(residual_skips_stream_,
+                          options_.output_path / "residual_skips.jsonl");
+  }
+
+  if (IsParameterSnapshotsEnabled()) {
+    const std::filesystem::path snapshot_path =
+        options_.output_path / "snapshots";
+    THROW_CHECK(!ExistsFile(snapshot_path))
+        << "Global positioning snapshot path points to a file: "
+        << snapshot_path;
+    if (!ExistsDir(snapshot_path)) {
+      CreateDirIfNotExists(snapshot_path, /*recursive=*/true);
+    }
+    THROW_CHECK(ExistsDir(snapshot_path))
+        << "Global positioning snapshot path is not a directory: "
+        << snapshot_path;
+  }
+
+  WriteManifest("running");
+}
+
+bool GlobalPositioningTraceRecorder::IsResidualLedgerEnabled() const {
+  return IsResidualLedgerLevel(options_.level);
+}
+
+bool GlobalPositioningTraceRecorder::IsParameterSnapshotsEnabled() const {
+  return IsParameterSnapshotsLevel(options_.level);
+}
+
+std::string GlobalPositioningTraceRecorder::AllocateResidualId() {
+  std::ostringstream stream;
+  stream << "r" << std::setw(10) << std::setfill('0') << residual_sequence_++;
+  return stream.str();
+}
+
+void GlobalPositioningTraceRecorder::WriteEvent(
+    GlobalPositioningTraceRecord record) {
+  WriteRecord(events_stream_, std::move(record));
+}
+
+void GlobalPositioningTraceRecorder::WriteIteration(
+    const ceres::IterationSummary& summary) {
+  GlobalPositioningTraceRecord record;
+  record.event_type = "ceres_iteration";
+  record.stage = "ceres_solve";
+  record.iteration = summary.iteration;
+  record.attrs = {
+      {"step_is_successful",
+       GlobalPositioningTraceValue::Bool(summary.step_is_successful)},
+      {"cost", GlobalPositioningTraceValue::Double(summary.cost)},
+      {"cost_change", GlobalPositioningTraceValue::Double(summary.cost_change)},
+      {"gradient_max_norm",
+       GlobalPositioningTraceValue::Double(summary.gradient_max_norm)},
+      {"step_norm", GlobalPositioningTraceValue::Double(summary.step_norm)},
+      {"trust_region_radius",
+       GlobalPositioningTraceValue::Double(summary.trust_region_radius)},
+      {"linear_solver_iterations",
+       GlobalPositioningTraceValue::Int(summary.linear_solver_iterations)},
+      {"iteration_time_sec",
+       GlobalPositioningTraceValue::Double(summary.iteration_time_in_seconds)},
+      {"cumulative_time_sec",
+       GlobalPositioningTraceValue::Double(summary.cumulative_time_in_seconds)},
+  };
+  WriteRecord(iteration_metrics_stream_, std::move(record));
+}
+
+void GlobalPositioningTraceRecorder::WriteResidualBlock(
+    GlobalPositioningTraceRecord record) {
+  if (!IsResidualLedgerEnabled()) {
+    return;
+  }
+  if (record.event_type.empty()) {
+    record.event_type = "residual_added";
+  }
+  if (record.stage.empty()) {
+    record.stage = "problem_build";
+  }
+  WriteRecord(residual_blocks_stream_, std::move(record));
+}
+
+void GlobalPositioningTraceRecorder::WriteResidualSkip(
+    GlobalPositioningTraceRecord record) {
+  if (!IsResidualLedgerEnabled()) {
+    return;
+  }
+  if (record.event_type.empty()) {
+    record.event_type = "residual_skipped";
+  }
+  if (record.stage.empty()) {
+    record.stage = "problem_build";
+  }
+  WriteRecord(residual_skips_stream_, std::move(record));
+}
+
+void GlobalPositioningTraceRecorder::WriteResidualBucketSummary(
+    GlobalPositioningTraceRecord record) {
+  if (!IsResidualLedgerEnabled()) {
+    return;
+  }
+  if (record.event_type.empty()) {
+    record.event_type = "residual_bucket_summary";
+  }
+  if (record.stage.empty()) {
+    record.stage = "problem_build";
+  }
+  WriteEvent(std::move(record));
+}
+
+void GlobalPositioningTraceRecorder::WriteParameterSnapshot(
+    const GlobalPositioningTraceParameterSnapshot& snapshot) {
+  if (!IsParameterSnapshotsEnabled()) {
+    return;
+  }
+
+  THROW_CHECK_GE(snapshot.iteration, 0)
+      << "Global positioning snapshot iteration must be non-negative.";
+  THROW_CHECK_EQ(sizeof(double), 8)
+      << "Global positioning snapshots require 64-bit doubles.";
+  THROW_CHECK(std::numeric_limits<double>::is_iec559)
+      << "Global positioning snapshots require IEEE-754 doubles.";
+  THROW_CHECK(IsLittleEndian())
+      << "Global positioning snapshot binaries are defined as little-endian.";
+
+  ValidateSnapshotArray("frame_centers", snapshot.frame_centers);
+  ValidateSnapshotArray("points3D", snapshot.points3D);
+  ValidateSnapshotArray("scales", snapshot.scales);
+  if (snapshot.dmap_scales.has_value()) {
+    ValidateSnapshotArray("dmap_scales", *snapshot.dmap_scales);
+  }
+  if (snapshot.cams_in_rig.has_value()) {
+    ValidateSnapshotArray("cams_in_rig", *snapshot.cams_in_rig);
+  }
+
+  const std::filesystem::path snapshot_path =
+      options_.output_path / "snapshots";
+  const std::string prefix = IterationPrefix(snapshot.iteration);
+  const std::filesystem::path metadata_path =
+      snapshot_path / (prefix + ".json");
+  const std::string frame_centers_filename = prefix + "_frame_centers_f64.bin";
+  const std::string points3D_filename = prefix + "_points3D_f64.bin";
+  const std::string scales_filename = prefix + "_scales_f64.bin";
+
+  WriteSnapshotSidecar(snapshot_path / frame_centers_filename,
+                       snapshot.frame_centers);
+  WriteSnapshotSidecar(snapshot_path / points3D_filename, snapshot.points3D);
+  WriteSnapshotSidecar(snapshot_path / scales_filename, snapshot.scales);
+
+  std::optional<std::string> dmap_scales_filename;
+  if (snapshot.dmap_scales.has_value()) {
+    dmap_scales_filename = prefix + "_dmap_scales_f64.bin";
+    WriteSnapshotSidecar(snapshot_path / *dmap_scales_filename,
+                         *snapshot.dmap_scales);
+  }
+
+  std::optional<std::string> cams_in_rig_filename;
+  if (snapshot.cams_in_rig.has_value()) {
+    cams_in_rig_filename = prefix + "_cams_in_rig_f64.bin";
+    WriteSnapshotSidecar(snapshot_path / *cams_in_rig_filename,
+                         *snapshot.cams_in_rig);
+  }
+
+  std::ofstream metadata_stream(metadata_path, std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(metadata_stream, metadata_path);
+  metadata_stream << "{\n"
+                  << "  \"schema_version\": " << kSchemaVersion << ",\n"
+                  << "  \"run_id\": " << JsonEscape(run_id_) << ",\n"
+                  << "  \"iteration\": " << snapshot.iteration << ",\n"
+                  << "  \"dtype\": \"float64\",\n"
+                  << "  \"byte_order\": \"little_endian\",\n"
+                  << "  \"coordinate_convention\": "
+                  << JsonEscape(
+                         "frame_centers are world-frame camera centers, not "
+                         "cam_from_world.translation")
+                  << ",\n"
+                  << "  \"frame_ids\": "
+                  << JsonUInt64Array(snapshot.frame_centers.ids) << ",\n"
+                  << "  \"frame_centers_world_shape\": "
+                  << JsonSizeArray(snapshot.frame_centers.shape) << ",\n"
+                  << "  \"point3D_ids\": "
+                  << JsonUInt64Array(snapshot.points3D.ids) << ",\n"
+                  << "  \"points3D_world_shape\": "
+                  << JsonSizeArray(snapshot.points3D.shape) << ",\n"
+                  << "  \"bata_residual_ids\": [],\n"
+                  << "  \"bata_scale_ids\": "
+                  << JsonUInt64Array(snapshot.scales.ids) << ",\n"
+                  << "  \"bata_scales_shape\": "
+                  << JsonSizeArray(snapshot.scales.shape) << ",\n"
+                  << "  \"dmap_image_ids\": "
+                  << JsonUInt64Array(snapshot.dmap_scales.has_value()
+                                         ? snapshot.dmap_scales->ids
+                                         : std::vector<uint64_t>{})
+                  << ",\n"
+                  << "  \"dmap_scales_stored_shape\": "
+                  << JsonSizeArray(snapshot.dmap_scales.has_value()
+                                       ? snapshot.dmap_scales->shape
+                                       : std::vector<size_t>{0})
+                  << ",\n"
+                  << "  \"coordinate_conventions\": {\n"
+                  << "    \"frame_centers\": "
+                  << JsonEscape(
+                         "world-frame camera centers; not "
+                         "cam_from_world.translation")
+                  << ",\n"
+                  << "    \"points3D\": " << JsonEscape("world-frame 3D points")
+                  << ",\n"
+                  << "    \"cams_in_rig\": "
+                  << JsonEscape("camera offsets in rig frame") << "\n"
+                  << "  },\n"
+                  << "  \"artifacts\": {\n";
+  WriteSnapshotArtifactMetadata(metadata_stream,
+                                "frame_centers",
+                                snapshot.frame_centers,
+                                frame_centers_filename);
+  metadata_stream << ",\n";
+  WriteSnapshotArtifactMetadata(
+      metadata_stream, "points3D", snapshot.points3D, points3D_filename);
+  metadata_stream << ",\n";
+  WriteSnapshotArtifactMetadata(
+      metadata_stream, "scales", snapshot.scales, scales_filename);
+  if (snapshot.dmap_scales.has_value()) {
+    metadata_stream << ",\n";
+    WriteSnapshotArtifactMetadata(metadata_stream,
+                                  "dmap_scales",
+                                  *snapshot.dmap_scales,
+                                  *dmap_scales_filename);
+  }
+  if (snapshot.cams_in_rig.has_value()) {
+    metadata_stream << ",\n";
+    WriteSnapshotArtifactMetadata(metadata_stream,
+                                  "cams_in_rig",
+                                  *snapshot.cams_in_rig,
+                                  *cams_in_rig_filename);
+  }
+  metadata_stream << "\n"
+                  << "  }\n"
+                  << "}\n";
+  metadata_stream.flush();
+}
+
+void GlobalPositioningTraceRecorder::MarkFinished(std::string status) {
+  WriteManifest(status);
+}
+
+void GlobalPositioningTraceRecorder::WriteRecord(
+    std::ofstream& stream, GlobalPositioningTraceRecord record) {
+  stream << "{\"schema_version\":" << kSchemaVersion
+         << ",\"run_id\":" << JsonEscape(run_id_) << ",\"seq\":" << sequence_++
+         << ",\"event_type\":" << JsonEscape(record.event_type)
+         << ",\"stage\":" << JsonEscape(record.stage) << ",\"iteration\":";
+  if (record.iteration.has_value()) {
+    stream << *record.iteration;
+  } else {
+    stream << "null";
+  }
+  stream << ",\"timestamp_ns\":" << SteadyNowNs()
+         << ",\"attrs\":" << JsonAttrs(record.attrs) << "}\n";
+  stream.flush();
+}
+
+void GlobalPositioningTraceRecorder::WriteManifest(const std::string& status) {
+  std::ofstream manifest_stream(options_.output_path / "manifest.json",
+                                std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(manifest_stream,
+                        options_.output_path / "manifest.json");
+  manifest_stream << "{\n"
+                  << "  \"schema_version\": " << kSchemaVersion << ",\n"
+                  << "  \"run_id\": " << JsonEscape(run_id_) << ",\n"
+                  << "  \"run_label\": " << JsonEscape(options_.run_label)
+                  << ",\n"
+                  << "  \"status\": " << JsonEscape(status) << ",\n"
+                  << "  \"trace_level\": "
+                  << JsonEscape(
+                         GlobalPositioningTraceLevelToString(options_.level))
+                  << ",\n"
+                  << "  \"created_at_unix_ns\": " << created_at_unix_ns_
+                  << ",\n"
+                  << "  \"non_finite_numeric_values\": \"strings\",\n"
+                  << "  \"options\": {\n"
+                  << "    \"snapshot_every_n_iterations\": "
+                  << options_.snapshot_every_n_iterations << ",\n"
+                  << "    \"max_snapshotted_points\": "
+                  << options_.max_snapshotted_points << "\n"
+                  << "  }\n"
+                  << "}\n";
+  manifest_stream.flush();
+}
+
+}  // namespace colmap

--- a/src/colmap/estimators/global_positioning_trace.cc
+++ b/src/colmap/estimators/global_positioning_trace.cc
@@ -372,13 +372,21 @@ void WriteSnapshotArtifactMetadata(
 void WriteResidualValueArtifactMetadata(std::ostream& stream,
                                         const std::string& name,
                                         const std::string& filename,
-                                        const size_t element_count) {
+                                        const std::vector<size_t>& shape) {
   stream << "    " << JsonEscape(name) << ": {\n"
          << "      \"file\": " << JsonEscape(filename) << ",\n"
          << "      \"dtype\": \"float64\",\n"
          << "      \"byte_order\": \"little_endian\",\n"
-         << "      \"shape\": [" << element_count << "]\n"
+         << "      \"shape\": " << JsonSizeArray(shape) << "\n"
          << "    }";
+}
+
+void WriteResidualValueArtifactMetadata(std::ostream& stream,
+                                        const std::string& name,
+                                        const std::string& filename,
+                                        const size_t element_count) {
+  WriteResidualValueArtifactMetadata(
+      stream, name, filename, std::vector<size_t>{element_count});
 }
 
 size_t ValidateResidualValues(
@@ -397,6 +405,10 @@ size_t ValidateResidualValues(
       << "Residual value raw_costs count must match residual_ids count.";
   THROW_CHECK_EQ(residual_values.robust_costs.size(), num_residual_blocks)
       << "Residual value robust_costs count must match residual_ids count.";
+  THROW_CHECK_EQ(residual_values.loss_rho_values.size(),
+                 num_residual_blocks * 3)
+      << "Residual value loss_rho_values count must be three per residual "
+         "block.";
 
   size_t total_scalar_residuals = 0;
   for (size_t i = 0; i < num_residual_blocks; ++i) {
@@ -905,6 +917,8 @@ void GlobalPositioningTraceRecorder::WriteResidualValues(
   const std::string raw_residuals_filename = prefix + "_raw_residuals_f64.bin";
   const std::string raw_costs_filename = prefix + "_raw_costs_f64.bin";
   const std::string robust_costs_filename = prefix + "_robust_costs_f64.bin";
+  const std::string loss_rho_values_filename =
+      prefix + "_loss_rho_values_f64.bin";
   const std::string raw_jacobians_filename = prefix + "_raw_jacobians_f64.bin";
 
   WriteDoubleSidecar(residual_values_path / raw_residuals_filename,
@@ -913,6 +927,8 @@ void GlobalPositioningTraceRecorder::WriteResidualValues(
                      residual_values.raw_costs);
   WriteDoubleSidecar(residual_values_path / robust_costs_filename,
                      residual_values.robust_costs);
+  WriteDoubleSidecar(residual_values_path / loss_rho_values_filename,
+                     residual_values.loss_rho_values);
   if (residual_values.has_raw_jacobians) {
     WriteDoubleSidecar(residual_values_path / raw_jacobians_filename,
                        residual_values.raw_jacobians);
@@ -944,7 +960,9 @@ void GlobalPositioningTraceRecorder::WriteResidualValues(
                   << "  \"residual_offsets\": "
                   << JsonSizeArray(residual_values.residual_offsets) << ",\n"
                   << "  \"evaluation_success\": "
-                  << JsonBoolArray(residual_values.evaluation_success) << ",\n";
+                  << JsonBoolArray(residual_values.evaluation_success) << ",\n"
+                  << "  \"loss_rho_layout\": "
+                  << JsonEscape("residual_block_major/rho0_rho1_rho2") << ",\n";
   if (residual_values.has_raw_jacobians) {
     metadata_stream
         << "  \"parameter_block_sizes\": "
@@ -985,6 +1003,11 @@ void GlobalPositioningTraceRecorder::WriteResidualValues(
                                      "robust_costs",
                                      robust_costs_filename,
                                      num_residual_blocks);
+  metadata_stream << ",\n";
+  WriteResidualValueArtifactMetadata(metadata_stream,
+                                     "loss_rho_values",
+                                     loss_rho_values_filename,
+                                     {num_residual_blocks, 3});
   if (residual_values.has_raw_jacobians) {
     metadata_stream << ",\n";
     WriteResidualValueArtifactMetadata(metadata_stream,

--- a/src/colmap/estimators/global_positioning_trace.cc
+++ b/src/colmap/estimators/global_positioning_trace.cc
@@ -19,8 +19,11 @@ namespace colmap {
 namespace {
 
 constexpr int kSchemaVersion = 1;
+constexpr int kRawBinaryResidualLedgerSchemaVersion = 2;
+constexpr int kRawBinaryResidualPointIndexSchemaVersion = 2;
 constexpr char kRawBinaryStorageFormat[] = "global_positioning_raw_binary_v1";
 constexpr char kRawBinaryLedgerMagic[] = "GPTRLGR1";
+constexpr char kRawBinaryResidualPointIndexMagic[] = "GPTRIDX1";
 constexpr char kRawBinaryArrayMagic[] = "GPTRARR1";
 constexpr char kRawBinaryResidualValuesMagic[] = "GPTRRSV1";
 constexpr int64_t kRawBinaryNoneId = -1;
@@ -535,6 +538,161 @@ void WriteRawParameterBlockDescriptor(
   WriteRawLittleEndian<uint64_t>(stream, descriptor.id, path);
 }
 
+void WriteRawLedgerParameterBlockDescriptor(
+    std::ofstream& stream,
+    const GlobalPositioningTraceParameterBlockDescriptor& descriptor,
+    const std::filesystem::path& path) {
+  WriteRawParameterBlockDescriptor(stream, descriptor, path);
+  WriteRawBool(stream, descriptor.size.has_value(), path);
+  if (descriptor.size.has_value()) {
+    WriteRawLittleEndian<uint64_t>(
+        stream, static_cast<uint64_t>(*descriptor.size), path);
+  }
+}
+
+void WriteRawOptionalDouble(std::ofstream& stream,
+                            const std::optional<double>& value,
+                            const std::filesystem::path& path) {
+  WriteRawBool(stream, value.has_value(), path);
+  if (value.has_value()) {
+    WriteRawLittleEndian<double>(stream, *value, path);
+  }
+}
+
+void WriteRawOptionalBool(std::ofstream& stream,
+                          const std::optional<bool>& value,
+                          const std::filesystem::path& path) {
+  WriteRawBool(stream, value.has_value(), path);
+  if (value.has_value()) {
+    WriteRawBool(stream, *value, path);
+  }
+}
+
+void WriteRawOptionalString(std::ofstream& stream,
+                            const std::optional<std::string>& value,
+                            const std::filesystem::path& path) {
+  WriteRawBool(stream, value.has_value(), path);
+  if (value.has_value()) {
+    WriteRawString(stream, *value, path);
+  }
+}
+
+void WriteRawOptionalDoubleArray(
+    std::ofstream& stream,
+    const std::optional<std::vector<double>>& value,
+    const std::filesystem::path& path) {
+  WriteRawBool(stream, value.has_value(), path);
+  if (!value.has_value()) {
+    return;
+  }
+  THROW_CHECK_LE(value->size(), std::numeric_limits<uint32_t>::max())
+      << "Raw binary trace arrays are length-prefixed with uint32.";
+  WriteRawLittleEndian<uint32_t>(
+      stream, static_cast<uint32_t>(value->size()), path);
+  for (const double item : *value) {
+    WriteRawLittleEndian<double>(stream, item, path);
+  }
+}
+
+void WriteRawLossConfig(std::ofstream& stream,
+                        const GlobalPositioningTraceLossConfig& value,
+                        const std::filesystem::path& path) {
+  WriteRawString(stream, value.bucket, path);
+  WriteRawString(stream, value.type, path);
+  WriteRawOptionalDouble(stream, value.scale, path);
+  WriteRawOptionalDouble(stream, value.weight, path);
+  WriteRawString(stream, value.source, path);
+  WriteRawOptionalDouble(stream, value.observation_count_weight, path);
+}
+
+void WriteRawFixedParameters(std::ofstream& stream,
+                             const GlobalPositioningTraceFixedParameters& value,
+                             const std::filesystem::path& path) {
+  WriteRawOptionalDoubleArray(stream, value.cam_from_point3D_dir, path);
+  WriteRawOptionalDoubleArray(
+      stream, value.keypoint_covariance_world_row_major, path);
+  WriteRawOptionalDoubleArray(stream, value.cam_from_rig_dir, path);
+  WriteRawOptionalDoubleArray(stream, value.rig_from_world_rotation_wxyz, path);
+  WriteRawOptionalDoubleArray(stream, value.world_from_rig_rotation_wxyz, path);
+  WriteRawOptionalDoubleArray(stream, value.camera_rotation_wxyz, path);
+  WriteRawOptionalBool(stream, value.metric_depth_use_log_scale, path);
+  WriteRawOptionalString(stream, value.metric_depth_residual_type, path);
+  WriteRawOptionalBool(stream, value.metric_depth_zero_residual_behind, path);
+  WriteRawOptionalDouble(stream, value.metric_depth_log_linear_threshold, path);
+  WriteRawOptionalDouble(stream, value.scale_prior_target, path);
+  WriteRawOptionalDouble(stream, value.scale_prior_stddev, path);
+}
+
+void WriteRawTraceValue(std::ofstream& stream,
+                        const GlobalPositioningTraceValue& value,
+                        const std::filesystem::path& path) {
+  using Type = GlobalPositioningTraceValue::Type;
+  WriteRawLittleEndian<uint8_t>(stream, static_cast<uint8_t>(value.type), path);
+  switch (value.type) {
+    case Type::kNull:
+      return;
+    case Type::kBool:
+      WriteRawBool(stream, value.bool_value, path);
+      return;
+    case Type::kInt:
+      WriteRawLittleEndian<int64_t>(stream, value.int_value, path);
+      return;
+    case Type::kUInt:
+      WriteRawLittleEndian<uint64_t>(stream, value.uint_value, path);
+      return;
+    case Type::kDouble:
+      WriteRawLittleEndian<double>(stream, value.double_value, path);
+      return;
+    case Type::kString:
+      WriteRawString(stream, value.string_value, path);
+      return;
+    case Type::kStringArray:
+      THROW_CHECK_LE(value.string_array_value.size(),
+                     std::numeric_limits<uint32_t>::max())
+          << "Raw binary trace string arrays are length-prefixed with uint32.";
+      WriteRawLittleEndian<uint32_t>(
+          stream, static_cast<uint32_t>(value.string_array_value.size()), path);
+      for (const std::string& item : value.string_array_value) {
+        WriteRawString(stream, item, path);
+      }
+      return;
+    case Type::kParameterBlockArray:
+      THROW_CHECK_LE(value.parameter_block_array_value.size(),
+                     std::numeric_limits<uint32_t>::max())
+          << "Raw binary trace parameter block arrays are length-prefixed with "
+             "uint32.";
+      WriteRawLittleEndian<uint32_t>(
+          stream,
+          static_cast<uint32_t>(value.parameter_block_array_value.size()),
+          path);
+      for (const GlobalPositioningTraceParameterBlockDescriptor& descriptor :
+           value.parameter_block_array_value) {
+        WriteRawLedgerParameterBlockDescriptor(stream, descriptor, path);
+      }
+      return;
+    case Type::kLossConfig:
+      WriteRawLossConfig(stream, value.loss_config_value, path);
+      return;
+    case Type::kFixedParameters:
+      WriteRawFixedParameters(stream, value.fixed_parameters_value, path);
+      return;
+  }
+}
+
+void WriteRawTraceAttrs(
+    std::ofstream& stream,
+    const std::map<std::string, GlobalPositioningTraceValue>& attrs,
+    const std::filesystem::path& path) {
+  THROW_CHECK_LE(attrs.size(), std::numeric_limits<uint32_t>::max())
+      << "Raw binary trace attrs are length-prefixed with uint32.";
+  WriteRawLittleEndian<uint32_t>(
+      stream, static_cast<uint32_t>(attrs.size()), path);
+  for (const auto& [key, value] : attrs) {
+    WriteRawString(stream, key, path);
+    WriteRawTraceValue(stream, value, path);
+  }
+}
+
 std::string TraceAttrString(
     const std::map<std::string, GlobalPositioningTraceValue>& attrs,
     const std::string& key) {
@@ -930,14 +1088,17 @@ GlobalPositioningTraceRecorder::GlobalPositioningTraceRecorder(
                         options_.output_path / "iteration_metrics.jsonl");
 
   if (IsResidualLedgerEnabled()) {
-    residual_blocks_stream_.open(options_.output_path / "residual_blocks.jsonl",
-                                 std::ios::out | std::ios::trunc);
-    THROW_CHECK_FILE_OPEN(residual_blocks_stream_,
-                          options_.output_path / "residual_blocks.jsonl");
-    residual_skips_stream_.open(options_.output_path / "residual_skips.jsonl",
-                                std::ios::out | std::ios::trunc);
-    THROW_CHECK_FILE_OPEN(residual_skips_stream_,
-                          options_.output_path / "residual_skips.jsonl");
+    if (options_.write_legacy_jsonl) {
+      residual_blocks_stream_.open(
+          options_.output_path / "residual_blocks.jsonl",
+          std::ios::out | std::ios::trunc);
+      THROW_CHECK_FILE_OPEN(residual_blocks_stream_,
+                            options_.output_path / "residual_blocks.jsonl");
+      residual_skips_stream_.open(options_.output_path / "residual_skips.jsonl",
+                                  std::ios::out | std::ios::trunc);
+      THROW_CHECK_FILE_OPEN(residual_skips_stream_,
+                            options_.output_path / "residual_skips.jsonl");
+    }
 
     const std::filesystem::path raw_binary_static_path =
         RawBinaryStaticPath(options_);
@@ -1055,7 +1216,9 @@ void GlobalPositioningTraceRecorder::WriteResidualBlock(
     record.stage = "problem_build";
   }
   WriteRawBinaryResidualBlock(record);
-  WriteRecord(residual_blocks_stream_, std::move(record));
+  if (residual_blocks_stream_.is_open()) {
+    WriteRecord(residual_blocks_stream_, std::move(record));
+  }
 }
 
 void GlobalPositioningTraceRecorder::WriteResidualSkip(
@@ -1069,7 +1232,9 @@ void GlobalPositioningTraceRecorder::WriteResidualSkip(
   if (record.stage.empty()) {
     record.stage = "problem_build";
   }
-  WriteRecord(residual_skips_stream_, std::move(record));
+  if (residual_skips_stream_.is_open()) {
+    WriteRecord(residual_skips_stream_, std::move(record));
+  }
 }
 
 void GlobalPositioningTraceRecorder::WriteResidualBucketSummary(
@@ -1390,8 +1555,9 @@ void GlobalPositioningTraceRecorder::WriteRawBinaryResidualLedgerHeader() {
   raw_binary_residual_ledger_stream_.seekp(0, std::ios::beg);
   WriteRawBytes(
       raw_binary_residual_ledger_stream_, kRawBinaryLedgerMagic, 8, path);
-  WriteRawLittleEndian<uint32_t>(
-      raw_binary_residual_ledger_stream_, kSchemaVersion, path);
+  WriteRawLittleEndian<uint32_t>(raw_binary_residual_ledger_stream_,
+                                 kRawBinaryResidualLedgerSchemaVersion,
+                                 path);
   WriteRawLittleEndian<uint64_t>(raw_binary_residual_ledger_stream_,
                                  raw_binary_residual_ledger_count_,
                                  path);
@@ -1414,6 +1580,13 @@ void GlobalPositioningTraceRecorder::WriteRawBinaryResidualBlock(
   const std::filesystem::path path =
       RawBinaryStaticPath(options_) / "residual_ledger.bin";
   raw_binary_residual_ledger_stream_.seekp(0, std::ios::end);
+  const std::streampos residual_offset_pos =
+      raw_binary_residual_ledger_stream_.tellp();
+  THROW_CHECK(residual_offset_pos >= 0)
+      << "Could not get residual ledger offset for raw binary trace: " << path;
+  const uint64_t residual_offset = static_cast<uint64_t>(residual_offset_pos);
+  const int64_t frame_id = TraceAttrOptionalId(record.attrs, "frame_id");
+  const int64_t point3D_id = TraceAttrOptionalId(record.attrs, "point3D_id");
   WriteRawString(raw_binary_residual_ledger_stream_,
                  TraceAttrString(record.attrs, "residual_id"),
                  path);
@@ -1423,21 +1596,76 @@ void GlobalPositioningTraceRecorder::WriteRawBinaryResidualBlock(
   WriteRawString(raw_binary_residual_ledger_stream_,
                  TraceAttrString(record.attrs, "loss_bucket"),
                  path);
-  WriteRawLittleEndian<int64_t>(raw_binary_residual_ledger_stream_,
-                                TraceAttrOptionalId(record.attrs, "frame_id"),
-                                path);
+  WriteRawLittleEndian<int64_t>(
+      raw_binary_residual_ledger_stream_, frame_id, path);
   WriteRawLittleEndian<int64_t>(raw_binary_residual_ledger_stream_,
                                 TraceAttrOptionalId(record.attrs, "image_id"),
                                 path);
-  WriteRawLittleEndian<int64_t>(raw_binary_residual_ledger_stream_,
-                                TraceAttrOptionalId(record.attrs, "point3D_id"),
-                                path);
+  WriteRawLittleEndian<int64_t>(
+      raw_binary_residual_ledger_stream_, point3D_id, path);
   WriteRawBool(raw_binary_residual_ledger_stream_,
                TraceAttrBool(record.attrs, "is_lc_observation"),
                path);
-  WriteRawString(
-      raw_binary_residual_ledger_stream_, JsonAttrs(record.attrs), path);
+  WriteRawTraceAttrs(raw_binary_residual_ledger_stream_, record.attrs, path);
+  if (frame_id != kRawBinaryNoneId && point3D_id != kRawBinaryNoneId) {
+    GlobalPositioningRawBinaryResidualPointIndexEntry& index_entry =
+        raw_binary_residual_point_index_[static_cast<uint64_t>(point3D_id)];
+    if (index_entry.residual_ledger_offsets.empty()) {
+      index_entry.min_frame_id = frame_id;
+      index_entry.max_frame_id = frame_id;
+    } else {
+      index_entry.min_frame_id = std::min(index_entry.min_frame_id, frame_id);
+      index_entry.max_frame_id = std::max(index_entry.max_frame_id, frame_id);
+    }
+    index_entry.residual_ledger_offsets.push_back(residual_offset);
+  }
   ++raw_binary_residual_ledger_count_;
+}
+
+void GlobalPositioningTraceRecorder::WriteRawBinaryResidualPointIndex() {
+  if (!IsResidualLedgerEnabled()) {
+    return;
+  }
+  const std::filesystem::path path =
+      RawBinaryStaticPath(options_) / "residual_point_index.bin";
+  const std::filesystem::path ledger_path =
+      RawBinaryStaticPath(options_) / "residual_ledger.bin";
+  raw_binary_residual_ledger_stream_.flush();
+  std::error_code file_size_error;
+  const uintmax_t ledger_size =
+      std::filesystem::file_size(ledger_path, file_size_error);
+  THROW_CHECK(!file_size_error)
+      << "Could not stat raw binary residual ledger " << ledger_path << ": "
+      << file_size_error.message();
+  std::ofstream stream(path,
+                       std::ios::binary | std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(stream, path);
+  WriteRawBytes(stream, kRawBinaryResidualPointIndexMagic, 8, path);
+  WriteRawLittleEndian<uint32_t>(
+      stream, kRawBinaryResidualPointIndexSchemaVersion, path);
+  WriteRawLittleEndian<uint64_t>(
+      stream,
+      static_cast<uint64_t>(raw_binary_residual_point_index_.size()),
+      path);
+  WriteRawLittleEndian<uint32_t>(
+      stream, kRawBinaryResidualLedgerSchemaVersion, path);
+  WriteRawLittleEndian<uint64_t>(
+      stream, raw_binary_residual_ledger_count_, path);
+  WriteRawLittleEndian<uint64_t>(
+      stream, static_cast<uint64_t>(ledger_size), path);
+  for (const auto& [point3D_id, index_entry] :
+       raw_binary_residual_point_index_) {
+    WriteRawLittleEndian<uint64_t>(stream, point3D_id, path);
+    WriteRawLittleEndian<int64_t>(stream, index_entry.min_frame_id, path);
+    WriteRawLittleEndian<int64_t>(stream, index_entry.max_frame_id, path);
+    WriteRawLittleEndian<uint64_t>(
+        stream,
+        static_cast<uint64_t>(index_entry.residual_ledger_offsets.size()),
+        path);
+    for (const uint64_t offset : index_entry.residual_ledger_offsets) {
+      WriteRawLittleEndian<uint64_t>(stream, offset, path);
+    }
+  }
 }
 
 void GlobalPositioningTraceRecorder::WriteRawBinaryParameterSnapshot(
@@ -1623,8 +1851,8 @@ void GlobalPositioningTraceRecorder::WriteManifest(const std::string& status) {
                   << "  \"options\": {\n"
                   << "    \"snapshot_every_n_iterations\": "
                   << options_.snapshot_every_n_iterations << ",\n"
-                  << "    \"max_snapshotted_points\": "
-                  << options_.max_snapshotted_points << "\n"
+                  << "    \"write_legacy_jsonl\": "
+                  << (options_.write_legacy_jsonl ? "true" : "false") << "\n"
                   << "  }\n"
                   << "}\n";
   manifest_stream.flush();
@@ -1637,6 +1865,7 @@ void GlobalPositioningTraceRecorder::WriteRawBinaryManifest(
     return;
   }
   UpdateRawBinaryResidualLedgerHeader();
+  WriteRawBinaryResidualPointIndex();
   const std::filesystem::path raw_binary_path = RawBinaryPath(options_);
   CreateDirIfNotExists(raw_binary_path, /*recursive=*/true);
   const std::filesystem::path manifest_path = raw_binary_path / "manifest.json";
@@ -1655,9 +1884,17 @@ void GlobalPositioningTraceRecorder::WriteRawBinaryManifest(
       << ",\n"
       << "  \"byte_order\": \"little_endian\",\n"
       << "  \"dtype\": \"float64\",\n"
+      << "  \"options\": {\n"
+      << "    \"snapshot_every_n_iterations\": "
+      << options_.snapshot_every_n_iterations << ",\n"
+      << "    \"write_legacy_jsonl\": "
+      << (options_.write_legacy_jsonl ? "true" : "false") << "\n"
+      << "  },\n"
       << "  \"static\": {\n"
       << "    \"residual_ledger\": " << JsonEscape("static/residual_ledger.bin")
-      << "\n"
+      << ",\n"
+      << "    \"residual_point_index\": "
+      << JsonEscape("static/residual_point_index.bin") << "\n"
       << "  },\n"
       << "  \"iterations\": [\n";
   bool first = true;

--- a/src/colmap/estimators/global_positioning_trace.cc
+++ b/src/colmap/estimators/global_positioning_trace.cc
@@ -155,6 +155,11 @@ bool IsResidualValuesLevel(const GlobalPositioningTraceLevel level) {
          static_cast<int>(GlobalPositioningTraceLevel::kResidualValues);
 }
 
+bool IsResidualJacobiansLevel(const GlobalPositioningTraceLevel level) {
+  return static_cast<int>(level) >=
+         static_cast<int>(GlobalPositioningTraceLevel::kResidualJacobians);
+}
+
 std::string IterationPrefix(const int iteration) {
   std::ostringstream stream;
   stream << "iter_" << std::setw(6) << std::setfill('0') << iteration;
@@ -190,6 +195,99 @@ std::string JsonSizeArray(const std::vector<size_t>& values) {
       stream << ",";
     }
     stream << values[i];
+  }
+  stream << "]";
+  return stream.str();
+}
+
+std::string JsonNestedSizeArray(
+    const std::vector<std::vector<size_t>>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << JsonSizeArray(values[i]);
+  }
+  stream << "]";
+  return stream.str();
+}
+
+std::string JsonNestedBoolArray(const std::vector<std::vector<bool>>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << "[";
+    for (size_t j = 0; j < values[i].size(); ++j) {
+      if (j > 0) {
+        stream << ",";
+      }
+      stream << (values[i][j] ? "true" : "false");
+    }
+    stream << "]";
+  }
+  stream << "]";
+  return stream.str();
+}
+
+std::string JsonDoubleArray(const std::vector<double>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << JsonDouble(values[i]);
+  }
+  stream << "]";
+  return stream.str();
+}
+
+std::string JsonNestedDoubleArray(
+    const std::vector<std::vector<std::vector<double>>>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << "[";
+    for (size_t j = 0; j < values[i].size(); ++j) {
+      if (j > 0) {
+        stream << ",";
+      }
+      stream << JsonDoubleArray(values[i][j]);
+    }
+    stream << "]";
+  }
+  stream << "]";
+  return stream.str();
+}
+
+std::string JsonParameterBlockDescriptors(
+    const std::vector<
+        std::vector<GlobalPositioningTraceParameterBlockDescriptor>>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << "[";
+    for (size_t j = 0; j < values[i].size(); ++j) {
+      if (j > 0) {
+        stream << ",";
+      }
+      stream << "{"
+             << "\"role\":" << JsonEscape(values[i][j].role) << ","
+             << "\"kind\":" << JsonEscape(values[i][j].kind) << ","
+             << "\"id\":" << values[i][j].id << "}";
+    }
+    stream << "]";
   }
   stream << "]";
   return stream.str();
@@ -311,6 +409,86 @@ size_t ValidateResidualValues(
   }
   THROW_CHECK_EQ(residual_values.raw_residuals.size(), total_scalar_residuals)
       << "Residual value raw_residuals count must match sum(residual_dims).";
+  if (residual_values.has_raw_jacobians) {
+    THROW_CHECK_EQ(residual_values.parameter_block_sizes.size(),
+                   num_residual_blocks)
+        << "Residual value parameter_block_sizes count must match "
+           "residual_ids count.";
+    THROW_CHECK_EQ(residual_values.raw_jacobian_offsets.size(),
+                   num_residual_blocks)
+        << "Residual value raw_jacobian_offsets count must match "
+           "residual_ids count.";
+    THROW_CHECK_EQ(residual_values.parameter_blocks.size(), num_residual_blocks)
+        << "Residual value parameter_blocks count must match residual_ids "
+           "count.";
+    THROW_CHECK_EQ(residual_values.parameter_block_is_constant.size(),
+                   num_residual_blocks)
+        << "Residual value parameter_block_is_constant count must match "
+           "residual_ids count.";
+    THROW_CHECK_EQ(residual_values.parameter_block_lower_bounds.size(),
+                   num_residual_blocks)
+        << "Residual value parameter_block_lower_bounds count must match "
+           "residual_ids count.";
+    size_t total_jacobian_scalars = 0;
+    for (size_t i = 0; i < num_residual_blocks; ++i) {
+      THROW_CHECK_EQ(residual_values.raw_jacobian_offsets[i].size(),
+                     residual_values.parameter_block_sizes[i].size())
+          << "Residual value raw_jacobian_offsets inner count must match "
+             "parameter_block_sizes inner count.";
+      THROW_CHECK_EQ(residual_values.parameter_blocks[i].size(),
+                     residual_values.parameter_block_sizes[i].size())
+          << "Residual value parameter_blocks inner count must match "
+             "parameter_block_sizes inner count.";
+      THROW_CHECK_EQ(residual_values.parameter_block_is_constant[i].size(),
+                     residual_values.parameter_block_sizes[i].size())
+          << "Residual value parameter_block_is_constant inner count must "
+             "match parameter_block_sizes inner count.";
+      THROW_CHECK_EQ(residual_values.parameter_block_lower_bounds[i].size(),
+                     residual_values.parameter_block_sizes[i].size())
+          << "Residual value parameter_block_lower_bounds inner count must "
+             "match parameter_block_sizes inner count.";
+      for (size_t block_idx = 0;
+           block_idx < residual_values.parameter_block_sizes[i].size();
+           ++block_idx) {
+        THROW_CHECK(
+            !residual_values.parameter_blocks[i][block_idx].role.empty())
+            << "Residual value parameter block role must be non-empty.";
+        THROW_CHECK(
+            !residual_values.parameter_blocks[i][block_idx].kind.empty())
+            << "Residual value parameter block kind must be non-empty.";
+        THROW_CHECK_EQ(
+            residual_values.parameter_block_lower_bounds[i][block_idx].size(),
+            residual_values.parameter_block_sizes[i][block_idx])
+            << "Residual value parameter_block_lower_bounds block shape must "
+               "match parameter_block_sizes.";
+        THROW_CHECK_EQ(residual_values.raw_jacobian_offsets[i][block_idx],
+                       total_jacobian_scalars)
+            << "Residual value raw_jacobian_offsets must be contiguous "
+               "cumulative offsets.";
+        total_jacobian_scalars +=
+            residual_values.residual_dims[i] *
+            residual_values.parameter_block_sizes[i][block_idx];
+      }
+    }
+    THROW_CHECK_EQ(residual_values.raw_jacobians.size(), total_jacobian_scalars)
+        << "Residual value raw_jacobians count must match residual_dims times "
+           "parameter_block_sizes.";
+  } else {
+    THROW_CHECK(residual_values.parameter_block_sizes.empty())
+        << "Residual value parameter_block_sizes require has_raw_jacobians.";
+    THROW_CHECK(residual_values.raw_jacobian_offsets.empty())
+        << "Residual value raw_jacobian_offsets require has_raw_jacobians.";
+    THROW_CHECK(residual_values.parameter_blocks.empty())
+        << "Residual value parameter_blocks require has_raw_jacobians.";
+    THROW_CHECK(residual_values.parameter_block_is_constant.empty())
+        << "Residual value parameter_block_is_constant require "
+           "has_raw_jacobians.";
+    THROW_CHECK(residual_values.parameter_block_lower_bounds.empty())
+        << "Residual value parameter_block_lower_bounds require "
+           "has_raw_jacobians.";
+    THROW_CHECK(residual_values.raw_jacobians.empty())
+        << "Residual value raw_jacobians require has_raw_jacobians.";
+  }
   return total_scalar_residuals;
 }
 
@@ -337,6 +515,8 @@ std::string GlobalPositioningTraceLevelToString(
       return "parameter_snapshots";
     case GlobalPositioningTraceLevel::kResidualValues:
       return "residual_values";
+    case GlobalPositioningTraceLevel::kResidualJacobians:
+      return "residual_jacobians";
   }
   return "unknown";
 }
@@ -481,6 +661,10 @@ bool GlobalPositioningTraceRecorder::IsParameterSnapshotsEnabled() const {
 
 bool GlobalPositioningTraceRecorder::IsResidualValuesEnabled() const {
   return IsResidualValuesLevel(options_.level);
+}
+
+bool GlobalPositioningTraceRecorder::IsResidualJacobiansEnabled() const {
+  return IsResidualJacobiansLevel(options_.level);
 }
 
 std::string GlobalPositioningTraceRecorder::AllocateResidualId() {
@@ -721,6 +905,7 @@ void GlobalPositioningTraceRecorder::WriteResidualValues(
   const std::string raw_residuals_filename = prefix + "_raw_residuals_f64.bin";
   const std::string raw_costs_filename = prefix + "_raw_costs_f64.bin";
   const std::string robust_costs_filename = prefix + "_robust_costs_f64.bin";
+  const std::string raw_jacobians_filename = prefix + "_raw_jacobians_f64.bin";
 
   WriteDoubleSidecar(residual_values_path / raw_residuals_filename,
                      residual_values.raw_residuals);
@@ -728,6 +913,10 @@ void GlobalPositioningTraceRecorder::WriteResidualValues(
                      residual_values.raw_costs);
   WriteDoubleSidecar(residual_values_path / robust_costs_filename,
                      residual_values.robust_costs);
+  if (residual_values.has_raw_jacobians) {
+    WriteDoubleSidecar(residual_values_path / raw_jacobians_filename,
+                       residual_values.raw_jacobians);
+  }
 
   std::ofstream metadata_stream(metadata_path, std::ios::out | std::ios::trunc);
   THROW_CHECK_FILE_OPEN(metadata_stream, metadata_path);
@@ -741,15 +930,49 @@ void GlobalPositioningTraceRecorder::WriteResidualValues(
                   << ",\n"
                   << "  \"total_scalar_residuals\": " << total_scalar_residuals
                   << ",\n"
-                  << "  \"residual_ids\": "
+                  << "  \"has_raw_jacobians\": "
+                  << (residual_values.has_raw_jacobians ? "true" : "false")
+                  << ",\n";
+  if (residual_values.has_raw_jacobians) {
+    metadata_stream << "  \"total_jacobian_scalars\": "
+                    << residual_values.raw_jacobians.size() << ",\n";
+  }
+  metadata_stream << "  \"residual_ids\": "
                   << JsonStringArray(residual_values.residual_ids) << ",\n"
                   << "  \"residual_dims\": "
                   << JsonSizeArray(residual_values.residual_dims) << ",\n"
                   << "  \"residual_offsets\": "
                   << JsonSizeArray(residual_values.residual_offsets) << ",\n"
                   << "  \"evaluation_success\": "
-                  << JsonBoolArray(residual_values.evaluation_success) << ",\n"
-                  << "  \"artifacts\": {\n";
+                  << JsonBoolArray(residual_values.evaluation_success) << ",\n";
+  if (residual_values.has_raw_jacobians) {
+    metadata_stream
+        << "  \"parameter_block_sizes\": "
+        << JsonNestedSizeArray(residual_values.parameter_block_sizes) << ",\n"
+        << "  \"raw_jacobian_offsets\": "
+        << JsonNestedSizeArray(residual_values.raw_jacobian_offsets) << ",\n"
+        << "  \"parameter_blocks\": "
+        << JsonParameterBlockDescriptors(residual_values.parameter_blocks)
+        << ",\n"
+        << "  \"parameter_block_is_constant\": "
+        << JsonNestedBoolArray(residual_values.parameter_block_is_constant)
+        << ",\n"
+        << "  \"parameter_block_lower_bounds\": "
+        << JsonNestedDoubleArray(residual_values.parameter_block_lower_bounds)
+        << ",\n"
+        << "  \"raw_jacobian_layout\": "
+        << JsonEscape(
+               "residual_block_major/parameter_block_major/"
+               "row_major")
+        << ",\n"
+        << "  \"jacobian_domain\": "
+        << JsonEscape("raw_cost_function_ambient_parameters") << ",\n"
+        << "  \"loss_applied_to_jacobians\": false,\n"
+        << "  \"manifold_applied_to_jacobians\": false,\n"
+        << "  \"constant_parameter_blocks_included\": true"
+        << ",\n";
+  }
+  metadata_stream << "  \"artifacts\": {\n";
   WriteResidualValueArtifactMetadata(metadata_stream,
                                      "raw_residuals",
                                      raw_residuals_filename,
@@ -762,6 +985,13 @@ void GlobalPositioningTraceRecorder::WriteResidualValues(
                                      "robust_costs",
                                      robust_costs_filename,
                                      num_residual_blocks);
+  if (residual_values.has_raw_jacobians) {
+    metadata_stream << ",\n";
+    WriteResidualValueArtifactMetadata(metadata_stream,
+                                       "raw_jacobians",
+                                       raw_jacobians_filename,
+                                       residual_values.raw_jacobians.size());
+  }
   metadata_stream << "\n"
                   << "  }\n"
                   << "}\n";

--- a/src/colmap/estimators/global_positioning_trace.cc
+++ b/src/colmap/estimators/global_positioning_trace.cc
@@ -150,6 +150,11 @@ bool IsParameterSnapshotsLevel(const GlobalPositioningTraceLevel level) {
          static_cast<int>(GlobalPositioningTraceLevel::kParameterSnapshots);
 }
 
+bool IsResidualValuesLevel(const GlobalPositioningTraceLevel level) {
+  return static_cast<int>(level) >=
+         static_cast<int>(GlobalPositioningTraceLevel::kResidualValues);
+}
+
 std::string IterationPrefix(const int iteration) {
   std::ostringstream stream;
   stream << "iter_" << std::setw(6) << std::setfill('0') << iteration;
@@ -190,6 +195,32 @@ std::string JsonSizeArray(const std::vector<size_t>& values) {
   return stream.str();
 }
 
+std::string JsonStringArray(const std::vector<std::string>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << JsonEscape(values[i]);
+  }
+  stream << "]";
+  return stream.str();
+}
+
+std::string JsonBoolArray(const std::vector<bool>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << (values[i] ? "true" : "false");
+  }
+  stream << "]";
+  return stream.str();
+}
+
 void ValidateSnapshotArray(const std::string& name,
                            const GlobalPositioningTraceSnapshotArray& array) {
   THROW_CHECK(!array.shape.empty())
@@ -214,6 +245,18 @@ void WriteSnapshotSidecar(const std::filesystem::path& path,
       << "Failed while writing global positioning snapshot sidecar: " << path;
 }
 
+void WriteDoubleSidecar(const std::filesystem::path& path,
+                        const std::vector<double>& values) {
+  std::ofstream sidecar_stream(
+      path, std::ios::binary | std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(sidecar_stream, path);
+  for (const double value : values) {
+    WriteBinaryLittleEndian<double>(&sidecar_stream, value);
+  }
+  THROW_CHECK(sidecar_stream.good())
+      << "Failed while writing global positioning trace sidecar: " << path;
+}
+
 void WriteSnapshotArtifactMetadata(
     std::ostream& stream,
     const std::string& name,
@@ -226,6 +269,49 @@ void WriteSnapshotArtifactMetadata(
          << "      \"ids\": " << JsonUInt64Array(array.ids) << ",\n"
          << "      \"shape\": " << JsonSizeArray(array.shape) << "\n"
          << "    }";
+}
+
+void WriteResidualValueArtifactMetadata(std::ostream& stream,
+                                        const std::string& name,
+                                        const std::string& filename,
+                                        const size_t element_count) {
+  stream << "    " << JsonEscape(name) << ": {\n"
+         << "      \"file\": " << JsonEscape(filename) << ",\n"
+         << "      \"dtype\": \"float64\",\n"
+         << "      \"byte_order\": \"little_endian\",\n"
+         << "      \"shape\": [" << element_count << "]\n"
+         << "    }";
+}
+
+size_t ValidateResidualValues(
+    const GlobalPositioningTraceResidualValues& residual_values) {
+  THROW_CHECK_GE(residual_values.iteration, 0)
+      << "Global positioning residual values iteration must be non-negative.";
+  const size_t num_residual_blocks = residual_values.residual_ids.size();
+  THROW_CHECK_EQ(residual_values.residual_dims.size(), num_residual_blocks)
+      << "Residual value residual_dims count must match residual_ids count.";
+  THROW_CHECK_EQ(residual_values.residual_offsets.size(), num_residual_blocks)
+      << "Residual value residual_offsets count must match residual_ids count.";
+  THROW_CHECK_EQ(residual_values.evaluation_success.size(), num_residual_blocks)
+      << "Residual value evaluation_success count must match residual_ids "
+         "count.";
+  THROW_CHECK_EQ(residual_values.raw_costs.size(), num_residual_blocks)
+      << "Residual value raw_costs count must match residual_ids count.";
+  THROW_CHECK_EQ(residual_values.robust_costs.size(), num_residual_blocks)
+      << "Residual value robust_costs count must match residual_ids count.";
+
+  size_t total_scalar_residuals = 0;
+  for (size_t i = 0; i < num_residual_blocks; ++i) {
+    THROW_CHECK(!residual_values.residual_ids[i].empty())
+        << "Residual value residual_ids entries must be non-empty.";
+    THROW_CHECK_EQ(residual_values.residual_offsets[i], total_scalar_residuals)
+        << "Residual value residual_offsets must be contiguous cumulative "
+           "offsets.";
+    total_scalar_residuals += residual_values.residual_dims[i];
+  }
+  THROW_CHECK_EQ(residual_values.raw_residuals.size(), total_scalar_residuals)
+      << "Residual value raw_residuals count must match sum(residual_dims).";
+  return total_scalar_residuals;
 }
 
 void RemoveTraceArtifactIfExists(const std::filesystem::path& path) {
@@ -330,6 +416,7 @@ GlobalPositioningTraceRecorder::GlobalPositioningTraceRecorder(
   RemoveTraceArtifactIfExists(options_.output_path / "residual_blocks.jsonl");
   RemoveTraceArtifactIfExists(options_.output_path / "residual_skips.jsonl");
   RemoveTraceArtifactIfExists(options_.output_path / "snapshots");
+  RemoveTraceArtifactIfExists(options_.output_path / "residual_values");
 
   run_id_ = MakeRunId(created_at_unix_ns_, options_.run_label);
 
@@ -367,6 +454,20 @@ GlobalPositioningTraceRecorder::GlobalPositioningTraceRecorder(
         << snapshot_path;
   }
 
+  if (IsResidualValuesEnabled()) {
+    const std::filesystem::path residual_values_path =
+        options_.output_path / "residual_values";
+    THROW_CHECK(!ExistsFile(residual_values_path))
+        << "Global positioning residual values path points to a file: "
+        << residual_values_path;
+    if (!ExistsDir(residual_values_path)) {
+      CreateDirIfNotExists(residual_values_path, /*recursive=*/true);
+    }
+    THROW_CHECK(ExistsDir(residual_values_path))
+        << "Global positioning residual values path is not a directory: "
+        << residual_values_path;
+  }
+
   WriteManifest("running");
 }
 
@@ -376,6 +477,10 @@ bool GlobalPositioningTraceRecorder::IsResidualLedgerEnabled() const {
 
 bool GlobalPositioningTraceRecorder::IsParameterSnapshotsEnabled() const {
   return IsParameterSnapshotsLevel(options_.level);
+}
+
+bool GlobalPositioningTraceRecorder::IsResidualValuesEnabled() const {
+  return IsResidualValuesLevel(options_.level);
 }
 
 std::string GlobalPositioningTraceRecorder::AllocateResidualId() {
@@ -582,6 +687,81 @@ void GlobalPositioningTraceRecorder::WriteParameterSnapshot(
                                   *snapshot.cams_in_rig,
                                   *cams_in_rig_filename);
   }
+  metadata_stream << "\n"
+                  << "  }\n"
+                  << "}\n";
+  metadata_stream.flush();
+}
+
+void GlobalPositioningTraceRecorder::WriteResidualValues(
+    const GlobalPositioningTraceResidualValues& residual_values) {
+  if (!IsResidualValuesEnabled()) {
+    return;
+  }
+
+  THROW_CHECK_EQ(sizeof(double), 8)
+      << "Global positioning residual value sidecars require 64-bit doubles.";
+  THROW_CHECK(std::numeric_limits<double>::is_iec559)
+      << "Global positioning residual value sidecars require IEEE-754 doubles.";
+  THROW_CHECK(IsLittleEndian())
+      << "Global positioning residual value binaries are defined as "
+         "little-endian.";
+
+  const size_t total_scalar_residuals = ValidateResidualValues(residual_values);
+  const size_t num_residual_blocks = residual_values.residual_ids.size();
+  const std::filesystem::path residual_values_path =
+      options_.output_path / "residual_values";
+  THROW_CHECK(ExistsDir(residual_values_path))
+      << "Global positioning residual values path is not a directory: "
+      << residual_values_path;
+
+  const std::string prefix = IterationPrefix(residual_values.iteration);
+  const std::filesystem::path metadata_path =
+      residual_values_path / (prefix + ".json");
+  const std::string raw_residuals_filename = prefix + "_raw_residuals_f64.bin";
+  const std::string raw_costs_filename = prefix + "_raw_costs_f64.bin";
+  const std::string robust_costs_filename = prefix + "_robust_costs_f64.bin";
+
+  WriteDoubleSidecar(residual_values_path / raw_residuals_filename,
+                     residual_values.raw_residuals);
+  WriteDoubleSidecar(residual_values_path / raw_costs_filename,
+                     residual_values.raw_costs);
+  WriteDoubleSidecar(residual_values_path / robust_costs_filename,
+                     residual_values.robust_costs);
+
+  std::ofstream metadata_stream(metadata_path, std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(metadata_stream, metadata_path);
+  metadata_stream << "{\n"
+                  << "  \"schema_version\": " << kSchemaVersion << ",\n"
+                  << "  \"run_id\": " << JsonEscape(run_id_) << ",\n"
+                  << "  \"iteration\": " << residual_values.iteration << ",\n"
+                  << "  \"dtype\": \"float64\",\n"
+                  << "  \"byte_order\": \"little_endian\",\n"
+                  << "  \"num_residual_blocks\": " << num_residual_blocks
+                  << ",\n"
+                  << "  \"total_scalar_residuals\": " << total_scalar_residuals
+                  << ",\n"
+                  << "  \"residual_ids\": "
+                  << JsonStringArray(residual_values.residual_ids) << ",\n"
+                  << "  \"residual_dims\": "
+                  << JsonSizeArray(residual_values.residual_dims) << ",\n"
+                  << "  \"residual_offsets\": "
+                  << JsonSizeArray(residual_values.residual_offsets) << ",\n"
+                  << "  \"evaluation_success\": "
+                  << JsonBoolArray(residual_values.evaluation_success) << ",\n"
+                  << "  \"artifacts\": {\n";
+  WriteResidualValueArtifactMetadata(metadata_stream,
+                                     "raw_residuals",
+                                     raw_residuals_filename,
+                                     total_scalar_residuals);
+  metadata_stream << ",\n";
+  WriteResidualValueArtifactMetadata(
+      metadata_stream, "raw_costs", raw_costs_filename, num_residual_blocks);
+  metadata_stream << ",\n";
+  WriteResidualValueArtifactMetadata(metadata_stream,
+                                     "robust_costs",
+                                     robust_costs_filename,
+                                     num_residual_blocks);
   metadata_stream << "\n"
                   << "  }\n"
                   << "}\n";

--- a/src/colmap/estimators/global_positioning_trace.cc
+++ b/src/colmap/estimators/global_positioning_trace.cc
@@ -4,6 +4,7 @@
 #include "colmap/util/file.h"
 #include "colmap/util/logging.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <iomanip>
@@ -18,6 +19,11 @@ namespace colmap {
 namespace {
 
 constexpr int kSchemaVersion = 1;
+constexpr char kRawBinaryStorageFormat[] = "global_positioning_raw_binary_v1";
+constexpr char kRawBinaryLedgerMagic[] = "GPTRLGR1";
+constexpr char kRawBinaryArrayMagic[] = "GPTRARR1";
+constexpr char kRawBinaryResidualValuesMagic[] = "GPTRRSV1";
+constexpr int64_t kRawBinaryNoneId = -1;
 
 int64_t UnixNowNs() {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -84,6 +90,163 @@ std::string JsonDouble(const double value) {
   return stream.str();
 }
 
+std::string JsonOptionalDouble(const std::optional<double>& value) {
+  return value.has_value() ? JsonDouble(*value) : "null";
+}
+
+std::string JsonDoubleArray(const std::vector<double>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << JsonDouble(values[i]);
+  }
+  stream << "]";
+  return stream.str();
+}
+
+std::string JsonParameterBlockDescriptors(
+    const std::vector<GlobalPositioningTraceParameterBlockDescriptor>& values) {
+  std::ostringstream stream;
+  stream << "[";
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0) {
+      stream << ",";
+    }
+    stream << "{"
+           << "\"role\":" << JsonEscape(values[i].role) << ","
+           << "\"kind\":" << JsonEscape(values[i].kind) << ","
+           << "\"id\":" << values[i].id;
+    if (values[i].size.has_value()) {
+      stream << ",\"size\":" << *values[i].size;
+    }
+    stream << "}";
+  }
+  stream << "]";
+  return stream.str();
+}
+
+std::string JsonLossConfig(const GlobalPositioningTraceLossConfig& value) {
+  std::ostringstream stream;
+  stream << "{"
+         << "\"bucket\":" << JsonEscape(value.bucket) << ","
+         << "\"type\":" << JsonEscape(value.type) << ","
+         << "\"scale\":" << JsonOptionalDouble(value.scale) << ","
+         << "\"weight\":" << JsonOptionalDouble(value.weight) << ","
+         << "\"source\":" << JsonEscape(value.source);
+  if (value.observation_count_weight.has_value()) {
+    stream << ",\"observation_count_weight\":"
+           << JsonDouble(*value.observation_count_weight);
+  }
+  stream << "}";
+  return stream.str();
+}
+
+void WriteOptionalDoubleArray(std::ostringstream& stream,
+                              bool& first,
+                              const std::string& key,
+                              const std::optional<std::vector<double>>& value) {
+  if (!value.has_value()) {
+    return;
+  }
+  if (!first) {
+    stream << ",";
+  }
+  first = false;
+  stream << JsonEscape(key) << ":" << JsonDoubleArray(*value);
+}
+
+void WriteOptionalBool(std::ostringstream& stream,
+                       bool& first,
+                       const std::string& key,
+                       const std::optional<bool>& value) {
+  if (!value.has_value()) {
+    return;
+  }
+  if (!first) {
+    stream << ",";
+  }
+  first = false;
+  stream << JsonEscape(key) << ":" << (*value ? "true" : "false");
+}
+
+void WriteOptionalString(std::ostringstream& stream,
+                         bool& first,
+                         const std::string& key,
+                         const std::optional<std::string>& value) {
+  if (!value.has_value()) {
+    return;
+  }
+  if (!first) {
+    stream << ",";
+  }
+  first = false;
+  stream << JsonEscape(key) << ":" << JsonEscape(*value);
+}
+
+void WriteOptionalDouble(std::ostringstream& stream,
+                         bool& first,
+                         const std::string& key,
+                         const std::optional<double>& value) {
+  if (!value.has_value()) {
+    return;
+  }
+  if (!first) {
+    stream << ",";
+  }
+  first = false;
+  stream << JsonEscape(key) << ":" << JsonDouble(*value);
+}
+
+std::string JsonFixedParameters(
+    const GlobalPositioningTraceFixedParameters& value) {
+  std::ostringstream stream;
+  stream << "{";
+  bool first = true;
+  WriteOptionalDoubleArray(
+      stream, first, "cam_from_point3D_dir", value.cam_from_point3D_dir);
+  WriteOptionalDoubleArray(stream,
+                           first,
+                           "keypoint_covariance_world_row_major",
+                           value.keypoint_covariance_world_row_major);
+  WriteOptionalDoubleArray(
+      stream, first, "cam_from_rig_dir", value.cam_from_rig_dir);
+  WriteOptionalDoubleArray(stream,
+                           first,
+                           "rig_from_world_rotation_wxyz",
+                           value.rig_from_world_rotation_wxyz);
+  WriteOptionalDoubleArray(stream,
+                           first,
+                           "world_from_rig_rotation_wxyz",
+                           value.world_from_rig_rotation_wxyz);
+  WriteOptionalDoubleArray(
+      stream, first, "camera_rotation_wxyz", value.camera_rotation_wxyz);
+  WriteOptionalBool(stream,
+                    first,
+                    "metric_depth_use_log_scale",
+                    value.metric_depth_use_log_scale);
+  WriteOptionalString(stream,
+                      first,
+                      "metric_depth_residual_type",
+                      value.metric_depth_residual_type);
+  WriteOptionalBool(stream,
+                    first,
+                    "metric_depth_zero_residual_behind",
+                    value.metric_depth_zero_residual_behind);
+  WriteOptionalDouble(stream,
+                      first,
+                      "metric_depth_log_linear_threshold",
+                      value.metric_depth_log_linear_threshold);
+  WriteOptionalDouble(
+      stream, first, "scale_prior_target", value.scale_prior_target);
+  WriteOptionalDouble(
+      stream, first, "scale_prior_stddev", value.scale_prior_stddev);
+  stream << "}";
+  return stream.str();
+}
+
 std::string JsonValue(const GlobalPositioningTraceValue& value) {
   switch (value.type) {
     case GlobalPositioningTraceValue::Type::kNull:
@@ -110,6 +273,12 @@ std::string JsonValue(const GlobalPositioningTraceValue& value) {
       stream << "]";
       return stream.str();
     }
+    case GlobalPositioningTraceValue::Type::kParameterBlockArray:
+      return JsonParameterBlockDescriptors(value.parameter_block_array_value);
+    case GlobalPositioningTraceValue::Type::kLossConfig:
+      return JsonLossConfig(value.loss_config_value);
+    case GlobalPositioningTraceValue::Type::kFixedParameters:
+      return JsonFixedParameters(value.fixed_parameters_value);
   }
   return "null";
 }
@@ -164,6 +333,26 @@ std::string IterationPrefix(const int iteration) {
   std::ostringstream stream;
   stream << "iter_" << std::setw(6) << std::setfill('0') << iteration;
   return stream.str();
+}
+
+std::filesystem::path RawBinaryPath(
+    const GlobalPositioningTraceOptions& options) {
+  return options.output_path / "raw_binary";
+}
+
+std::filesystem::path RawBinaryStaticPath(
+    const GlobalPositioningTraceOptions& options) {
+  return RawBinaryPath(options) / "static";
+}
+
+std::filesystem::path RawBinaryIterationsPath(
+    const GlobalPositioningTraceOptions& options) {
+  return RawBinaryPath(options) / "iterations";
+}
+
+std::filesystem::path RawBinaryIterationPath(
+    const GlobalPositioningTraceOptions& options, const int iteration) {
+  return RawBinaryIterationsPath(options) / IterationPrefix(iteration);
 }
 
 uint64_t ShapeElementCount(const std::vector<size_t>& shape) {
@@ -234,19 +423,6 @@ std::string JsonNestedBoolArray(const std::vector<std::vector<bool>>& values) {
   return stream.str();
 }
 
-std::string JsonDoubleArray(const std::vector<double>& values) {
-  std::ostringstream stream;
-  stream << "[";
-  for (size_t i = 0; i < values.size(); ++i) {
-    if (i > 0) {
-      stream << ",";
-    }
-    stream << JsonDouble(values[i]);
-  }
-  stream << "]";
-  return stream.str();
-}
-
 std::string JsonNestedDoubleArray(
     const std::vector<std::vector<std::vector<double>>>& values) {
   std::ostringstream stream;
@@ -268,7 +444,7 @@ std::string JsonNestedDoubleArray(
   return stream.str();
 }
 
-std::string JsonParameterBlockDescriptors(
+std::string JsonNestedParameterBlockDescriptors(
     const std::vector<
         std::vector<GlobalPositioningTraceParameterBlockDescriptor>>& values) {
   std::ostringstream stream;
@@ -277,17 +453,7 @@ std::string JsonParameterBlockDescriptors(
     if (i > 0) {
       stream << ",";
     }
-    stream << "[";
-    for (size_t j = 0; j < values[i].size(); ++j) {
-      if (j > 0) {
-        stream << ",";
-      }
-      stream << "{"
-             << "\"role\":" << JsonEscape(values[i][j].role) << ","
-             << "\"kind\":" << JsonEscape(values[i][j].kind) << ","
-             << "\"id\":" << values[i][j].id << "}";
-    }
-    stream << "]";
+    stream << JsonParameterBlockDescriptors(values[i]);
   }
   stream << "]";
   return stream.str();
@@ -317,6 +483,123 @@ std::string JsonBoolArray(const std::vector<bool>& values) {
   }
   stream << "]";
   return stream.str();
+}
+
+void WriteRawBytes(std::ofstream& stream,
+                   const char* data,
+                   const size_t size,
+                   const std::filesystem::path& path) {
+  stream.write(data, static_cast<std::streamsize>(size));
+  THROW_CHECK(stream.good())
+      << "Failed while writing global positioning raw binary trace: " << path;
+}
+
+template <typename T>
+void WriteRawLittleEndian(std::ofstream& stream,
+                          const T value,
+                          const std::filesystem::path& path) {
+  WriteBinaryLittleEndian<T>(&stream, value);
+  THROW_CHECK(stream.good())
+      << "Failed while writing global positioning raw binary trace: " << path;
+}
+
+void WriteRawBool(std::ofstream& stream,
+                  const bool value,
+                  const std::filesystem::path& path) {
+  const char byte = value ? 1 : 0;
+  WriteRawBytes(stream, &byte, 1, path);
+}
+
+void WriteRawString(std::ofstream& stream,
+                    const std::string& value,
+                    const std::filesystem::path& path) {
+  THROW_CHECK_LE(value.size(), std::numeric_limits<uint32_t>::max())
+      << "Raw binary trace strings are length-prefixed with uint32.";
+  WriteRawLittleEndian<uint32_t>(
+      stream, static_cast<uint32_t>(value.size()), path);
+  if (!value.empty()) {
+    WriteRawBytes(stream, value.data(), value.size(), path);
+  }
+}
+
+void WriteRawParameterBlockDescriptor(
+    std::ofstream& stream,
+    const GlobalPositioningTraceParameterBlockDescriptor& descriptor,
+    const std::filesystem::path& path) {
+  THROW_CHECK(!descriptor.role.empty())
+      << "Raw binary parameter block role must be non-empty.";
+  THROW_CHECK(!descriptor.kind.empty())
+      << "Raw binary parameter block kind must be non-empty.";
+  WriteRawString(stream, descriptor.role, path);
+  WriteRawString(stream, descriptor.kind, path);
+  WriteRawLittleEndian<uint64_t>(stream, descriptor.id, path);
+}
+
+std::string TraceAttrString(
+    const std::map<std::string, GlobalPositioningTraceValue>& attrs,
+    const std::string& key) {
+  const auto it = attrs.find(key);
+  THROW_CHECK(it != attrs.end()) << "Missing trace attr: " << key;
+  THROW_CHECK(it->second.type == GlobalPositioningTraceValue::Type::kString)
+      << "Trace attr must be a string: " << key;
+  return it->second.string_value;
+}
+
+int64_t TraceAttrOptionalId(
+    const std::map<std::string, GlobalPositioningTraceValue>& attrs,
+    const std::string& key) {
+  const auto it = attrs.find(key);
+  THROW_CHECK(it != attrs.end()) << "Missing trace attr: " << key;
+  if (it->second.type == GlobalPositioningTraceValue::Type::kNull) {
+    return kRawBinaryNoneId;
+  }
+  THROW_CHECK(it->second.type == GlobalPositioningTraceValue::Type::kUInt)
+      << "Trace attr must be an unsigned ID or null: " << key;
+  THROW_CHECK_LE(it->second.uint_value,
+                 static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+      << "Raw binary trace IDs are stored as signed int64.";
+  return static_cast<int64_t>(it->second.uint_value);
+}
+
+bool TraceAttrBool(
+    const std::map<std::string, GlobalPositioningTraceValue>& attrs,
+    const std::string& key) {
+  const auto it = attrs.find(key);
+  THROW_CHECK(it != attrs.end()) << "Missing trace attr: " << key;
+  THROW_CHECK(it->second.type == GlobalPositioningTraceValue::Type::kBool)
+      << "Trace attr must be a bool: " << key;
+  return it->second.bool_value;
+}
+
+void ValidateSnapshotArray(const std::string& name,
+                           const GlobalPositioningTraceSnapshotArray& array);
+
+void WriteRawSnapshotArray(const std::filesystem::path& path,
+                           const std::string& name,
+                           const GlobalPositioningTraceSnapshotArray& array) {
+  ValidateSnapshotArray(name, array);
+  THROW_CHECK_LE(array.shape.size(), 2)
+      << "Raw binary snapshot arrays support rank-1 or rank-2 arrays.";
+  const uint64_t rows = static_cast<uint64_t>(array.shape.front());
+  const uint64_t cols =
+      array.shape.size() == 1 ? 1 : static_cast<uint64_t>(array.shape[1]);
+  std::ofstream stream(path,
+                       std::ios::binary | std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(stream, path);
+  WriteRawBytes(stream, kRawBinaryArrayMagic, 8, path);
+  WriteRawLittleEndian<uint32_t>(stream, kSchemaVersion, path);
+  WriteRawLittleEndian<uint64_t>(stream, rows, path);
+  WriteRawLittleEndian<uint64_t>(stream, cols, path);
+  WriteRawString(stream, name, path);
+  for (const uint64_t id : array.ids) {
+    THROW_CHECK_LE(id,
+                   static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+        << "Raw binary snapshot IDs are stored as signed int64.";
+    WriteRawLittleEndian<int64_t>(stream, static_cast<int64_t>(id), path);
+  }
+  for (const double value : array.values) {
+    WriteRawLittleEndian<double>(stream, value, path);
+  }
 }
 
 void ValidateSnapshotArray(const std::string& name,
@@ -585,6 +868,30 @@ GlobalPositioningTraceValue GlobalPositioningTraceValue::StringArray(
   return trace_value;
 }
 
+GlobalPositioningTraceValue GlobalPositioningTraceValue::ParameterBlockArray(
+    std::vector<GlobalPositioningTraceParameterBlockDescriptor> value) {
+  GlobalPositioningTraceValue trace_value;
+  trace_value.type = Type::kParameterBlockArray;
+  trace_value.parameter_block_array_value = std::move(value);
+  return trace_value;
+}
+
+GlobalPositioningTraceValue GlobalPositioningTraceValue::LossConfig(
+    GlobalPositioningTraceLossConfig value) {
+  GlobalPositioningTraceValue trace_value;
+  trace_value.type = Type::kLossConfig;
+  trace_value.loss_config_value = std::move(value);
+  return trace_value;
+}
+
+GlobalPositioningTraceValue GlobalPositioningTraceValue::FixedParameters(
+    GlobalPositioningTraceFixedParameters value) {
+  GlobalPositioningTraceValue trace_value;
+  trace_value.type = Type::kFixedParameters;
+  trace_value.fixed_parameters_value = std::move(value);
+  return trace_value;
+}
+
 GlobalPositioningTraceRecorder::GlobalPositioningTraceRecorder(
     const GlobalPositioningTraceOptions& options)
     : options_(options), created_at_unix_ns_(UnixNowNs()) {
@@ -609,6 +916,7 @@ GlobalPositioningTraceRecorder::GlobalPositioningTraceRecorder(
   RemoveTraceArtifactIfExists(options_.output_path / "residual_skips.jsonl");
   RemoveTraceArtifactIfExists(options_.output_path / "snapshots");
   RemoveTraceArtifactIfExists(options_.output_path / "residual_values");
+  RemoveTraceArtifactIfExists(options_.output_path / "raw_binary");
 
   run_id_ = MakeRunId(created_at_unix_ns_, options_.run_label);
 
@@ -630,6 +938,25 @@ GlobalPositioningTraceRecorder::GlobalPositioningTraceRecorder(
                                 std::ios::out | std::ios::trunc);
     THROW_CHECK_FILE_OPEN(residual_skips_stream_,
                           options_.output_path / "residual_skips.jsonl");
+
+    const std::filesystem::path raw_binary_static_path =
+        RawBinaryStaticPath(options_);
+    CreateDirIfNotExists(raw_binary_static_path, /*recursive=*/true);
+    THROW_CHECK(ExistsDir(raw_binary_static_path))
+        << "Global positioning raw binary static path is not a directory: "
+        << raw_binary_static_path;
+    const std::filesystem::path raw_binary_iterations_path =
+        RawBinaryIterationsPath(options_);
+    CreateDirIfNotExists(raw_binary_iterations_path, /*recursive=*/true);
+    THROW_CHECK(ExistsDir(raw_binary_iterations_path))
+        << "Global positioning raw binary iterations path is not a directory: "
+        << raw_binary_iterations_path;
+    raw_binary_residual_ledger_stream_.open(
+        raw_binary_static_path / "residual_ledger.bin",
+        std::ios::binary | std::ios::out | std::ios::trunc);
+    THROW_CHECK_FILE_OPEN(raw_binary_residual_ledger_stream_,
+                          raw_binary_static_path / "residual_ledger.bin");
+    WriteRawBinaryResidualLedgerHeader();
   }
 
   if (IsParameterSnapshotsEnabled()) {
@@ -727,6 +1054,7 @@ void GlobalPositioningTraceRecorder::WriteResidualBlock(
   if (record.stage.empty()) {
     record.stage = "problem_build";
   }
+  WriteRawBinaryResidualBlock(record);
   WriteRecord(residual_blocks_stream_, std::move(record));
 }
 
@@ -782,6 +1110,7 @@ void GlobalPositioningTraceRecorder::WriteParameterSnapshot(
   if (snapshot.cams_in_rig.has_value()) {
     ValidateSnapshotArray("cams_in_rig", *snapshot.cams_in_rig);
   }
+  WriteRawBinaryParameterSnapshot(snapshot);
 
   const std::filesystem::path snapshot_path =
       options_.output_path / "snapshots";
@@ -904,6 +1233,7 @@ void GlobalPositioningTraceRecorder::WriteResidualValues(
          "little-endian.";
 
   const size_t total_scalar_residuals = ValidateResidualValues(residual_values);
+  WriteRawBinaryResidualValues(residual_values);
   const size_t num_residual_blocks = residual_values.residual_ids.size();
   const std::filesystem::path residual_values_path =
       options_.output_path / "residual_values";
@@ -970,7 +1300,7 @@ void GlobalPositioningTraceRecorder::WriteResidualValues(
         << "  \"raw_jacobian_offsets\": "
         << JsonNestedSizeArray(residual_values.raw_jacobian_offsets) << ",\n"
         << "  \"parameter_blocks\": "
-        << JsonParameterBlockDescriptors(residual_values.parameter_blocks)
+        << JsonNestedParameterBlockDescriptors(residual_values.parameter_blocks)
         << ",\n"
         << "  \"parameter_block_is_constant\": "
         << JsonNestedBoolArray(residual_values.parameter_block_is_constant)
@@ -1025,6 +1355,237 @@ void GlobalPositioningTraceRecorder::MarkFinished(std::string status) {
   WriteManifest(status);
 }
 
+GlobalPositioningRawBinaryTraceIterationArtifacts&
+GlobalPositioningTraceRecorder::RawBinaryIterationArtifacts(
+    const int iteration) {
+  for (GlobalPositioningRawBinaryTraceIterationArtifacts& artifacts :
+       raw_binary_iterations_) {
+    if (artifacts.iteration == iteration) {
+      return artifacts;
+    }
+  }
+  raw_binary_iterations_.push_back({iteration});
+  std::sort(raw_binary_iterations_.begin(),
+            raw_binary_iterations_.end(),
+            [](const GlobalPositioningRawBinaryTraceIterationArtifacts& a,
+               const GlobalPositioningRawBinaryTraceIterationArtifacts& b) {
+              return a.iteration < b.iteration;
+            });
+  for (GlobalPositioningRawBinaryTraceIterationArtifacts& artifacts :
+       raw_binary_iterations_) {
+    if (artifacts.iteration == iteration) {
+      return artifacts;
+    }
+  }
+  THROW_CHECK(false) << "Failed to register raw binary iteration.";
+  return raw_binary_iterations_.front();
+}
+
+void GlobalPositioningTraceRecorder::WriteRawBinaryResidualLedgerHeader() {
+  if (!raw_binary_residual_ledger_stream_.is_open()) {
+    return;
+  }
+  const std::filesystem::path path =
+      RawBinaryStaticPath(options_) / "residual_ledger.bin";
+  raw_binary_residual_ledger_stream_.seekp(0, std::ios::beg);
+  WriteRawBytes(
+      raw_binary_residual_ledger_stream_, kRawBinaryLedgerMagic, 8, path);
+  WriteRawLittleEndian<uint32_t>(
+      raw_binary_residual_ledger_stream_, kSchemaVersion, path);
+  WriteRawLittleEndian<uint64_t>(raw_binary_residual_ledger_stream_,
+                                 raw_binary_residual_ledger_count_,
+                                 path);
+  raw_binary_residual_ledger_stream_.seekp(0, std::ios::end);
+}
+
+void GlobalPositioningTraceRecorder::UpdateRawBinaryResidualLedgerHeader() {
+  if (!raw_binary_residual_ledger_stream_.is_open()) {
+    return;
+  }
+  WriteRawBinaryResidualLedgerHeader();
+  raw_binary_residual_ledger_stream_.flush();
+}
+
+void GlobalPositioningTraceRecorder::WriteRawBinaryResidualBlock(
+    const GlobalPositioningTraceRecord& record) {
+  if (!raw_binary_residual_ledger_stream_.is_open()) {
+    return;
+  }
+  const std::filesystem::path path =
+      RawBinaryStaticPath(options_) / "residual_ledger.bin";
+  raw_binary_residual_ledger_stream_.seekp(0, std::ios::end);
+  WriteRawString(raw_binary_residual_ledger_stream_,
+                 TraceAttrString(record.attrs, "residual_id"),
+                 path);
+  WriteRawString(raw_binary_residual_ledger_stream_,
+                 TraceAttrString(record.attrs, "residual_type"),
+                 path);
+  WriteRawString(raw_binary_residual_ledger_stream_,
+                 TraceAttrString(record.attrs, "loss_bucket"),
+                 path);
+  WriteRawLittleEndian<int64_t>(raw_binary_residual_ledger_stream_,
+                                TraceAttrOptionalId(record.attrs, "frame_id"),
+                                path);
+  WriteRawLittleEndian<int64_t>(raw_binary_residual_ledger_stream_,
+                                TraceAttrOptionalId(record.attrs, "image_id"),
+                                path);
+  WriteRawLittleEndian<int64_t>(raw_binary_residual_ledger_stream_,
+                                TraceAttrOptionalId(record.attrs, "point3D_id"),
+                                path);
+  WriteRawBool(raw_binary_residual_ledger_stream_,
+               TraceAttrBool(record.attrs, "is_lc_observation"),
+               path);
+  WriteRawString(
+      raw_binary_residual_ledger_stream_, JsonAttrs(record.attrs), path);
+  ++raw_binary_residual_ledger_count_;
+}
+
+void GlobalPositioningTraceRecorder::WriteRawBinaryParameterSnapshot(
+    const GlobalPositioningTraceParameterSnapshot& snapshot) {
+  if (!IsParameterSnapshotsEnabled() || !IsResidualLedgerEnabled()) {
+    return;
+  }
+  const std::filesystem::path iteration_path =
+      RawBinaryIterationPath(options_, snapshot.iteration);
+  CreateDirIfNotExists(iteration_path, /*recursive=*/true);
+  THROW_CHECK(ExistsDir(iteration_path))
+      << "Global positioning raw binary iteration path is not a directory: "
+      << iteration_path;
+
+  WriteRawSnapshotArray(iteration_path / "frame_centers.bin",
+                        "frame_centers",
+                        snapshot.frame_centers);
+  WriteRawSnapshotArray(
+      iteration_path / "point_xyz.bin", "point_xyz", snapshot.points3D);
+  WriteRawSnapshotArray(
+      iteration_path / "scales.bin", "scales", snapshot.scales);
+  GlobalPositioningRawBinaryTraceIterationArtifacts& artifacts =
+      RawBinaryIterationArtifacts(snapshot.iteration);
+  artifacts.has_frame_centers = true;
+  artifacts.has_point_xyz = true;
+  artifacts.has_scales = true;
+  if (snapshot.dmap_scales.has_value()) {
+    WriteRawSnapshotArray(iteration_path / "dmap_scales.bin",
+                          "dmap_scales",
+                          *snapshot.dmap_scales);
+    artifacts.has_dmap_scales = true;
+  }
+  if (snapshot.cams_in_rig.has_value()) {
+    WriteRawSnapshotArray(iteration_path / "cams_in_rig.bin",
+                          "cams_in_rig",
+                          *snapshot.cams_in_rig);
+    artifacts.has_cams_in_rig = true;
+  }
+}
+
+void GlobalPositioningTraceRecorder::WriteRawBinaryResidualValues(
+    const GlobalPositioningTraceResidualValues& residual_values) {
+  if (!IsResidualValuesEnabled() || !IsResidualLedgerEnabled()) {
+    return;
+  }
+  const size_t total_scalar_residuals = ValidateResidualValues(residual_values);
+  const size_t num_residual_blocks = residual_values.residual_ids.size();
+  const std::filesystem::path iteration_path =
+      RawBinaryIterationPath(options_, residual_values.iteration);
+  CreateDirIfNotExists(iteration_path, /*recursive=*/true);
+  THROW_CHECK(ExistsDir(iteration_path))
+      << "Global positioning raw binary iteration path is not a directory: "
+      << iteration_path;
+  const std::filesystem::path path = iteration_path / "residual_values.bin";
+  std::ofstream stream(path,
+                       std::ios::binary | std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(stream, path);
+  WriteRawBytes(stream, kRawBinaryResidualValuesMagic, 8, path);
+  WriteRawLittleEndian<uint32_t>(
+      stream,
+      residual_values.has_raw_jacobians ? uint32_t{2} : uint32_t{1},
+      path);
+  WriteRawLittleEndian<int64_t>(stream, residual_values.iteration, path);
+  WriteRawLittleEndian<uint64_t>(
+      stream, static_cast<uint64_t>(num_residual_blocks), path);
+  WriteRawLittleEndian<uint64_t>(
+      stream, static_cast<uint64_t>(total_scalar_residuals), path);
+  WriteRawBool(stream, true, path);
+  if (residual_values.has_raw_jacobians) {
+    WriteRawBool(stream, true, path);
+  }
+  for (size_t i = 0; i < num_residual_blocks; ++i) {
+    THROW_CHECK_LE(residual_values.residual_dims[i],
+                   std::numeric_limits<uint32_t>::max())
+        << "Raw binary residual dimensions are stored as uint32.";
+    WriteRawString(stream, residual_values.residual_ids[i], path);
+    WriteRawLittleEndian<uint32_t>(
+        stream, static_cast<uint32_t>(residual_values.residual_dims[i]), path);
+    WriteRawLittleEndian<uint64_t>(
+        stream,
+        static_cast<uint64_t>(residual_values.residual_offsets[i]),
+        path);
+    WriteRawBool(stream, residual_values.evaluation_success[i], path);
+  }
+  for (const double value : residual_values.raw_residuals) {
+    WriteRawLittleEndian<double>(stream, value, path);
+  }
+  for (const double value : residual_values.raw_costs) {
+    WriteRawLittleEndian<double>(stream, value, path);
+  }
+  for (const double value : residual_values.robust_costs) {
+    WriteRawLittleEndian<double>(stream, value, path);
+  }
+  for (const double value : residual_values.loss_rho_values) {
+    WriteRawLittleEndian<double>(stream, value, path);
+  }
+  if (residual_values.has_raw_jacobians) {
+    WriteRawLittleEndian<uint64_t>(
+        stream,
+        static_cast<uint64_t>(residual_values.raw_jacobians.size()),
+        path);
+    for (size_t residual_idx = 0; residual_idx < num_residual_blocks;
+         ++residual_idx) {
+      const size_t num_parameter_blocks =
+          residual_values.parameter_block_sizes[residual_idx].size();
+      THROW_CHECK_LE(num_parameter_blocks, std::numeric_limits<uint32_t>::max())
+          << "Raw binary parameter block counts are stored as uint32.";
+      WriteRawLittleEndian<uint32_t>(
+          stream, static_cast<uint32_t>(num_parameter_blocks), path);
+      for (size_t block_idx = 0; block_idx < num_parameter_blocks;
+           ++block_idx) {
+        THROW_CHECK_LE(
+            residual_values.parameter_block_sizes[residual_idx][block_idx],
+            std::numeric_limits<uint32_t>::max())
+            << "Raw binary parameter block sizes are stored as uint32.";
+        WriteRawParameterBlockDescriptor(
+            stream,
+            residual_values.parameter_blocks[residual_idx][block_idx],
+            path);
+        WriteRawLittleEndian<uint32_t>(
+            stream,
+            static_cast<uint32_t>(
+                residual_values.parameter_block_sizes[residual_idx][block_idx]),
+            path);
+        WriteRawLittleEndian<uint64_t>(
+            stream,
+            static_cast<uint64_t>(
+                residual_values.raw_jacobian_offsets[residual_idx][block_idx]),
+            path);
+        WriteRawBool(stream,
+                     residual_values
+                         .parameter_block_is_constant[residual_idx][block_idx],
+                     path);
+        for (const double value :
+             residual_values
+                 .parameter_block_lower_bounds[residual_idx][block_idx]) {
+          WriteRawLittleEndian<double>(stream, value, path);
+        }
+      }
+    }
+    for (const double value : residual_values.raw_jacobians) {
+      WriteRawLittleEndian<double>(stream, value, path);
+    }
+  }
+  RawBinaryIterationArtifacts(residual_values.iteration).has_residual_values =
+      true;
+}
+
 void GlobalPositioningTraceRecorder::WriteRecord(
     std::ofstream& stream, GlobalPositioningTraceRecord record) {
   stream << "{\"schema_version\":" << kSchemaVersion
@@ -1065,6 +1626,80 @@ void GlobalPositioningTraceRecorder::WriteManifest(const std::string& status) {
                   << "    \"max_snapshotted_points\": "
                   << options_.max_snapshotted_points << "\n"
                   << "  }\n"
+                  << "}\n";
+  manifest_stream.flush();
+  WriteRawBinaryManifest(status);
+}
+
+void GlobalPositioningTraceRecorder::WriteRawBinaryManifest(
+    const std::string& status) {
+  if (!IsResidualLedgerEnabled()) {
+    return;
+  }
+  UpdateRawBinaryResidualLedgerHeader();
+  const std::filesystem::path raw_binary_path = RawBinaryPath(options_);
+  CreateDirIfNotExists(raw_binary_path, /*recursive=*/true);
+  const std::filesystem::path manifest_path = raw_binary_path / "manifest.json";
+  std::ofstream manifest_stream(manifest_path, std::ios::out | std::ios::trunc);
+  THROW_CHECK_FILE_OPEN(manifest_stream, manifest_path);
+  manifest_stream
+      << "{\n"
+      << "  \"schema_version\": " << kSchemaVersion << ",\n"
+      << "  \"storage_format\": " << JsonEscape(kRawBinaryStorageFormat)
+      << ",\n"
+      << "  \"run_id\": " << JsonEscape(run_id_) << ",\n"
+      << "  \"run_label\": " << JsonEscape(options_.run_label) << ",\n"
+      << "  \"status\": " << JsonEscape(status) << ",\n"
+      << "  \"trace_level\": "
+      << JsonEscape(GlobalPositioningTraceLevelToString(options_.level))
+      << ",\n"
+      << "  \"byte_order\": \"little_endian\",\n"
+      << "  \"dtype\": \"float64\",\n"
+      << "  \"static\": {\n"
+      << "    \"residual_ledger\": " << JsonEscape("static/residual_ledger.bin")
+      << "\n"
+      << "  },\n"
+      << "  \"iterations\": [\n";
+  bool first = true;
+  for (const GlobalPositioningRawBinaryTraceIterationArtifacts& artifacts :
+       raw_binary_iterations_) {
+    if (!first) {
+      manifest_stream << ",\n";
+    }
+    first = false;
+    const std::string prefix = IterationPrefix(artifacts.iteration);
+    manifest_stream << "    {\n"
+                    << "      \"iteration\": " << artifacts.iteration << ",\n"
+                    << "      \"directory\": "
+                    << JsonEscape("iterations/" + prefix);
+    if (artifacts.has_frame_centers) {
+      manifest_stream << ",\n      \"frame_centers\": "
+                      << JsonEscape("frame_centers.bin");
+    }
+    if (artifacts.has_point_xyz) {
+      manifest_stream << ",\n      \"point_xyz\": "
+                      << JsonEscape("point_xyz.bin");
+    }
+    if (artifacts.has_scales) {
+      manifest_stream << ",\n      \"scales\": " << JsonEscape("scales.bin");
+    }
+    if (artifacts.has_dmap_scales) {
+      manifest_stream << ",\n      \"dmap_scales\": "
+                      << JsonEscape("dmap_scales.bin");
+    }
+    if (artifacts.has_cams_in_rig) {
+      manifest_stream << ",\n      \"cams_in_rig\": "
+                      << JsonEscape("cams_in_rig.bin");
+    }
+    if (artifacts.has_residual_values) {
+      manifest_stream << ",\n      \"residual_values\": "
+                      << JsonEscape("residual_values.bin");
+    }
+    manifest_stream << "\n"
+                    << "    }";
+  }
+  manifest_stream << "\n"
+                  << "  ]\n"
                   << "}\n";
   manifest_stream.flush();
 }

--- a/src/colmap/estimators/global_positioning_trace.h
+++ b/src/colmap/estimators/global_positioning_trace.h
@@ -83,6 +83,17 @@ struct GlobalPositioningTraceParameterSnapshot {
   std::optional<GlobalPositioningTraceSnapshotArray> cams_in_rig;
 };
 
+struct GlobalPositioningTraceResidualValues {
+  int iteration = 0;
+  std::vector<std::string> residual_ids;
+  std::vector<size_t> residual_dims;
+  std::vector<size_t> residual_offsets;
+  std::vector<bool> evaluation_success;
+  std::vector<double> raw_residuals;
+  std::vector<double> raw_costs;
+  std::vector<double> robust_costs;
+};
+
 class GlobalPositioningTraceRecorder {
  public:
   explicit GlobalPositioningTraceRecorder(
@@ -91,6 +102,7 @@ class GlobalPositioningTraceRecorder {
   const std::string& RunId() const { return run_id_; }
   bool IsResidualLedgerEnabled() const;
   bool IsParameterSnapshotsEnabled() const;
+  bool IsResidualValuesEnabled() const;
   std::string AllocateResidualId();
 
   void WriteEvent(GlobalPositioningTraceRecord record);
@@ -100,6 +112,8 @@ class GlobalPositioningTraceRecorder {
   void WriteResidualBucketSummary(GlobalPositioningTraceRecord record);
   void WriteParameterSnapshot(
       const GlobalPositioningTraceParameterSnapshot& snapshot);
+  void WriteResidualValues(
+      const GlobalPositioningTraceResidualValues& residual_values);
   void MarkFinished(std::string status);
 
  private:

--- a/src/colmap/estimators/global_positioning_trace.h
+++ b/src/colmap/estimators/global_positioning_trace.h
@@ -99,6 +99,7 @@ struct GlobalPositioningTraceResidualValues {
   std::vector<double> raw_residuals;
   std::vector<double> raw_costs;
   std::vector<double> robust_costs;
+  std::vector<double> loss_rho_values;
   bool has_raw_jacobians = false;
   std::vector<std::vector<size_t>> parameter_block_sizes;
   std::vector<std::vector<size_t>> raw_jacobian_offsets;

--- a/src/colmap/estimators/global_positioning_trace.h
+++ b/src/colmap/estimators/global_positioning_trace.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <ceres/ceres.h>
+
+namespace colmap {
+
+enum class GlobalPositioningTraceLevel {
+  kOff = 0,
+  kSummary = 1,
+  kResidualLedger = 2,
+  kParameterSnapshots = 3,
+  kResidualValues = 4,
+};
+
+std::string GlobalPositioningTraceLevelToString(
+    GlobalPositioningTraceLevel level);
+
+struct GlobalPositioningTraceOptions {
+  GlobalPositioningTraceLevel level = GlobalPositioningTraceLevel::kOff;
+  std::filesystem::path output_path;
+  std::string run_label;
+  int snapshot_every_n_iterations = 1;
+  int max_snapshotted_points = -1;
+};
+
+struct GlobalPositioningTraceValue {
+  enum class Type {
+    kNull,
+    kBool,
+    kInt,
+    kUInt,
+    kDouble,
+    kString,
+    kStringArray,
+  };
+
+  static GlobalPositioningTraceValue Null();
+  static GlobalPositioningTraceValue Bool(bool value);
+  static GlobalPositioningTraceValue Int(int64_t value);
+  static GlobalPositioningTraceValue UInt(uint64_t value);
+  static GlobalPositioningTraceValue Double(double value);
+  static GlobalPositioningTraceValue String(std::string value);
+  static GlobalPositioningTraceValue StringArray(
+      std::vector<std::string> value);
+
+  Type type = Type::kNull;
+  bool bool_value = false;
+  int64_t int_value = 0;
+  uint64_t uint_value = 0;
+  double double_value = 0.0;
+  std::string string_value;
+  std::vector<std::string> string_array_value;
+};
+
+struct GlobalPositioningTraceRecord {
+  std::string event_type;
+  std::string stage;
+  std::optional<int> iteration;
+  std::map<std::string, GlobalPositioningTraceValue> attrs;
+};
+
+struct GlobalPositioningTraceSnapshotArray {
+  std::vector<uint64_t> ids;
+  std::vector<size_t> shape;
+  std::vector<double> values;
+};
+
+struct GlobalPositioningTraceParameterSnapshot {
+  int iteration = 0;
+  GlobalPositioningTraceSnapshotArray frame_centers;
+  GlobalPositioningTraceSnapshotArray points3D;
+  GlobalPositioningTraceSnapshotArray scales;
+  std::optional<GlobalPositioningTraceSnapshotArray> dmap_scales;
+  std::optional<GlobalPositioningTraceSnapshotArray> cams_in_rig;
+};
+
+class GlobalPositioningTraceRecorder {
+ public:
+  explicit GlobalPositioningTraceRecorder(
+      const GlobalPositioningTraceOptions& options);
+
+  const std::string& RunId() const { return run_id_; }
+  bool IsResidualLedgerEnabled() const;
+  bool IsParameterSnapshotsEnabled() const;
+  std::string AllocateResidualId();
+
+  void WriteEvent(GlobalPositioningTraceRecord record);
+  void WriteIteration(const ceres::IterationSummary& summary);
+  void WriteResidualBlock(GlobalPositioningTraceRecord record);
+  void WriteResidualSkip(GlobalPositioningTraceRecord record);
+  void WriteResidualBucketSummary(GlobalPositioningTraceRecord record);
+  void WriteParameterSnapshot(
+      const GlobalPositioningTraceParameterSnapshot& snapshot);
+  void MarkFinished(std::string status);
+
+ private:
+  void WriteRecord(std::ofstream& stream, GlobalPositioningTraceRecord record);
+  void WriteManifest(const std::string& status);
+
+  GlobalPositioningTraceOptions options_;
+  std::string run_id_;
+  int64_t created_at_unix_ns_ = 0;
+  uint64_t sequence_ = 0;
+  uint64_t residual_sequence_ = 0;
+  std::ofstream events_stream_;
+  std::ofstream iteration_metrics_stream_;
+  std::ofstream residual_blocks_stream_;
+  std::ofstream residual_skips_stream_;
+};
+
+}  // namespace colmap

--- a/src/colmap/estimators/global_positioning_trace.h
+++ b/src/colmap/estimators/global_positioning_trace.h
@@ -33,6 +33,37 @@ struct GlobalPositioningTraceOptions {
   int max_snapshotted_points = -1;
 };
 
+struct GlobalPositioningTraceParameterBlockDescriptor {
+  std::string role;
+  std::string kind;
+  uint64_t id = 0;
+  std::optional<size_t> size;
+};
+
+struct GlobalPositioningTraceLossConfig {
+  std::string bucket;
+  std::string type;
+  std::optional<double> scale;
+  std::optional<double> weight;
+  std::string source;
+  std::optional<double> observation_count_weight;
+};
+
+struct GlobalPositioningTraceFixedParameters {
+  std::optional<std::vector<double>> cam_from_point3D_dir;
+  std::optional<std::vector<double>> keypoint_covariance_world_row_major;
+  std::optional<std::vector<double>> cam_from_rig_dir;
+  std::optional<std::vector<double>> rig_from_world_rotation_wxyz;
+  std::optional<std::vector<double>> world_from_rig_rotation_wxyz;
+  std::optional<std::vector<double>> camera_rotation_wxyz;
+  std::optional<bool> metric_depth_use_log_scale;
+  std::optional<std::string> metric_depth_residual_type;
+  std::optional<bool> metric_depth_zero_residual_behind;
+  std::optional<double> metric_depth_log_linear_threshold;
+  std::optional<double> scale_prior_target;
+  std::optional<double> scale_prior_stddev;
+};
+
 struct GlobalPositioningTraceValue {
   enum class Type {
     kNull,
@@ -42,6 +73,9 @@ struct GlobalPositioningTraceValue {
     kDouble,
     kString,
     kStringArray,
+    kParameterBlockArray,
+    kLossConfig,
+    kFixedParameters,
   };
 
   static GlobalPositioningTraceValue Null();
@@ -52,6 +86,12 @@ struct GlobalPositioningTraceValue {
   static GlobalPositioningTraceValue String(std::string value);
   static GlobalPositioningTraceValue StringArray(
       std::vector<std::string> value);
+  static GlobalPositioningTraceValue ParameterBlockArray(
+      std::vector<GlobalPositioningTraceParameterBlockDescriptor> value);
+  static GlobalPositioningTraceValue LossConfig(
+      GlobalPositioningTraceLossConfig value);
+  static GlobalPositioningTraceValue FixedParameters(
+      GlobalPositioningTraceFixedParameters value);
 
   Type type = Type::kNull;
   bool bool_value = false;
@@ -60,6 +100,10 @@ struct GlobalPositioningTraceValue {
   double double_value = 0.0;
   std::string string_value;
   std::vector<std::string> string_array_value;
+  std::vector<GlobalPositioningTraceParameterBlockDescriptor>
+      parameter_block_array_value;
+  GlobalPositioningTraceLossConfig loss_config_value;
+  GlobalPositioningTraceFixedParameters fixed_parameters_value;
 };
 
 struct GlobalPositioningTraceRecord {
@@ -84,12 +128,6 @@ struct GlobalPositioningTraceParameterSnapshot {
   std::optional<GlobalPositioningTraceSnapshotArray> cams_in_rig;
 };
 
-struct GlobalPositioningTraceParameterBlockDescriptor {
-  std::string role;
-  std::string kind;
-  uint64_t id = 0;
-};
-
 struct GlobalPositioningTraceResidualValues {
   int iteration = 0;
   std::vector<std::string> residual_ids;
@@ -108,6 +146,16 @@ struct GlobalPositioningTraceResidualValues {
   std::vector<std::vector<bool>> parameter_block_is_constant;
   std::vector<std::vector<std::vector<double>>> parameter_block_lower_bounds;
   std::vector<double> raw_jacobians;
+};
+
+struct GlobalPositioningRawBinaryTraceIterationArtifacts {
+  int iteration = 0;
+  bool has_frame_centers = false;
+  bool has_point_xyz = false;
+  bool has_scales = false;
+  bool has_dmap_scales = false;
+  bool has_cams_in_rig = false;
+  bool has_residual_values = false;
 };
 
 class GlobalPositioningTraceRecorder {
@@ -136,16 +184,30 @@ class GlobalPositioningTraceRecorder {
  private:
   void WriteRecord(std::ofstream& stream, GlobalPositioningTraceRecord record);
   void WriteManifest(const std::string& status);
+  void WriteRawBinaryManifest(const std::string& status);
+  void WriteRawBinaryResidualLedgerHeader();
+  void UpdateRawBinaryResidualLedgerHeader();
+  void WriteRawBinaryResidualBlock(const GlobalPositioningTraceRecord& record);
+  void WriteRawBinaryParameterSnapshot(
+      const GlobalPositioningTraceParameterSnapshot& snapshot);
+  void WriteRawBinaryResidualValues(
+      const GlobalPositioningTraceResidualValues& residual_values);
+  GlobalPositioningRawBinaryTraceIterationArtifacts&
+  RawBinaryIterationArtifacts(int iteration);
 
   GlobalPositioningTraceOptions options_;
   std::string run_id_;
   int64_t created_at_unix_ns_ = 0;
   uint64_t sequence_ = 0;
   uint64_t residual_sequence_ = 0;
+  uint64_t raw_binary_residual_ledger_count_ = 0;
   std::ofstream events_stream_;
   std::ofstream iteration_metrics_stream_;
   std::ofstream residual_blocks_stream_;
   std::ofstream residual_skips_stream_;
+  std::ofstream raw_binary_residual_ledger_stream_;
+  std::vector<GlobalPositioningRawBinaryTraceIterationArtifacts>
+      raw_binary_iterations_;
 };
 
 }  // namespace colmap

--- a/src/colmap/estimators/global_positioning_trace.h
+++ b/src/colmap/estimators/global_positioning_trace.h
@@ -19,6 +19,7 @@ enum class GlobalPositioningTraceLevel {
   kResidualLedger = 2,
   kParameterSnapshots = 3,
   kResidualValues = 4,
+  kResidualJacobians = 5,
 };
 
 std::string GlobalPositioningTraceLevelToString(
@@ -83,6 +84,12 @@ struct GlobalPositioningTraceParameterSnapshot {
   std::optional<GlobalPositioningTraceSnapshotArray> cams_in_rig;
 };
 
+struct GlobalPositioningTraceParameterBlockDescriptor {
+  std::string role;
+  std::string kind;
+  uint64_t id = 0;
+};
+
 struct GlobalPositioningTraceResidualValues {
   int iteration = 0;
   std::vector<std::string> residual_ids;
@@ -92,6 +99,14 @@ struct GlobalPositioningTraceResidualValues {
   std::vector<double> raw_residuals;
   std::vector<double> raw_costs;
   std::vector<double> robust_costs;
+  bool has_raw_jacobians = false;
+  std::vector<std::vector<size_t>> parameter_block_sizes;
+  std::vector<std::vector<size_t>> raw_jacobian_offsets;
+  std::vector<std::vector<GlobalPositioningTraceParameterBlockDescriptor>>
+      parameter_blocks;
+  std::vector<std::vector<bool>> parameter_block_is_constant;
+  std::vector<std::vector<std::vector<double>>> parameter_block_lower_bounds;
+  std::vector<double> raw_jacobians;
 };
 
 class GlobalPositioningTraceRecorder {
@@ -103,6 +118,7 @@ class GlobalPositioningTraceRecorder {
   bool IsResidualLedgerEnabled() const;
   bool IsParameterSnapshotsEnabled() const;
   bool IsResidualValuesEnabled() const;
+  bool IsResidualJacobiansEnabled() const;
   std::string AllocateResidualId();
 
   void WriteEvent(GlobalPositioningTraceRecord record);

--- a/src/colmap/estimators/global_positioning_trace.h
+++ b/src/colmap/estimators/global_positioning_trace.h
@@ -30,7 +30,7 @@ struct GlobalPositioningTraceOptions {
   std::filesystem::path output_path;
   std::string run_label;
   int snapshot_every_n_iterations = 1;
-  int max_snapshotted_points = -1;
+  bool write_legacy_jsonl = true;
 };
 
 struct GlobalPositioningTraceParameterBlockDescriptor {
@@ -158,6 +158,12 @@ struct GlobalPositioningRawBinaryTraceIterationArtifacts {
   bool has_residual_values = false;
 };
 
+struct GlobalPositioningRawBinaryResidualPointIndexEntry {
+  int64_t min_frame_id = 0;
+  int64_t max_frame_id = 0;
+  std::vector<uint64_t> residual_ledger_offsets;
+};
+
 class GlobalPositioningTraceRecorder {
  public:
   explicit GlobalPositioningTraceRecorder(
@@ -188,6 +194,7 @@ class GlobalPositioningTraceRecorder {
   void WriteRawBinaryResidualLedgerHeader();
   void UpdateRawBinaryResidualLedgerHeader();
   void WriteRawBinaryResidualBlock(const GlobalPositioningTraceRecord& record);
+  void WriteRawBinaryResidualPointIndex();
   void WriteRawBinaryParameterSnapshot(
       const GlobalPositioningTraceParameterSnapshot& snapshot);
   void WriteRawBinaryResidualValues(
@@ -206,6 +213,8 @@ class GlobalPositioningTraceRecorder {
   std::ofstream residual_blocks_stream_;
   std::ofstream residual_skips_stream_;
   std::ofstream raw_binary_residual_ledger_stream_;
+  std::map<uint64_t, GlobalPositioningRawBinaryResidualPointIndexEntry>
+      raw_binary_residual_point_index_;
   std::vector<GlobalPositioningRawBinaryTraceIterationArtifacts>
       raw_binary_iterations_;
 };

--- a/src/colmap/estimators/global_positioning_tracer.cc
+++ b/src/colmap/estimators/global_positioning_tracer.cc
@@ -1,10 +1,10 @@
 #include "colmap/estimators/global_positioning_tracer.h"
 
+#include "colmap/estimators/global_positioning_residual_evaluation.h"
 #include "colmap/scene/reconstruction.h"
 #include "colmap/util/misc.h"
 
 #include <algorithm>
-#include <limits>
 #include <utility>
 
 namespace colmap {
@@ -33,6 +33,30 @@ std::optional<uint64_t> TraceSensorId(
     return std::nullopt;
   }
   return static_cast<uint64_t>(sensor_id->id);
+}
+
+std::vector<std::string> DeferredFixedParametersForReplay(
+    const GlobalPositioningResidualDescriptor& residual) {
+  if (residual.residual_type == "bata_ref_frame") {
+    std::vector<std::string> missing = {"cam_from_point3D_dir"};
+    if (residual.uses_keypoint_covariance) {
+      missing.push_back("keypoint_covariance_left_sqrt_info");
+    }
+    return missing;
+  }
+  if (residual.residual_type == "bata_constant_rig") {
+    return {"cam_from_point3D_dir", "cam_from_rig_dir"};
+  }
+  if (residual.residual_type == "bata_variable_rig") {
+    return {"cam_from_point3D_dir", "world_from_rig_rot"};
+  }
+  if (residual.residual_type == "metric_depth") {
+    return {"camera_rotation", "metric_depth_options"};
+  }
+  if (residual.residual_type == "scale_prior") {
+    return {"scale_prior_target", "scale_prior_stddev"};
+  }
+  return {"unclassified_fixed_parameters"};
 }
 
 void WriteParameterSnapshot(
@@ -131,210 +155,6 @@ void WriteParameterSnapshot(
   recorder->WriteParameterSnapshot(snapshot);
 }
 
-void WriteResidualValues(
-    GlobalPositioningTraceRecorder* recorder,
-    const ceres::Problem& problem,
-    const int iteration,
-    const std::vector<GlobalPositioningResidualReplayEntry>& replay_entries,
-    const bool write_raw_jacobians) {
-  if (recorder == nullptr) {
-    return;
-  }
-
-  GlobalPositioningTraceResidualValues residual_values;
-  residual_values.iteration = iteration;
-  residual_values.residual_ids.reserve(replay_entries.size());
-  residual_values.residual_dims.reserve(replay_entries.size());
-  residual_values.residual_offsets.reserve(replay_entries.size());
-  residual_values.evaluation_success.resize(replay_entries.size(), false);
-  residual_values.raw_costs.resize(replay_entries.size(),
-                                   std::numeric_limits<double>::quiet_NaN());
-  residual_values.robust_costs.resize(replay_entries.size(),
-                                      std::numeric_limits<double>::quiet_NaN());
-  residual_values.loss_rho_values.resize(
-      replay_entries.size() * 3, std::numeric_limits<double>::quiet_NaN());
-  residual_values.has_raw_jacobians = write_raw_jacobians;
-  if (write_raw_jacobians) {
-    residual_values.parameter_block_sizes.reserve(replay_entries.size());
-    residual_values.raw_jacobian_offsets.reserve(replay_entries.size());
-    residual_values.parameter_blocks.reserve(replay_entries.size());
-    residual_values.parameter_block_is_constant.reserve(replay_entries.size());
-    residual_values.parameter_block_lower_bounds.reserve(replay_entries.size());
-  }
-
-  size_t total_scalar_residuals = 0;
-  size_t total_jacobian_scalars = 0;
-  for (const GlobalPositioningResidualReplayEntry& entry : replay_entries) {
-    THROW_CHECK(!entry.residual_id.empty())
-        << "Residual replay entry has an empty residual id.";
-    THROW_CHECK(entry.cost_function != nullptr)
-        << "Residual replay entry " << entry.residual_id
-        << " has a null cost function.";
-    THROW_CHECK_EQ(entry.residual_dimension,
-                   static_cast<size_t>(entry.cost_function->num_residuals()))
-        << "Residual replay entry " << entry.residual_id
-        << " residual dimension does not match the Ceres cost function.";
-    const std::vector<int>& cost_function_parameter_block_sizes =
-        entry.cost_function->parameter_block_sizes();
-    THROW_CHECK_EQ(entry.parameter_block_sizes.size(),
-                   cost_function_parameter_block_sizes.size())
-        << "Residual replay entry " << entry.residual_id
-        << " parameter-block size count does not match the Ceres cost "
-           "function.";
-    THROW_CHECK_EQ(entry.parameter_blocks.size(),
-                   entry.parameter_block_sizes.size())
-        << "Residual replay entry " << entry.residual_id
-        << " parameter-block pointer count does not match the stored block "
-           "sizes.";
-    THROW_CHECK_EQ(entry.parameter_block_descriptors.size(),
-                   entry.parameter_block_sizes.size())
-        << "Residual replay entry " << entry.residual_id
-        << " parameter-block descriptor count does not match the stored block "
-           "sizes.";
-    for (size_t block_idx = 0; block_idx < entry.parameter_blocks.size();
-         ++block_idx) {
-      THROW_CHECK(entry.parameter_blocks[block_idx] != nullptr)
-          << "Residual replay entry " << entry.residual_id
-          << " has a null parameter block pointer at index " << block_idx
-          << ".";
-      THROW_CHECK_EQ(entry.parameter_block_sizes[block_idx],
-                     cost_function_parameter_block_sizes[block_idx])
-          << "Residual replay entry " << entry.residual_id
-          << " parameter block size at index " << block_idx
-          << " does not match the Ceres cost function.";
-      THROW_CHECK_GT(entry.parameter_block_sizes[block_idx], 0)
-          << "Residual replay entry " << entry.residual_id
-          << " parameter block size at index " << block_idx
-          << " must be positive.";
-      THROW_CHECK(!entry.parameter_block_descriptors[block_idx].role.empty())
-          << "Residual replay entry " << entry.residual_id
-          << " parameter block descriptor at index " << block_idx
-          << " has an empty role.";
-      THROW_CHECK(!entry.parameter_block_descriptors[block_idx].kind.empty())
-          << "Residual replay entry " << entry.residual_id
-          << " parameter block descriptor at index " << block_idx
-          << " has an empty kind.";
-    }
-
-    residual_values.residual_ids.push_back(entry.residual_id);
-    residual_values.residual_dims.push_back(entry.residual_dimension);
-    residual_values.residual_offsets.push_back(total_scalar_residuals);
-    total_scalar_residuals += entry.residual_dimension;
-    if (write_raw_jacobians) {
-      std::vector<size_t> parameter_block_sizes;
-      std::vector<size_t> raw_jacobian_offsets;
-      std::vector<bool> parameter_block_is_constant;
-      std::vector<std::vector<double>> parameter_block_lower_bounds;
-      parameter_block_sizes.reserve(entry.parameter_block_sizes.size());
-      raw_jacobian_offsets.reserve(entry.parameter_block_sizes.size());
-      parameter_block_is_constant.reserve(entry.parameter_block_sizes.size());
-      parameter_block_lower_bounds.reserve(entry.parameter_block_sizes.size());
-      for (size_t block_idx = 0; block_idx < entry.parameter_block_sizes.size();
-           ++block_idx) {
-        const int parameter_block_size = entry.parameter_block_sizes[block_idx];
-        parameter_block_sizes.push_back(
-            static_cast<size_t>(parameter_block_size));
-        raw_jacobian_offsets.push_back(total_jacobian_scalars);
-        parameter_block_is_constant.push_back(problem.IsParameterBlockConstant(
-            entry.parameter_blocks[block_idx]));
-        std::vector<double> lower_bounds;
-        lower_bounds.reserve(static_cast<size_t>(parameter_block_size));
-        for (int parameter_idx = 0; parameter_idx < parameter_block_size;
-             ++parameter_idx) {
-          lower_bounds.push_back(problem.GetParameterLowerBound(
-              entry.parameter_blocks[block_idx], parameter_idx));
-        }
-        parameter_block_lower_bounds.push_back(std::move(lower_bounds));
-        total_jacobian_scalars += entry.residual_dimension *
-                                  static_cast<size_t>(parameter_block_size);
-      }
-      residual_values.parameter_block_sizes.push_back(
-          std::move(parameter_block_sizes));
-      residual_values.raw_jacobian_offsets.push_back(
-          std::move(raw_jacobian_offsets));
-      residual_values.parameter_blocks.push_back(
-          entry.parameter_block_descriptors);
-      residual_values.parameter_block_is_constant.push_back(
-          std::move(parameter_block_is_constant));
-      residual_values.parameter_block_lower_bounds.push_back(
-          std::move(parameter_block_lower_bounds));
-    }
-  }
-  residual_values.raw_residuals.resize(
-      total_scalar_residuals, std::numeric_limits<double>::quiet_NaN());
-  if (write_raw_jacobians) {
-    residual_values.raw_jacobians.resize(
-        total_jacobian_scalars, std::numeric_limits<double>::quiet_NaN());
-  }
-
-  for (size_t entry_idx = 0; entry_idx < replay_entries.size(); ++entry_idx) {
-    const GlobalPositioningResidualReplayEntry& entry =
-        replay_entries[entry_idx];
-    std::vector<double> raw_jacobian_workspace;
-    std::vector<double*> raw_jacobian_blocks;
-    if (write_raw_jacobians) {
-      size_t workspace_offset = 0;
-      for (const int parameter_block_size : entry.parameter_block_sizes) {
-        workspace_offset += entry.residual_dimension *
-                            static_cast<size_t>(parameter_block_size);
-      }
-      raw_jacobian_workspace.assign(workspace_offset,
-                                    std::numeric_limits<double>::quiet_NaN());
-      raw_jacobian_blocks.reserve(entry.parameter_block_sizes.size());
-      workspace_offset = 0;
-      for (const int parameter_block_size : entry.parameter_block_sizes) {
-        raw_jacobian_blocks.push_back(raw_jacobian_workspace.data() +
-                                      workspace_offset);
-        workspace_offset += entry.residual_dimension *
-                            static_cast<size_t>(parameter_block_size);
-      }
-    }
-
-    double* raw_residuals = residual_values.raw_residuals.data() +
-                            residual_values.residual_offsets[entry_idx];
-    const bool evaluation_success = entry.cost_function->Evaluate(
-        entry.parameter_blocks.data(),
-        raw_residuals,
-        write_raw_jacobians ? raw_jacobian_blocks.data() : nullptr);
-    residual_values.evaluation_success[entry_idx] = evaluation_success;
-    if (!evaluation_success) {
-      continue;
-    }
-    if (write_raw_jacobians) {
-      for (size_t block_idx = 0; block_idx < entry.parameter_block_sizes.size();
-           ++block_idx) {
-        const size_t jacobian_size =
-            entry.residual_dimension *
-            static_cast<size_t>(entry.parameter_block_sizes[block_idx]);
-        std::copy_n(
-            raw_jacobian_blocks[block_idx],
-            jacobian_size,
-            residual_values.raw_jacobians.data() +
-                residual_values.raw_jacobian_offsets[entry_idx][block_idx]);
-      }
-    }
-
-    double squared_norm = 0.0;
-    for (size_t residual_idx = 0; residual_idx < entry.residual_dimension;
-         ++residual_idx) {
-      squared_norm += raw_residuals[residual_idx] * raw_residuals[residual_idx];
-    }
-
-    const double raw_cost = 0.5 * squared_norm;
-    residual_values.raw_costs[entry_idx] = raw_cost;
-    double rho[3] = {squared_norm, 1.0, 0.0};
-    if (entry.loss_function != nullptr) {
-      entry.loss_function->Evaluate(squared_norm, rho);
-    }
-    residual_values.loss_rho_values[3 * entry_idx] = rho[0];
-    residual_values.loss_rho_values[3 * entry_idx + 1] = rho[1];
-    residual_values.loss_rho_values[3 * entry_idx + 2] = rho[2];
-    residual_values.robust_costs[entry_idx] = 0.5 * rho[0];
-  }
-
-  recorder->WriteResidualValues(residual_values);
-}
-
 class GlobalPositioningTraceIterationCallback
     : public ceres::IterationCallback {
  public:
@@ -385,11 +205,11 @@ class GlobalPositioningTraceIterationCallback
                                max_snapshotted_points_);
       }
       if (write_residual_values_) {
-        WriteResidualValues(recorder_,
-                            *problem_,
-                            summary.iteration,
-                            *residual_replay_entries_,
-                            write_raw_jacobians_);
+        recorder_->WriteResidualValues(
+            EvaluateGlobalPositioningResiduals({*problem_,
+                                                summary.iteration,
+                                                *residual_replay_entries_,
+                                                write_raw_jacobians_}));
       }
     }
     return ceres::SOLVER_CONTINUE;
@@ -508,27 +328,59 @@ std::string GlobalPositioningTracer::RecordResidual(
   GlobalPositioningTraceRecord record =
       MakeResidualRecord(residual, "residual_added", "problem_build");
   record.attrs["residual_id"] = TraceValue::String(residual_id);
+  record.attrs["replay_schema_version"] = TraceValue::Int(1);
+  THROW_CHECK(cost_function != nullptr)
+      << "Residual ledger tracing requires every recorded residual to have a "
+         "cost function so parameter block descriptors can be serialized.";
+  const std::vector<int>& parameter_block_sizes =
+      cost_function->parameter_block_sizes();
+  THROW_CHECK_EQ(parameter_blocks.size(), parameter_block_sizes.size())
+      << "Residual ledger parameter-block count does not match the Ceres cost "
+         "function.";
+  THROW_CHECK_EQ(parameter_block_descriptors.size(),
+                 parameter_block_sizes.size())
+      << "Residual ledger parameter-block descriptor count does not match the "
+         "Ceres cost function.";
+  std::vector<GlobalPositioningTraceParameterBlockDescriptor>
+      ledger_parameter_block_descriptors = parameter_block_descriptors;
+  for (size_t block_idx = 0; block_idx < parameter_block_sizes.size();
+       ++block_idx) {
+    THROW_CHECK(parameter_blocks[block_idx] != nullptr)
+        << "Residual ledger parameter block pointer is null.";
+    THROW_CHECK(!ledger_parameter_block_descriptors[block_idx].role.empty())
+        << "Residual ledger parameter block role must be non-empty.";
+    THROW_CHECK(!ledger_parameter_block_descriptors[block_idx].kind.empty())
+        << "Residual ledger parameter block kind must be non-empty.";
+    THROW_CHECK_GT(parameter_block_sizes[block_idx], 0)
+        << "Residual ledger parameter block size must be positive.";
+    ledger_parameter_block_descriptors[block_idx].size =
+        static_cast<size_t>(parameter_block_sizes[block_idx]);
+  }
+  record.attrs["parameter_blocks"] = TraceValue::ParameterBlockArray(
+      std::move(ledger_parameter_block_descriptors));
+  THROW_CHECK(residual.loss.has_value())
+      << "Residual ledger tracing requires an explicit loss config for "
+         "residual type "
+      << residual.residual_type << " and loss bucket " << residual.loss_bucket
+      << ".";
+  record.attrs["loss"] = TraceValue::LossConfig(*residual.loss);
+  if (residual.fixed_parameters.has_value()) {
+    record.attrs["fixed_parameters_status"] = TraceValue::String("serialized");
+    record.attrs["fixed_parameters"] =
+        TraceValue::FixedParameters(*residual.fixed_parameters);
+  } else {
+    record.attrs["fixed_parameters_status"] =
+        TraceValue::String("deferred_not_serialized");
+    record.attrs["fixed_parameters_todo"] = TraceValue::String(
+        "GP_REPLAY_FIXED_PARAMETERS_" + residual.residual_type);
+    record.attrs["fixed_parameters_missing"] =
+        TraceValue::StringArray(DeferredFixedParametersForReplay(residual));
+  }
   recorder_->WriteResidualBlock(std::move(record));
   ++residual_bucket_counts_[residual.residual_type + "|" +
                             residual.loss_bucket];
 
   if (ResidualValuesEnabled()) {
-    THROW_CHECK(cost_function != nullptr)
-        << "Residual-values tracing requires every recorded residual to have a "
-           "cost function.";
-    const std::vector<int>& parameter_block_sizes =
-        cost_function->parameter_block_sizes();
-    THROW_CHECK_EQ(parameter_blocks.size(), parameter_block_sizes.size())
-        << "Residual replay parameter-block count does not match the Ceres "
-           "cost function.";
-    THROW_CHECK_EQ(parameter_block_descriptors.size(),
-                   parameter_block_sizes.size())
-        << "Residual replay parameter-block descriptor count does not match "
-           "the Ceres cost function.";
-    for (const double* parameter_block : parameter_blocks) {
-      THROW_CHECK(parameter_block != nullptr)
-          << "Residual replay parameter block pointer is null.";
-    }
     residual_replay_entries_.push_back(
         {residual_id,
          cost_function,

--- a/src/colmap/estimators/global_positioning_tracer.cc
+++ b/src/colmap/estimators/global_positioning_tracer.cc
@@ -151,6 +151,8 @@ void WriteResidualValues(
                                    std::numeric_limits<double>::quiet_NaN());
   residual_values.robust_costs.resize(replay_entries.size(),
                                       std::numeric_limits<double>::quiet_NaN());
+  residual_values.loss_rho_values.resize(
+      replay_entries.size() * 3, std::numeric_limits<double>::quiet_NaN());
   residual_values.has_raw_jacobians = write_raw_jacobians;
   if (write_raw_jacobians) {
     residual_values.parameter_block_sizes.reserve(replay_entries.size());
@@ -320,13 +322,14 @@ void WriteResidualValues(
 
     const double raw_cost = 0.5 * squared_norm;
     residual_values.raw_costs[entry_idx] = raw_cost;
+    double rho[3] = {squared_norm, 1.0, 0.0};
     if (entry.loss_function != nullptr) {
-      double rho[3];
       entry.loss_function->Evaluate(squared_norm, rho);
-      residual_values.robust_costs[entry_idx] = 0.5 * rho[0];
-    } else {
-      residual_values.robust_costs[entry_idx] = raw_cost;
     }
+    residual_values.loss_rho_values[3 * entry_idx] = rho[0];
+    residual_values.loss_rho_values[3 * entry_idx + 1] = rho[1];
+    residual_values.loss_rho_values[3 * entry_idx + 2] = rho[2];
+    residual_values.robust_costs[entry_idx] = 0.5 * rho[0];
   }
 
   recorder->WriteResidualValues(residual_values);

--- a/src/colmap/estimators/global_positioning_tracer.cc
+++ b/src/colmap/estimators/global_positioning_tracer.cc
@@ -66,8 +66,7 @@ void WriteParameterSnapshot(
     const std::unordered_map<frame_t, Eigen::Vector3d>& frame_centers,
     const std::vector<double>& scales,
     const std::map<image_t, double>& dmap_scales,
-    const std::unordered_map<sensor_t, Eigen::Vector3d>& cams_in_rig,
-    const int max_snapshotted_points) {
+    const std::unordered_map<sensor_t, Eigen::Vector3d>& cams_in_rig) {
   if (recorder == nullptr) {
     return;
   }
@@ -98,10 +97,6 @@ void WriteParameterSnapshot(
     point3D_ids.push_back(point3D_id);
   }
   std::sort(point3D_ids.begin(), point3D_ids.end());
-  if (max_snapshotted_points >= 0 &&
-      point3D_ids.size() > static_cast<size_t>(max_snapshotted_points)) {
-    point3D_ids.resize(static_cast<size_t>(max_snapshotted_points));
-  }
   snapshot.points3D.shape = {point3D_ids.size(), 3};
   snapshot.points3D.ids.reserve(point3D_ids.size());
   snapshot.points3D.values.reserve(3 * point3D_ids.size());
@@ -169,7 +164,6 @@ class GlobalPositioningTraceIterationCallback
       const std::vector<GlobalPositioningResidualReplayEntry>*
           residual_replay_entries,
       const int snapshot_every_n_iterations,
-      const int max_snapshotted_points,
       const bool write_parameter_snapshots,
       const bool write_residual_values,
       const bool write_raw_jacobians)
@@ -182,7 +176,6 @@ class GlobalPositioningTraceIterationCallback
         cams_in_rig_(cams_in_rig),
         residual_replay_entries_(residual_replay_entries),
         snapshot_every_n_iterations_(snapshot_every_n_iterations),
-        max_snapshotted_points_(max_snapshotted_points),
         write_parameter_snapshots_(write_parameter_snapshots),
         write_residual_values_(write_residual_values),
         write_raw_jacobians_(write_raw_jacobians) {}
@@ -201,8 +194,7 @@ class GlobalPositioningTraceIterationCallback
                                *frame_centers_,
                                *scales_,
                                *dmap_scales_,
-                               *cams_in_rig_,
-                               max_snapshotted_points_);
+                               *cams_in_rig_);
       }
       if (write_residual_values_) {
         recorder_->WriteResidualValues(
@@ -226,7 +218,6 @@ class GlobalPositioningTraceIterationCallback
   const std::vector<GlobalPositioningResidualReplayEntry>*
       residual_replay_entries_ = nullptr;
   int snapshot_every_n_iterations_ = 1;
-  int max_snapshotted_points_ = -1;
   bool write_parameter_snapshots_ = false;
   bool write_residual_values_ = false;
   bool write_raw_jacobians_ = false;
@@ -445,7 +436,6 @@ GlobalPositioningTracer::CreateIterationCallback(
       &live_state.cams_in_rig,
       &residual_replay_entries_,
       options_.snapshot_every_n_iterations,
-      options_.max_snapshotted_points,
       ParameterSnapshotsEnabled(),
       ResidualValuesEnabled(),
       ResidualJacobiansEnabled());

--- a/src/colmap/estimators/global_positioning_tracer.cc
+++ b/src/colmap/estimators/global_positioning_tracer.cc
@@ -133,8 +133,10 @@ void WriteParameterSnapshot(
 
 void WriteResidualValues(
     GlobalPositioningTraceRecorder* recorder,
+    const ceres::Problem& problem,
     const int iteration,
-    const std::vector<GlobalPositioningResidualReplayEntry>& replay_entries) {
+    const std::vector<GlobalPositioningResidualReplayEntry>& replay_entries,
+    const bool write_raw_jacobians) {
   if (recorder == nullptr) {
     return;
   }
@@ -149,31 +151,165 @@ void WriteResidualValues(
                                    std::numeric_limits<double>::quiet_NaN());
   residual_values.robust_costs.resize(replay_entries.size(),
                                       std::numeric_limits<double>::quiet_NaN());
+  residual_values.has_raw_jacobians = write_raw_jacobians;
+  if (write_raw_jacobians) {
+    residual_values.parameter_block_sizes.reserve(replay_entries.size());
+    residual_values.raw_jacobian_offsets.reserve(replay_entries.size());
+    residual_values.parameter_blocks.reserve(replay_entries.size());
+    residual_values.parameter_block_is_constant.reserve(replay_entries.size());
+    residual_values.parameter_block_lower_bounds.reserve(replay_entries.size());
+  }
 
   size_t total_scalar_residuals = 0;
+  size_t total_jacobian_scalars = 0;
   for (const GlobalPositioningResidualReplayEntry& entry : replay_entries) {
+    THROW_CHECK(!entry.residual_id.empty())
+        << "Residual replay entry has an empty residual id.";
+    THROW_CHECK(entry.cost_function != nullptr)
+        << "Residual replay entry " << entry.residual_id
+        << " has a null cost function.";
+    THROW_CHECK_EQ(entry.residual_dimension,
+                   static_cast<size_t>(entry.cost_function->num_residuals()))
+        << "Residual replay entry " << entry.residual_id
+        << " residual dimension does not match the Ceres cost function.";
+    const std::vector<int>& cost_function_parameter_block_sizes =
+        entry.cost_function->parameter_block_sizes();
+    THROW_CHECK_EQ(entry.parameter_block_sizes.size(),
+                   cost_function_parameter_block_sizes.size())
+        << "Residual replay entry " << entry.residual_id
+        << " parameter-block size count does not match the Ceres cost "
+           "function.";
+    THROW_CHECK_EQ(entry.parameter_blocks.size(),
+                   entry.parameter_block_sizes.size())
+        << "Residual replay entry " << entry.residual_id
+        << " parameter-block pointer count does not match the stored block "
+           "sizes.";
+    THROW_CHECK_EQ(entry.parameter_block_descriptors.size(),
+                   entry.parameter_block_sizes.size())
+        << "Residual replay entry " << entry.residual_id
+        << " parameter-block descriptor count does not match the stored block "
+           "sizes.";
+    for (size_t block_idx = 0; block_idx < entry.parameter_blocks.size();
+         ++block_idx) {
+      THROW_CHECK(entry.parameter_blocks[block_idx] != nullptr)
+          << "Residual replay entry " << entry.residual_id
+          << " has a null parameter block pointer at index " << block_idx
+          << ".";
+      THROW_CHECK_EQ(entry.parameter_block_sizes[block_idx],
+                     cost_function_parameter_block_sizes[block_idx])
+          << "Residual replay entry " << entry.residual_id
+          << " parameter block size at index " << block_idx
+          << " does not match the Ceres cost function.";
+      THROW_CHECK_GT(entry.parameter_block_sizes[block_idx], 0)
+          << "Residual replay entry " << entry.residual_id
+          << " parameter block size at index " << block_idx
+          << " must be positive.";
+      THROW_CHECK(!entry.parameter_block_descriptors[block_idx].role.empty())
+          << "Residual replay entry " << entry.residual_id
+          << " parameter block descriptor at index " << block_idx
+          << " has an empty role.";
+      THROW_CHECK(!entry.parameter_block_descriptors[block_idx].kind.empty())
+          << "Residual replay entry " << entry.residual_id
+          << " parameter block descriptor at index " << block_idx
+          << " has an empty kind.";
+    }
+
     residual_values.residual_ids.push_back(entry.residual_id);
     residual_values.residual_dims.push_back(entry.residual_dimension);
     residual_values.residual_offsets.push_back(total_scalar_residuals);
     total_scalar_residuals += entry.residual_dimension;
+    if (write_raw_jacobians) {
+      std::vector<size_t> parameter_block_sizes;
+      std::vector<size_t> raw_jacobian_offsets;
+      std::vector<bool> parameter_block_is_constant;
+      std::vector<std::vector<double>> parameter_block_lower_bounds;
+      parameter_block_sizes.reserve(entry.parameter_block_sizes.size());
+      raw_jacobian_offsets.reserve(entry.parameter_block_sizes.size());
+      parameter_block_is_constant.reserve(entry.parameter_block_sizes.size());
+      parameter_block_lower_bounds.reserve(entry.parameter_block_sizes.size());
+      for (size_t block_idx = 0; block_idx < entry.parameter_block_sizes.size();
+           ++block_idx) {
+        const int parameter_block_size = entry.parameter_block_sizes[block_idx];
+        parameter_block_sizes.push_back(
+            static_cast<size_t>(parameter_block_size));
+        raw_jacobian_offsets.push_back(total_jacobian_scalars);
+        parameter_block_is_constant.push_back(problem.IsParameterBlockConstant(
+            entry.parameter_blocks[block_idx]));
+        std::vector<double> lower_bounds;
+        lower_bounds.reserve(static_cast<size_t>(parameter_block_size));
+        for (int parameter_idx = 0; parameter_idx < parameter_block_size;
+             ++parameter_idx) {
+          lower_bounds.push_back(problem.GetParameterLowerBound(
+              entry.parameter_blocks[block_idx], parameter_idx));
+        }
+        parameter_block_lower_bounds.push_back(std::move(lower_bounds));
+        total_jacobian_scalars += entry.residual_dimension *
+                                  static_cast<size_t>(parameter_block_size);
+      }
+      residual_values.parameter_block_sizes.push_back(
+          std::move(parameter_block_sizes));
+      residual_values.raw_jacobian_offsets.push_back(
+          std::move(raw_jacobian_offsets));
+      residual_values.parameter_blocks.push_back(
+          entry.parameter_block_descriptors);
+      residual_values.parameter_block_is_constant.push_back(
+          std::move(parameter_block_is_constant));
+      residual_values.parameter_block_lower_bounds.push_back(
+          std::move(parameter_block_lower_bounds));
+    }
   }
   residual_values.raw_residuals.resize(
       total_scalar_residuals, std::numeric_limits<double>::quiet_NaN());
+  if (write_raw_jacobians) {
+    residual_values.raw_jacobians.resize(
+        total_jacobian_scalars, std::numeric_limits<double>::quiet_NaN());
+  }
 
   for (size_t entry_idx = 0; entry_idx < replay_entries.size(); ++entry_idx) {
     const GlobalPositioningResidualReplayEntry& entry =
         replay_entries[entry_idx];
-    if (entry.cost_function == nullptr) {
-      continue;
+    std::vector<double> raw_jacobian_workspace;
+    std::vector<double*> raw_jacobian_blocks;
+    if (write_raw_jacobians) {
+      size_t workspace_offset = 0;
+      for (const int parameter_block_size : entry.parameter_block_sizes) {
+        workspace_offset += entry.residual_dimension *
+                            static_cast<size_t>(parameter_block_size);
+      }
+      raw_jacobian_workspace.assign(workspace_offset,
+                                    std::numeric_limits<double>::quiet_NaN());
+      raw_jacobian_blocks.reserve(entry.parameter_block_sizes.size());
+      workspace_offset = 0;
+      for (const int parameter_block_size : entry.parameter_block_sizes) {
+        raw_jacobian_blocks.push_back(raw_jacobian_workspace.data() +
+                                      workspace_offset);
+        workspace_offset += entry.residual_dimension *
+                            static_cast<size_t>(parameter_block_size);
+      }
     }
 
     double* raw_residuals = residual_values.raw_residuals.data() +
                             residual_values.residual_offsets[entry_idx];
     const bool evaluation_success = entry.cost_function->Evaluate(
-        entry.parameter_blocks.data(), raw_residuals, nullptr);
+        entry.parameter_blocks.data(),
+        raw_residuals,
+        write_raw_jacobians ? raw_jacobian_blocks.data() : nullptr);
     residual_values.evaluation_success[entry_idx] = evaluation_success;
     if (!evaluation_success) {
       continue;
+    }
+    if (write_raw_jacobians) {
+      for (size_t block_idx = 0; block_idx < entry.parameter_block_sizes.size();
+           ++block_idx) {
+        const size_t jacobian_size =
+            entry.residual_dimension *
+            static_cast<size_t>(entry.parameter_block_sizes[block_idx]);
+        std::copy_n(
+            raw_jacobian_blocks[block_idx],
+            jacobian_size,
+            residual_values.raw_jacobians.data() +
+                residual_values.raw_jacobian_offsets[entry_idx][block_idx]);
+      }
     }
 
     double squared_norm = 0.0;
@@ -201,6 +337,7 @@ class GlobalPositioningTraceIterationCallback
  public:
   GlobalPositioningTraceIterationCallback(
       GlobalPositioningTraceRecorder* recorder,
+      const ceres::Problem* problem,
       const Reconstruction* reconstruction,
       const std::unordered_map<frame_t, Eigen::Vector3d>* frame_centers,
       const std::vector<double>* scales,
@@ -211,8 +348,10 @@ class GlobalPositioningTraceIterationCallback
       const int snapshot_every_n_iterations,
       const int max_snapshotted_points,
       const bool write_parameter_snapshots,
-      const bool write_residual_values)
+      const bool write_residual_values,
+      const bool write_raw_jacobians)
       : recorder_(recorder),
+        problem_(problem),
         reconstruction_(reconstruction),
         frame_centers_(frame_centers),
         scales_(scales),
@@ -222,7 +361,8 @@ class GlobalPositioningTraceIterationCallback
         snapshot_every_n_iterations_(snapshot_every_n_iterations),
         max_snapshotted_points_(max_snapshotted_points),
         write_parameter_snapshots_(write_parameter_snapshots),
-        write_residual_values_(write_residual_values) {}
+        write_residual_values_(write_residual_values),
+        write_raw_jacobians_(write_raw_jacobians) {}
 
   ceres::CallbackReturnType operator()(
       const ceres::IterationSummary& summary) override {
@@ -242,8 +382,11 @@ class GlobalPositioningTraceIterationCallback
                                max_snapshotted_points_);
       }
       if (write_residual_values_) {
-        WriteResidualValues(
-            recorder_, summary.iteration, *residual_replay_entries_);
+        WriteResidualValues(recorder_,
+                            *problem_,
+                            summary.iteration,
+                            *residual_replay_entries_,
+                            write_raw_jacobians_);
       }
     }
     return ceres::SOLVER_CONTINUE;
@@ -251,6 +394,7 @@ class GlobalPositioningTraceIterationCallback
 
  private:
   GlobalPositioningTraceRecorder* recorder_ = nullptr;
+  const ceres::Problem* problem_ = nullptr;
   const Reconstruction* reconstruction_ = nullptr;
   const std::unordered_map<frame_t, Eigen::Vector3d>* frame_centers_ = nullptr;
   const std::vector<double>* scales_ = nullptr;
@@ -262,6 +406,7 @@ class GlobalPositioningTraceIterationCallback
   int max_snapshotted_points_ = -1;
   bool write_parameter_snapshots_ = false;
   bool write_residual_values_ = false;
+  bool write_raw_jacobians_ = false;
 };
 
 }  // namespace
@@ -292,6 +437,10 @@ bool GlobalPositioningTracer::ParameterSnapshotsEnabled() const {
 
 bool GlobalPositioningTracer::ResidualValuesEnabled() const {
   return recorder_ != nullptr && recorder_->IsResidualValuesEnabled();
+}
+
+bool GlobalPositioningTracer::ResidualJacobiansEnabled() const {
+  return recorder_ != nullptr && recorder_->IsResidualJacobiansEnabled();
 }
 
 void GlobalPositioningTracer::WriteEvent(std::string event_type,
@@ -345,7 +494,9 @@ std::string GlobalPositioningTracer::RecordResidual(
     const GlobalPositioningResidualDescriptor& residual,
     const ceres::CostFunction* cost_function,
     const ceres::LossFunction* loss_function,
-    std::vector<const double*> parameter_blocks) {
+    std::vector<const double*> parameter_blocks,
+    std::vector<GlobalPositioningTraceParameterBlockDescriptor>
+        parameter_block_descriptors) {
   if (!ResidualLedgerEnabled()) {
     return "";
   }
@@ -367,6 +518,10 @@ std::string GlobalPositioningTracer::RecordResidual(
     THROW_CHECK_EQ(parameter_blocks.size(), parameter_block_sizes.size())
         << "Residual replay parameter-block count does not match the Ceres "
            "cost function.";
+    THROW_CHECK_EQ(parameter_block_descriptors.size(),
+                   parameter_block_sizes.size())
+        << "Residual replay parameter-block descriptor count does not match "
+           "the Ceres cost function.";
     for (const double* parameter_block : parameter_blocks) {
       THROW_CHECK(parameter_block != nullptr)
           << "Residual replay parameter block pointer is null.";
@@ -377,7 +532,8 @@ std::string GlobalPositioningTracer::RecordResidual(
          loss_function,
          static_cast<size_t>(cost_function->num_residuals()),
          parameter_block_sizes,
-         std::move(parameter_blocks)});
+         std::move(parameter_blocks),
+         std::move(parameter_block_descriptors)});
   }
   return residual_id;
 }
@@ -426,6 +582,7 @@ GlobalPositioningTracer::CreateIterationCallback(
 
   return std::make_unique<GlobalPositioningTraceIterationCallback>(
       recorder_.get(),
+      &live_state.problem,
       &live_state.reconstruction,
       &live_state.frame_centers,
       &live_state.scales,
@@ -435,7 +592,8 @@ GlobalPositioningTracer::CreateIterationCallback(
       options_.snapshot_every_n_iterations,
       options_.max_snapshotted_points,
       ParameterSnapshotsEnabled(),
-      ResidualValuesEnabled());
+      ResidualValuesEnabled(),
+      ResidualJacobiansEnabled());
 }
 
 GlobalPositioningTraceRecord GlobalPositioningTracer::MakeResidualRecord(

--- a/src/colmap/estimators/global_positioning_tracer.cc
+++ b/src/colmap/estimators/global_positioning_tracer.cc
@@ -1,0 +1,473 @@
+#include "colmap/estimators/global_positioning_tracer.h"
+
+#include "colmap/scene/reconstruction.h"
+#include "colmap/util/misc.h"
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+namespace colmap {
+namespace {
+
+using TraceValue = GlobalPositioningTraceValue;
+
+template <typename T>
+TraceValue TraceOptionalId(const std::optional<T>& value) {
+  if (!value.has_value()) {
+    return TraceValue::Null();
+  }
+  return TraceValue::UInt(static_cast<uint64_t>(*value));
+}
+
+TraceValue TraceOptionalDouble(const std::optional<double>& value) {
+  if (!value.has_value()) {
+    return TraceValue::Null();
+  }
+  return TraceValue::Double(*value);
+}
+
+std::optional<uint64_t> TraceSensorId(
+    const std::optional<sensor_t>& sensor_id) {
+  if (!sensor_id.has_value() || *sensor_id == kInvalidSensorId) {
+    return std::nullopt;
+  }
+  return static_cast<uint64_t>(sensor_id->id);
+}
+
+void WriteParameterSnapshot(
+    GlobalPositioningTraceRecorder* recorder,
+    const int iteration,
+    const Reconstruction& reconstruction,
+    const std::unordered_map<frame_t, Eigen::Vector3d>& frame_centers,
+    const std::vector<double>& scales,
+    const std::map<image_t, double>& dmap_scales,
+    const std::unordered_map<sensor_t, Eigen::Vector3d>& cams_in_rig,
+    const int max_snapshotted_points) {
+  if (recorder == nullptr) {
+    return;
+  }
+
+  GlobalPositioningTraceParameterSnapshot snapshot;
+  snapshot.iteration = iteration;
+
+  std::vector<frame_t> frame_ids;
+  frame_ids.reserve(frame_centers.size());
+  for (const auto& [frame_id, center] : frame_centers) {
+    frame_ids.push_back(frame_id);
+  }
+  std::sort(frame_ids.begin(), frame_ids.end());
+  snapshot.frame_centers.shape = {frame_ids.size(), 3};
+  snapshot.frame_centers.ids.reserve(frame_ids.size());
+  snapshot.frame_centers.values.reserve(3 * frame_ids.size());
+  for (const frame_t frame_id : frame_ids) {
+    const Eigen::Vector3d& center = frame_centers.at(frame_id);
+    snapshot.frame_centers.ids.push_back(static_cast<uint64_t>(frame_id));
+    snapshot.frame_centers.values.push_back(center.x());
+    snapshot.frame_centers.values.push_back(center.y());
+    snapshot.frame_centers.values.push_back(center.z());
+  }
+
+  std::vector<point3D_t> point3D_ids;
+  point3D_ids.reserve(reconstruction.NumPoints3D());
+  for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
+    point3D_ids.push_back(point3D_id);
+  }
+  std::sort(point3D_ids.begin(), point3D_ids.end());
+  if (max_snapshotted_points >= 0 &&
+      point3D_ids.size() > static_cast<size_t>(max_snapshotted_points)) {
+    point3D_ids.resize(static_cast<size_t>(max_snapshotted_points));
+  }
+  snapshot.points3D.shape = {point3D_ids.size(), 3};
+  snapshot.points3D.ids.reserve(point3D_ids.size());
+  snapshot.points3D.values.reserve(3 * point3D_ids.size());
+  for (const point3D_t point3D_id : point3D_ids) {
+    const Eigen::Vector3d& xyz = reconstruction.Point3D(point3D_id).xyz;
+    snapshot.points3D.ids.push_back(static_cast<uint64_t>(point3D_id));
+    snapshot.points3D.values.push_back(xyz.x());
+    snapshot.points3D.values.push_back(xyz.y());
+    snapshot.points3D.values.push_back(xyz.z());
+  }
+
+  snapshot.scales.shape = {scales.size()};
+  snapshot.scales.ids.reserve(scales.size());
+  snapshot.scales.values.reserve(scales.size());
+  for (size_t scale_idx = 0; scale_idx < scales.size(); ++scale_idx) {
+    snapshot.scales.ids.push_back(static_cast<uint64_t>(scale_idx));
+    snapshot.scales.values.push_back(scales[scale_idx]);
+  }
+
+  if (!dmap_scales.empty()) {
+    snapshot.dmap_scales.emplace();
+    snapshot.dmap_scales->shape = {dmap_scales.size()};
+    snapshot.dmap_scales->ids.reserve(dmap_scales.size());
+    snapshot.dmap_scales->values.reserve(dmap_scales.size());
+    for (const auto& [image_id, scale] : dmap_scales) {
+      snapshot.dmap_scales->ids.push_back(static_cast<uint64_t>(image_id));
+      snapshot.dmap_scales->values.push_back(scale);
+    }
+  }
+
+  std::vector<sensor_t> sensor_ids;
+  sensor_ids.reserve(cams_in_rig.size());
+  for (const auto& [sensor_id, center] : cams_in_rig) {
+    sensor_ids.push_back(sensor_id);
+  }
+  std::sort(sensor_ids.begin(), sensor_ids.end());
+  if (!sensor_ids.empty()) {
+    snapshot.cams_in_rig.emplace();
+    snapshot.cams_in_rig->shape = {sensor_ids.size(), 3};
+    snapshot.cams_in_rig->ids.reserve(sensor_ids.size());
+    snapshot.cams_in_rig->values.reserve(3 * sensor_ids.size());
+    for (const sensor_t sensor_id : sensor_ids) {
+      const Eigen::Vector3d& cam_in_rig = cams_in_rig.at(sensor_id);
+      snapshot.cams_in_rig->ids.push_back(static_cast<uint64_t>(sensor_id.id));
+      snapshot.cams_in_rig->values.push_back(cam_in_rig.x());
+      snapshot.cams_in_rig->values.push_back(cam_in_rig.y());
+      snapshot.cams_in_rig->values.push_back(cam_in_rig.z());
+    }
+  }
+
+  recorder->WriteParameterSnapshot(snapshot);
+}
+
+void WriteResidualValues(
+    GlobalPositioningTraceRecorder* recorder,
+    const int iteration,
+    const std::vector<GlobalPositioningResidualReplayEntry>& replay_entries) {
+  if (recorder == nullptr) {
+    return;
+  }
+
+  GlobalPositioningTraceResidualValues residual_values;
+  residual_values.iteration = iteration;
+  residual_values.residual_ids.reserve(replay_entries.size());
+  residual_values.residual_dims.reserve(replay_entries.size());
+  residual_values.residual_offsets.reserve(replay_entries.size());
+  residual_values.evaluation_success.resize(replay_entries.size(), false);
+  residual_values.raw_costs.resize(replay_entries.size(),
+                                   std::numeric_limits<double>::quiet_NaN());
+  residual_values.robust_costs.resize(replay_entries.size(),
+                                      std::numeric_limits<double>::quiet_NaN());
+
+  size_t total_scalar_residuals = 0;
+  for (const GlobalPositioningResidualReplayEntry& entry : replay_entries) {
+    residual_values.residual_ids.push_back(entry.residual_id);
+    residual_values.residual_dims.push_back(entry.residual_dimension);
+    residual_values.residual_offsets.push_back(total_scalar_residuals);
+    total_scalar_residuals += entry.residual_dimension;
+  }
+  residual_values.raw_residuals.resize(
+      total_scalar_residuals, std::numeric_limits<double>::quiet_NaN());
+
+  for (size_t entry_idx = 0; entry_idx < replay_entries.size(); ++entry_idx) {
+    const GlobalPositioningResidualReplayEntry& entry =
+        replay_entries[entry_idx];
+    if (entry.cost_function == nullptr) {
+      continue;
+    }
+
+    double* raw_residuals = residual_values.raw_residuals.data() +
+                            residual_values.residual_offsets[entry_idx];
+    const bool evaluation_success = entry.cost_function->Evaluate(
+        entry.parameter_blocks.data(), raw_residuals, nullptr);
+    residual_values.evaluation_success[entry_idx] = evaluation_success;
+    if (!evaluation_success) {
+      continue;
+    }
+
+    double squared_norm = 0.0;
+    for (size_t residual_idx = 0; residual_idx < entry.residual_dimension;
+         ++residual_idx) {
+      squared_norm += raw_residuals[residual_idx] * raw_residuals[residual_idx];
+    }
+
+    const double raw_cost = 0.5 * squared_norm;
+    residual_values.raw_costs[entry_idx] = raw_cost;
+    if (entry.loss_function != nullptr) {
+      double rho[3];
+      entry.loss_function->Evaluate(squared_norm, rho);
+      residual_values.robust_costs[entry_idx] = 0.5 * rho[0];
+    } else {
+      residual_values.robust_costs[entry_idx] = raw_cost;
+    }
+  }
+
+  recorder->WriteResidualValues(residual_values);
+}
+
+class GlobalPositioningTraceIterationCallback
+    : public ceres::IterationCallback {
+ public:
+  GlobalPositioningTraceIterationCallback(
+      GlobalPositioningTraceRecorder* recorder,
+      const Reconstruction* reconstruction,
+      const std::unordered_map<frame_t, Eigen::Vector3d>* frame_centers,
+      const std::vector<double>* scales,
+      const std::map<image_t, double>* dmap_scales,
+      const std::unordered_map<sensor_t, Eigen::Vector3d>* cams_in_rig,
+      const std::vector<GlobalPositioningResidualReplayEntry>*
+          residual_replay_entries,
+      const int snapshot_every_n_iterations,
+      const int max_snapshotted_points,
+      const bool write_parameter_snapshots,
+      const bool write_residual_values)
+      : recorder_(recorder),
+        reconstruction_(reconstruction),
+        frame_centers_(frame_centers),
+        scales_(scales),
+        dmap_scales_(dmap_scales),
+        cams_in_rig_(cams_in_rig),
+        residual_replay_entries_(residual_replay_entries),
+        snapshot_every_n_iterations_(snapshot_every_n_iterations),
+        max_snapshotted_points_(max_snapshotted_points),
+        write_parameter_snapshots_(write_parameter_snapshots),
+        write_residual_values_(write_residual_values) {}
+
+  ceres::CallbackReturnType operator()(
+      const ceres::IterationSummary& summary) override {
+    if (recorder_ != nullptr) {
+      recorder_->WriteIteration(summary);
+    }
+    if ((write_parameter_snapshots_ || write_residual_values_) &&
+        summary.iteration % snapshot_every_n_iterations_ == 0) {
+      if (write_parameter_snapshots_) {
+        WriteParameterSnapshot(recorder_,
+                               summary.iteration,
+                               *reconstruction_,
+                               *frame_centers_,
+                               *scales_,
+                               *dmap_scales_,
+                               *cams_in_rig_,
+                               max_snapshotted_points_);
+      }
+      if (write_residual_values_) {
+        WriteResidualValues(
+            recorder_, summary.iteration, *residual_replay_entries_);
+      }
+    }
+    return ceres::SOLVER_CONTINUE;
+  }
+
+ private:
+  GlobalPositioningTraceRecorder* recorder_ = nullptr;
+  const Reconstruction* reconstruction_ = nullptr;
+  const std::unordered_map<frame_t, Eigen::Vector3d>* frame_centers_ = nullptr;
+  const std::vector<double>* scales_ = nullptr;
+  const std::map<image_t, double>* dmap_scales_ = nullptr;
+  const std::unordered_map<sensor_t, Eigen::Vector3d>* cams_in_rig_ = nullptr;
+  const std::vector<GlobalPositioningResidualReplayEntry>*
+      residual_replay_entries_ = nullptr;
+  int snapshot_every_n_iterations_ = 1;
+  int max_snapshotted_points_ = -1;
+  bool write_parameter_snapshots_ = false;
+  bool write_residual_values_ = false;
+};
+
+}  // namespace
+
+GlobalPositioningTracer::GlobalPositioningTracer(
+    const GlobalPositioningTraceOptions& options)
+    : options_(options) {
+  if (options_.level != GlobalPositioningTraceLevel::kOff) {
+    recorder_ = std::make_unique<GlobalPositioningTraceRecorder>(options_);
+  }
+}
+
+bool GlobalPositioningTracer::Enabled() const { return recorder_ != nullptr; }
+
+GlobalPositioningTracer::~GlobalPositioningTracer() {
+  if (recorder_ != nullptr && !finished_) {
+    recorder_->MarkFinished("aborted");
+  }
+}
+
+bool GlobalPositioningTracer::ResidualLedgerEnabled() const {
+  return recorder_ != nullptr && recorder_->IsResidualLedgerEnabled();
+}
+
+bool GlobalPositioningTracer::ParameterSnapshotsEnabled() const {
+  return recorder_ != nullptr && recorder_->IsParameterSnapshotsEnabled();
+}
+
+bool GlobalPositioningTracer::ResidualValuesEnabled() const {
+  return recorder_ != nullptr && recorder_->IsResidualValuesEnabled();
+}
+
+void GlobalPositioningTracer::WriteEvent(std::string event_type,
+                                         std::string stage,
+                                         GlobalPositioningTraceAttrs attrs) {
+  if (recorder_ == nullptr) {
+    return;
+  }
+
+  GlobalPositioningTraceRecord record;
+  record.event_type = std::move(event_type);
+  record.stage = std::move(stage);
+  record.attrs = std::move(attrs);
+  recorder_->WriteEvent(std::move(record));
+}
+
+void GlobalPositioningTracer::MarkFinished() {
+  if (recorder_ == nullptr || finished_) {
+    return;
+  }
+  recorder_->MarkFinished("finished");
+  finished_ = true;
+}
+
+void GlobalPositioningTracer::ResetProblemState() {
+  residual_bucket_counts_.clear();
+  scale_observations_.clear();
+  residual_replay_entries_.clear();
+}
+
+void GlobalPositioningTracer::RecordScaleObservation(
+    const size_t scale_index,
+    const point3D_t point3D_id,
+    const TrackElement& observation,
+    const bool is_lc_observation) {
+  if (!ResidualLedgerEnabled()) {
+    return;
+  }
+  if (scale_observations_.size() <= scale_index) {
+    scale_observations_.resize(scale_index + 1);
+  }
+  scale_observations_[scale_index] = {
+      point3D_id,
+      observation.image_id,
+      observation.point2D_idx,
+      is_lc_observation,
+  };
+}
+
+std::string GlobalPositioningTracer::RecordResidual(
+    const GlobalPositioningResidualDescriptor& residual,
+    const ceres::CostFunction* cost_function,
+    const ceres::LossFunction* loss_function,
+    std::vector<const double*> parameter_blocks) {
+  if (!ResidualLedgerEnabled()) {
+    return "";
+  }
+
+  std::string residual_id = recorder_->AllocateResidualId();
+  GlobalPositioningTraceRecord record =
+      MakeResidualRecord(residual, "residual_added", "problem_build");
+  record.attrs["residual_id"] = TraceValue::String(residual_id);
+  recorder_->WriteResidualBlock(std::move(record));
+  ++residual_bucket_counts_[residual.residual_type + "|" +
+                            residual.loss_bucket];
+
+  if (ResidualValuesEnabled()) {
+    THROW_CHECK(cost_function != nullptr)
+        << "Residual-values tracing requires every recorded residual to have a "
+           "cost function.";
+    const std::vector<int>& parameter_block_sizes =
+        cost_function->parameter_block_sizes();
+    THROW_CHECK_EQ(parameter_blocks.size(), parameter_block_sizes.size())
+        << "Residual replay parameter-block count does not match the Ceres "
+           "cost function.";
+    for (const double* parameter_block : parameter_blocks) {
+      THROW_CHECK(parameter_block != nullptr)
+          << "Residual replay parameter block pointer is null.";
+    }
+    residual_replay_entries_.push_back(
+        {residual_id,
+         cost_function,
+         loss_function,
+         static_cast<size_t>(cost_function->num_residuals()),
+         parameter_block_sizes,
+         std::move(parameter_blocks)});
+  }
+  return residual_id;
+}
+
+void GlobalPositioningTracer::RecordSkip(
+    const GlobalPositioningResidualDescriptor& residual,
+    std::string skip_reason) {
+  if (!ResidualLedgerEnabled()) {
+    return;
+  }
+
+  GlobalPositioningTraceRecord record =
+      MakeResidualRecord(residual, "residual_skipped", "problem_build");
+  record.attrs["skip_reason"] = TraceValue::String(std::move(skip_reason));
+  recorder_->WriteResidualSkip(std::move(record));
+}
+
+void GlobalPositioningTracer::RecordBucketSummaries() {
+  if (!ResidualLedgerEnabled()) {
+    return;
+  }
+
+  for (const auto& [key, count] : residual_bucket_counts_) {
+    const size_t separator = key.find('|');
+    GlobalPositioningTraceRecord record;
+    record.event_type = "residual_bucket_summary";
+    record.stage = "problem_build";
+    record.attrs = {
+        {"residual_type", TraceValue::String(key.substr(0, separator))},
+        {"loss_bucket",
+         TraceValue::String(separator == std::string::npos
+                                ? "none"
+                                : key.substr(separator + 1))},
+        {"count", TraceValue::UInt(count)},
+    };
+    recorder_->WriteResidualBucketSummary(std::move(record));
+  }
+}
+
+std::unique_ptr<ceres::IterationCallback>
+GlobalPositioningTracer::CreateIterationCallback(
+    GlobalPositioningTraceLiveState live_state) {
+  if (!Enabled()) {
+    return nullptr;
+  }
+
+  return std::make_unique<GlobalPositioningTraceIterationCallback>(
+      recorder_.get(),
+      &live_state.reconstruction,
+      &live_state.frame_centers,
+      &live_state.scales,
+      &live_state.dmap_scales,
+      &live_state.cams_in_rig,
+      &residual_replay_entries_,
+      options_.snapshot_every_n_iterations,
+      options_.max_snapshotted_points,
+      ParameterSnapshotsEnabled(),
+      ResidualValuesEnabled());
+}
+
+GlobalPositioningTraceRecord GlobalPositioningTracer::MakeResidualRecord(
+    const GlobalPositioningResidualDescriptor& residual,
+    std::string event_type,
+    std::string stage) const {
+  GlobalPositioningTraceRecord record;
+  record.event_type = std::move(event_type);
+  record.stage = std::move(stage);
+  record.attrs = {
+      {"residual_type", TraceValue::String(residual.residual_type)},
+      {"point3D_id", TraceOptionalId(residual.point3D_id)},
+      {"image_id", TraceOptionalId(residual.image_id)},
+      {"point2D_idx", TraceOptionalId(residual.point2D_idx)},
+      {"frame_id", TraceOptionalId(residual.frame_id)},
+      {"camera_id", TraceOptionalId(residual.camera_id)},
+      {"sensor_id", TraceOptionalId(TraceSensorId(residual.sensor_id))},
+      {"is_lc_observation", TraceValue::Bool(residual.is_lc_observation)},
+      {"is_ref_in_frame", TraceValue::Bool(residual.is_ref_in_frame)},
+      {"camera_has_prior_focal_length",
+       TraceValue::Bool(residual.camera_has_prior_focal_length)},
+      {"loss_bucket", TraceValue::String(residual.loss_bucket)},
+      {"uses_keypoint_covariance",
+       TraceValue::Bool(residual.uses_keypoint_covariance)},
+      {"has_depth_prior", TraceValue::Bool(residual.has_depth_prior)},
+      {"depth_prior", TraceOptionalDouble(residual.depth_prior)},
+      {"depth_sigma", TraceOptionalDouble(residual.depth_sigma)},
+      {"dmap_scale_image_id", TraceOptionalId(residual.dmap_scale_image_id)},
+      {"depth_outlier_source",
+       TraceValue::String(residual.depth_outlier_source)},
+  };
+  return record;
+}
+
+}  // namespace colmap

--- a/src/colmap/estimators/global_positioning_tracer.h
+++ b/src/colmap/estimators/global_positioning_tracer.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "colmap/estimators/global_positioning_trace.h"
+#include "colmap/scene/track.h"
+#include "colmap/util/types.h"
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Core>
+#include <ceres/ceres.h>
+
+namespace colmap {
+
+class Reconstruction;
+
+using GlobalPositioningTraceAttrs =
+    std::map<std::string, GlobalPositioningTraceValue>;
+
+struct GlobalPositioningResidualDescriptor {
+  std::string residual_type;
+  std::optional<point3D_t> point3D_id;
+  std::optional<image_t> image_id;
+  std::optional<point2D_t> point2D_idx;
+  std::optional<frame_t> frame_id;
+  std::optional<camera_t> camera_id;
+  std::optional<sensor_t> sensor_id;
+  bool is_lc_observation = false;
+  bool is_ref_in_frame = false;
+  bool camera_has_prior_focal_length = false;
+  std::string loss_bucket = "none";
+  bool uses_keypoint_covariance = false;
+  bool has_depth_prior = false;
+  std::optional<double> depth_prior;
+  std::optional<double> depth_sigma;
+  std::optional<image_t> dmap_scale_image_id;
+  std::string depth_outlier_source = "none";
+};
+
+struct GlobalPositioningResidualReplayEntry {
+  std::string residual_id;
+  const ceres::CostFunction* cost_function = nullptr;
+  const ceres::LossFunction* loss_function = nullptr;
+  size_t residual_dimension = 0;
+  std::vector<int> parameter_block_sizes;
+  std::vector<const double*> parameter_blocks;
+};
+
+struct GlobalPositioningTraceLiveState {
+  const Reconstruction& reconstruction;
+  const std::unordered_map<frame_t, Eigen::Vector3d>& frame_centers;
+  const std::vector<double>& scales;
+  const std::map<image_t, double>& dmap_scales;
+  const std::unordered_map<sensor_t, Eigen::Vector3d>& cams_in_rig;
+};
+
+class GlobalPositioningTracer {
+ public:
+  explicit GlobalPositioningTracer(
+      const GlobalPositioningTraceOptions& options);
+  ~GlobalPositioningTracer();
+
+  bool Enabled() const;
+  bool ResidualLedgerEnabled() const;
+  bool ParameterSnapshotsEnabled() const;
+  bool ResidualValuesEnabled() const;
+
+  void WriteEvent(std::string event_type,
+                  std::string stage,
+                  GlobalPositioningTraceAttrs attrs = {});
+
+  void MarkFinished();
+
+  void ResetProblemState();
+
+  void RecordScaleObservation(size_t scale_index,
+                              point3D_t point3D_id,
+                              const TrackElement& observation,
+                              bool is_lc_observation);
+
+  std::string RecordResidual(
+      const GlobalPositioningResidualDescriptor& residual,
+      const ceres::CostFunction* cost_function,
+      const ceres::LossFunction* loss_function,
+      std::vector<const double*> parameter_blocks);
+
+  void RecordSkip(const GlobalPositioningResidualDescriptor& residual,
+                  std::string skip_reason);
+
+  void RecordBucketSummaries();
+
+  std::unique_ptr<ceres::IterationCallback> CreateIterationCallback(
+      GlobalPositioningTraceLiveState live_state);
+
+  const std::vector<GlobalPositioningResidualReplayEntry>& ReplayEntries()
+      const {
+    return residual_replay_entries_;
+  }
+
+ private:
+  struct ScaleObservationMetadata {
+    point3D_t point3D_id = kInvalidPoint3DId;
+    image_t image_id = kInvalidImageId;
+    point2D_t point2D_idx = kInvalidPoint2DIdx;
+    bool is_lc_observation = false;
+  };
+
+  GlobalPositioningTraceRecord MakeResidualRecord(
+      const GlobalPositioningResidualDescriptor& residual,
+      std::string event_type,
+      std::string stage) const;
+
+  GlobalPositioningTraceOptions options_;
+  std::unique_ptr<GlobalPositioningTraceRecorder> recorder_;
+  bool finished_ = false;
+  std::map<std::string, uint64_t> residual_bucket_counts_;
+  std::vector<ScaleObservationMetadata> scale_observations_;
+  std::vector<GlobalPositioningResidualReplayEntry> residual_replay_entries_;
+};
+
+}  // namespace colmap

--- a/src/colmap/estimators/global_positioning_tracer.h
+++ b/src/colmap/estimators/global_positioning_tracer.h
@@ -33,6 +33,8 @@ struct GlobalPositioningResidualDescriptor {
   bool is_ref_in_frame = false;
   bool camera_has_prior_focal_length = false;
   std::string loss_bucket = "none";
+  std::optional<GlobalPositioningTraceLossConfig> loss;
+  std::optional<GlobalPositioningTraceFixedParameters> fixed_parameters;
   bool uses_keypoint_covariance = false;
   bool has_depth_prior = false;
   std::optional<double> depth_prior;

--- a/src/colmap/estimators/global_positioning_tracer.h
+++ b/src/colmap/estimators/global_positioning_tracer.h
@@ -48,9 +48,12 @@ struct GlobalPositioningResidualReplayEntry {
   size_t residual_dimension = 0;
   std::vector<int> parameter_block_sizes;
   std::vector<const double*> parameter_blocks;
+  std::vector<GlobalPositioningTraceParameterBlockDescriptor>
+      parameter_block_descriptors;
 };
 
 struct GlobalPositioningTraceLiveState {
+  const ceres::Problem& problem;
   const Reconstruction& reconstruction;
   const std::unordered_map<frame_t, Eigen::Vector3d>& frame_centers;
   const std::vector<double>& scales;
@@ -68,6 +71,7 @@ class GlobalPositioningTracer {
   bool ResidualLedgerEnabled() const;
   bool ParameterSnapshotsEnabled() const;
   bool ResidualValuesEnabled() const;
+  bool ResidualJacobiansEnabled() const;
 
   void WriteEvent(std::string event_type,
                   std::string stage,
@@ -86,7 +90,9 @@ class GlobalPositioningTracer {
       const GlobalPositioningResidualDescriptor& residual,
       const ceres::CostFunction* cost_function,
       const ceres::LossFunction* loss_function,
-      std::vector<const double*> parameter_blocks);
+      std::vector<const double*> parameter_blocks,
+      std::vector<GlobalPositioningTraceParameterBlockDescriptor>
+          parameter_block_descriptors);
 
   void RecordSkip(const GlobalPositioningResidualDescriptor& residual,
                   std::string skip_reason);

--- a/src/pycolmap/estimators/global_positioning_trace_jacobian_reducer.cc
+++ b/src/pycolmap/estimators/global_positioning_trace_jacobian_reducer.cc
@@ -1,0 +1,1430 @@
+#include "colmap/estimators/cost_functions/metric_depth.h"
+#include "colmap/estimators/cost_functions/motion_averaging.h"
+#include "colmap/estimators/cost_functions/utils.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Cholesky>
+#include <Eigen/LU>
+#include <Eigen/SVD>
+#include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+using namespace colmap;
+using namespace pybind11::literals;
+namespace py = pybind11;
+
+namespace {
+
+using SnapshotTable =
+    std::unordered_map<std::string,
+                       std::unordered_map<uint64_t, Eigen::VectorXd>>;
+
+struct NativePointSchurAccumulator {
+  Eigen::Matrix3d hpp_raw = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d hpp_rho1 = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d hpp_analytic = Eigen::Matrix3d::Zero();
+  Eigen::Vector3d point_gradient_raw = Eigen::Vector3d::Zero();
+  Eigen::Vector3d point_gradient_robust = Eigen::Vector3d::Zero();
+  Eigen::Matrix3d left_raw = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d right_raw = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d left_rho1 = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d right_rho1 = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d left_analytic = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d right_analytic = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d left_hff_analytic = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d right_hff_analytic = Eigen::Matrix3d::Zero();
+  Eigen::Vector3d left_gradient_raw = Eigen::Vector3d::Zero();
+  Eigen::Vector3d right_gradient_raw = Eigen::Vector3d::Zero();
+  Eigen::Vector3d left_gradient_robust = Eigen::Vector3d::Zero();
+  Eigen::Vector3d right_gradient_robust = Eigen::Vector3d::Zero();
+  uint64_t left_count = 0;
+  uint64_t right_count = 0;
+};
+
+struct NativeTopResidualRow {
+  std::string residual_id;
+  std::string side;
+  uint64_t frame_id = 0;
+  uint64_t image_id = 0;
+  uint64_t point2D_idx = 0;
+  uint64_t point3D_id = 0;
+  std::string residual_type;
+  std::string loss_bucket;
+  std::string source;
+  double descent_projection = 0.0;
+  double opposing_projection = 0.0;
+  double raw_gradient_norm = 0.0;
+  double robust_gradient_norm = 0.0;
+  double raw_cost = 0.0;
+  double robust_cost = 0.0;
+  double rho1 = 0.0;
+  std::optional<double> directional_curvature;
+  std::optional<double> newton_step_along_projection;
+  Eigen::Vector3d raw_gradient = Eigen::Vector3d::Zero();
+  Eigen::Vector3d robust_gradient = Eigen::Vector3d::Zero();
+};
+
+struct NativeSchurResidualRow {
+  std::string residual_id;
+  std::string side;
+  uint64_t frame_id = 0;
+  uint64_t image_id = 0;
+  uint64_t point2D_idx = 0;
+  uint64_t point3D_id = 0;
+  std::string residual_type;
+  std::string loss_bucket;
+  std::string source;
+  double raw_cost = 0.0;
+  double robust_cost = 0.0;
+  double rho1 = 0.0;
+  Eigen::Vector3d robust_frame_gradient = Eigen::Vector3d::Zero();
+  Eigen::Vector3d robust_point_gradient = Eigen::Vector3d::Zero();
+  Eigen::Matrix3d analytic_cross = Eigen::Matrix3d::Zero();
+  Eigen::Matrix3d analytic_hff = Eigen::Matrix3d::Zero();
+};
+
+struct NativeEdgeJacobianAccumulator {
+  uint64_t residual_ids_selected = 0;
+  uint64_t residuals_replayed = 0;
+  uint64_t residuals_with_frame_jacobian = 0;
+  uint64_t residuals_with_frame_point_jacobians = 0;
+  double raw_cost_sum = 0.0;
+  double robust_cost_sum = 0.0;
+  double rho1_sum = 0.0;
+  double rho2_sum = 0.0;
+  double rho2_min = std::numeric_limits<double>::infinity();
+  double rho2_max = -std::numeric_limits<double>::infinity();
+  uint64_t rho1_downweighted_count = 0;
+  Eigen::Vector3d left_gradient_raw = Eigen::Vector3d::Zero();
+  Eigen::Vector3d right_gradient_raw = Eigen::Vector3d::Zero();
+  Eigen::Vector3d left_gradient_robust = Eigen::Vector3d::Zero();
+  Eigen::Vector3d right_gradient_robust = Eigen::Vector3d::Zero();
+  std::unordered_map<uint64_t, NativePointSchurAccumulator> point_accumulators;
+  std::vector<NativeTopResidualRow> top_opposing_residuals;
+  std::vector<NativeTopResidualRow> top_pinning_residuals;
+  std::vector<NativeSchurResidualRow> schur_residuals;
+};
+
+Eigen::VectorXd VectorFromPy(const py::handle value, const std::string& label) {
+  const py::array_t<double, py::array::c_style | py::array::forcecast> array(
+      py::reinterpret_borrow<py::object>(value));
+  if (array.ndim() != 1) {
+    throw std::runtime_error(label + ": expected a rank-1 float64 array");
+  }
+  Eigen::VectorXd result(array.shape(0));
+  const double* data = array.data();
+  for (ssize_t idx = 0; idx < array.shape(0); ++idx) {
+    result[static_cast<Eigen::Index>(idx)] = data[idx];
+  }
+  return result;
+}
+
+Eigen::Vector3d Vector3FromPy(const py::dict& dict,
+                              const char* key,
+                              const std::string& label) {
+  if (!dict.contains(key)) {
+    throw std::runtime_error(label + ": missing " + key);
+  }
+  const py::list values = py::cast<py::list>(dict[py::str(key)]);
+  if (values.size() != 3) {
+    throw std::runtime_error(label + "." + key + ": expected length 3");
+  }
+  return Eigen::Vector3d(py::cast<double>(values[0]),
+                         py::cast<double>(values[1]),
+                         py::cast<double>(values[2]));
+}
+
+Eigen::Quaterniond QuaternionWxyzFromPy(const py::dict& dict,
+                                        const char* key,
+                                        const std::string& label) {
+  if (!dict.contains(key)) {
+    throw std::runtime_error(label + ": missing " + key);
+  }
+  const py::list values = py::cast<py::list>(dict[py::str(key)]);
+  if (values.size() != 4) {
+    throw std::runtime_error(label + "." + key + ": expected length 4");
+  }
+  return Eigen::Quaterniond(py::cast<double>(values[0]),
+                            py::cast<double>(values[1]),
+                            py::cast<double>(values[2]),
+                            py::cast<double>(values[3]));
+}
+
+Eigen::Matrix3d Matrix3RowMajorFromPy(const py::dict& dict,
+                                      const char* key,
+                                      const std::string& label) {
+  if (!dict.contains(key)) {
+    throw std::runtime_error(label + ": missing " + key);
+  }
+  const py::list values = py::cast<py::list>(dict[py::str(key)]);
+  if (values.size() != 9) {
+    throw std::runtime_error(label + "." + key + ": expected length 9");
+  }
+  Eigen::Matrix3d matrix;
+  size_t idx = 0;
+  for (int row = 0; row < 3; ++row) {
+    for (int col = 0; col < 3; ++col) {
+      matrix(row, col) = py::cast<double>(values[idx++]);
+    }
+  }
+  return matrix;
+}
+
+double OptionalDoubleFromPy(const py::dict& dict,
+                            const char* key,
+                            const double default_value) {
+  if (!dict.contains(key) || dict[py::str(key)].is_none()) {
+    return default_value;
+  }
+  return py::cast<double>(dict[py::str(key)]);
+}
+
+uint64_t OptionalUInt64FromPy(const py::dict& dict,
+                              const char* key,
+                              const uint64_t default_value) {
+  if (!dict.contains(key) || dict[py::str(key)].is_none()) {
+    return default_value;
+  }
+  return py::cast<uint64_t>(dict[py::str(key)]);
+}
+
+std::string OptionalStringFromPy(const py::dict& dict,
+                                 const char* key,
+                                 const std::string& default_value) {
+  if (!dict.contains(key) || dict[py::str(key)].is_none()) {
+    return default_value;
+  }
+  return py::cast<std::string>(dict[py::str(key)]);
+}
+
+double RequiredDoubleFromPy(const py::dict& dict,
+                            const char* key,
+                            const std::string& label) {
+  if (!dict.contains(key) || dict[py::str(key)].is_none()) {
+    throw std::runtime_error(label + ": missing " + key);
+  }
+  return py::cast<double>(dict[py::str(key)]);
+}
+
+bool RequiredBoolFromPy(const py::dict& dict,
+                        const char* key,
+                        const std::string& label) {
+  if (!dict.contains(key) || dict[py::str(key)].is_none()) {
+    throw std::runtime_error(label + ": missing " + key);
+  }
+  return py::cast<bool>(dict[py::str(key)]);
+}
+
+std::string RequiredStringFromPy(const py::dict& dict,
+                                 const char* key,
+                                 const std::string& label) {
+  if (!dict.contains(key) || dict[py::str(key)].is_none()) {
+    throw std::runtime_error(label + ": missing " + key);
+  }
+  return py::cast<std::string>(dict[py::str(key)]);
+}
+
+SnapshotTable SnapshotTableFromPy(const py::dict& snapshot) {
+  SnapshotTable table;
+  for (const auto item : snapshot) {
+    const std::string kind = py::cast<std::string>(item.first);
+    const py::dict values = py::cast<py::dict>(item.second);
+    auto& kind_table = table[kind];
+    for (const auto value_item : values) {
+      kind_table[py::cast<uint64_t>(value_item.first)] =
+          VectorFromPy(value_item.second, kind);
+    }
+  }
+  return table;
+}
+
+const Eigen::VectorXd& SnapshotValue(const SnapshotTable& table,
+                                     const std::string& kind,
+                                     const uint64_t id,
+                                     const size_t expected_size) {
+  const auto kind_it = table.find(kind);
+  if (kind_it == table.end()) {
+    throw std::runtime_error("snapshot missing parameter kind: " + kind);
+  }
+  const auto value_it = kind_it->second.find(id);
+  if (value_it == kind_it->second.end()) {
+    throw std::runtime_error("snapshot missing parameter kind=" + kind +
+                             ", id=" + std::to_string(id));
+  }
+  if (static_cast<size_t>(value_it->second.size()) != expected_size) {
+    throw std::runtime_error("snapshot parameter kind=" + kind + ", id=" +
+                             std::to_string(id) + " has unexpected size");
+  }
+  return value_it->second;
+}
+
+std::unique_ptr<ceres::CostFunction> CreateCostFunctionFromRecord(
+    const py::dict& attrs) {
+  const std::string residual_type =
+      RequiredStringFromPy(attrs, "residual_type", "residual attrs");
+  const py::dict fixed = py::cast<py::dict>(attrs[py::str("fixed_parameters")]);
+
+  if (residual_type == "bata_ref_frame") {
+    const Eigen::Vector3d direction =
+        Vector3FromPy(fixed, "cam_from_point3D_dir", residual_type);
+    if (fixed.contains("keypoint_covariance_world_row_major")) {
+      return std::unique_ptr<ceres::CostFunction>(
+          CovarianceWeightedCostFunctor<BATAPairwiseDirectionCostFunctor>::
+              Create(
+                  Matrix3RowMajorFromPy(fixed,
+                                        "keypoint_covariance_world_row_major",
+                                        residual_type),
+                  direction));
+    }
+    return std::unique_ptr<ceres::CostFunction>(
+        BATAPairwiseDirectionCostFunctor::Create(direction));
+  }
+
+  if (residual_type == "bata_constant_rig") {
+    return std::unique_ptr<ceres::CostFunction>(
+        RigBATAPairwiseDirectionConstantRigCostFunctor::Create(
+            Vector3FromPy(fixed, "cam_from_point3D_dir", residual_type),
+            Vector3FromPy(fixed, "cam_from_rig_dir", residual_type)));
+  }
+
+  if (residual_type == "bata_variable_rig") {
+    return std::unique_ptr<ceres::CostFunction>(
+        RigBATAPairwiseDirectionCostFunctor::Create(
+            Vector3FromPy(fixed, "cam_from_point3D_dir", residual_type),
+            QuaternionWxyzFromPy(
+                fixed, "rig_from_world_rotation_wxyz", residual_type)));
+  }
+
+  if (residual_type == "metric_depth") {
+    MetricDepthOptions options;
+    options.use_log_scale =
+        RequiredBoolFromPy(fixed, "metric_depth_use_log_scale", residual_type);
+    const std::string metric_type = RequiredStringFromPy(
+        fixed, "metric_depth_residual_type", residual_type);
+    if (metric_type == "linear") {
+      options.residual_type = MetricDepthResidualType::kLinear;
+    } else if (metric_type == "log") {
+      options.residual_type = MetricDepthResidualType::kLog;
+    } else if (metric_type == "log_linear") {
+      options.residual_type = MetricDepthResidualType::kLogLinear;
+    } else {
+      throw std::runtime_error("unsupported metric depth residual type: " +
+                               metric_type);
+    }
+    options.zero_residual_behind = RequiredBoolFromPy(
+        fixed, "metric_depth_zero_residual_behind", residual_type);
+    options.log_linear_threshold = RequiredDoubleFromPy(
+        fixed, "metric_depth_log_linear_threshold", residual_type);
+    return std::unique_ptr<ceres::CostFunction>(MetricDepthError::Create(
+        QuaternionWxyzFromPy(fixed, "camera_rotation_wxyz", residual_type),
+        RequiredDoubleFromPy(attrs, "depth_prior", residual_type),
+        RequiredDoubleFromPy(attrs, "depth_sigma", residual_type),
+        options));
+  }
+
+  if (residual_type == "scale_prior") {
+    const Eigen::Matrix<double, 1, 1> prior(
+        RequiredDoubleFromPy(fixed, "scale_prior_target", residual_type));
+    const double stddev =
+        RequiredDoubleFromPy(fixed, "scale_prior_stddev", residual_type);
+    const Eigen::Matrix<double, 1, 1> covariance(stddev * stddev);
+    return std::unique_ptr<ceres::CostFunction>(
+        CovarianceWeightedCostFunctor<NormalPriorCostFunctor<1>>::Create(
+            covariance, prior));
+  }
+
+  throw std::runtime_error("unsupported residual_type: " + residual_type);
+}
+
+Eigen::Vector3d LossRhoFromRecord(const py::dict& attrs,
+                                  const double squared_norm) {
+  const py::dict loss = py::cast<py::dict>(attrs[py::str("loss")]);
+  const std::string type = RequiredStringFromPy(loss, "type", "loss");
+  const double scale = OptionalDoubleFromPy(loss, "scale", 1.0);
+  const double weight = OptionalDoubleFromPy(loss, "weight", 1.0);
+  if (scale <= 0.0) {
+    throw std::runtime_error("loss scale must be positive");
+  }
+  if (weight < 0.0) {
+    throw std::runtime_error("loss weight must be non-negative");
+  }
+  Eigen::Vector3d rho;
+  if (type == "trivial") {
+    rho << squared_norm, 1.0, 0.0;
+  } else if (type == "huber") {
+    const double threshold = scale * scale;
+    if (squared_norm <= threshold) {
+      rho << squared_norm, 1.0, 0.0;
+    } else {
+      const double root = std::sqrt(squared_norm);
+      rho << 2.0 * scale * root - threshold, scale / root,
+          -0.5 * scale / (squared_norm * root);
+    }
+  } else if (type == "soft_l1") {
+    const double z = 1.0 + squared_norm / (scale * scale);
+    const double root = std::sqrt(z);
+    rho << 2.0 * scale * scale * (root - 1.0), 1.0 / root,
+        -0.5 / (scale * scale * z * root);
+  } else if (type == "cauchy") {
+    const double z = 1.0 + squared_norm / (scale * scale);
+    rho << scale * scale * std::log(z), 1.0 / z, -1.0 / (scale * scale * z * z);
+  } else {
+    throw std::runtime_error("unsupported loss type: " + type);
+  }
+  return weight * rho;
+}
+
+struct NativeParameterBlock {
+  std::string role;
+  std::string kind;
+  uint64_t id = 0;
+  size_t size = 0;
+};
+
+std::vector<NativeParameterBlock> ParameterBlocksFromRecord(
+    const py::dict& attrs) {
+  const py::list blocks =
+      py::cast<py::list>(attrs[py::str("parameter_blocks")]);
+  std::vector<NativeParameterBlock> parsed;
+  parsed.reserve(blocks.size());
+  for (const py::handle block_handle : blocks) {
+    const py::dict block = py::cast<py::dict>(block_handle);
+    parsed.push_back({RequiredStringFromPy(block, "role", "parameter_block"),
+                      RequiredStringFromPy(block, "kind", "parameter_block"),
+                      py::cast<uint64_t>(block[py::str("id")]),
+                      py::cast<size_t>(block[py::str("size")])});
+  }
+  return parsed;
+}
+
+class NativeGlobalPositioningTraceJacobianReducer {
+ public:
+  explicit NativeGlobalPositioningTraceJacobianReducer(
+      const py::dict& snapshot,
+      const bool accumulate_point_schur = true,
+      const py::object& projection_direction = py::none(),
+      const size_t top_k_residuals = 0,
+      const py::object& pinning_target_step = py::none(),
+      const std::string& schur_residual_source_filter = "")
+      : snapshot_(SnapshotTableFromPy(snapshot)),
+        accumulate_point_schur_(accumulate_point_schur),
+        projection_direction_(ProjectionDirectionFromPy(projection_direction)),
+        top_k_residuals_(top_k_residuals),
+        pinning_target_step_(OptionalPositiveDoubleFromPy(
+            pinning_target_step, "pinning_target_step")),
+        schur_residual_source_filter_(schur_residual_source_filter) {}
+
+  size_t AddChunk(const py::list& records, const py::list& memberships) {
+    if (records.size() != memberships.size()) {
+      throw std::runtime_error(
+          "records and memberships must have equal length");
+    }
+    size_t replayed = 0;
+    for (size_t idx = 0; idx < records.size(); ++idx) {
+      AddResidual(py::cast<py::dict>(records[idx]),
+                  py::cast<py::list>(memberships[idx]));
+      ++replayed;
+    }
+    return replayed;
+  }
+
+  py::dict Summary(const double damping, const size_t top_k_points) const {
+    py::dict result;
+    for (const auto& [edge_key, accumulator] : accumulators_) {
+      result[py::str(edge_key)] = EdgeSummary(accumulator,
+                                              damping,
+                                              top_k_points,
+                                              top_k_residuals_,
+                                              projection_direction_,
+                                              pinning_target_step_);
+    }
+    return result;
+  }
+
+ private:
+  void AddResidual(const py::dict& record, const py::list& memberships) {
+    if (memberships.empty()) {
+      return;
+    }
+    const py::dict attrs = py::cast<py::dict>(record[py::str("attrs")]);
+    const std::vector<NativeParameterBlock> parameter_blocks =
+        ParameterBlocksFromRecord(attrs);
+    std::unique_ptr<ceres::CostFunction> cost_function =
+        CreateCostFunctionFromRecord(attrs);
+    if (cost_function == nullptr) {
+      throw std::runtime_error("failed to create native replay cost function");
+    }
+
+    std::vector<Eigen::VectorXd> parameter_values;
+    std::vector<const double*> parameter_ptrs;
+    parameter_values.reserve(parameter_blocks.size());
+    parameter_ptrs.reserve(parameter_blocks.size());
+    for (const NativeParameterBlock& block : parameter_blocks) {
+      parameter_values.push_back(
+          SnapshotValue(snapshot_, block.kind, block.id, block.size));
+      parameter_ptrs.push_back(parameter_values.back().data());
+    }
+
+    const int residual_dim = cost_function->num_residuals();
+    Eigen::VectorXd residuals(residual_dim);
+    std::vector<std::vector<double>> jacobian_storage;
+    std::vector<double*> jacobian_ptrs;
+    jacobian_storage.reserve(parameter_blocks.size());
+    jacobian_ptrs.reserve(parameter_blocks.size());
+    for (const NativeParameterBlock& block : parameter_blocks) {
+      jacobian_storage.emplace_back(
+          static_cast<size_t>(residual_dim) * block.size,
+          std::numeric_limits<double>::quiet_NaN());
+      jacobian_ptrs.push_back(jacobian_storage.back().data());
+    }
+    const bool success = cost_function->Evaluate(
+        parameter_ptrs.data(), residuals.data(), jacobian_ptrs.data());
+    if (!success) {
+      return;
+    }
+
+    const double squared_norm = residuals.squaredNorm();
+    const double raw_cost = 0.5 * squared_norm;
+    const Eigen::Vector3d rho = LossRhoFromRecord(attrs, squared_norm);
+    const double robust_cost = 0.5 * rho[0];
+    const double rho1 = rho[1];
+    const double rho2 = rho[2];
+
+    const int frame_block_idx = FindBlock(parameter_blocks, "frame_center");
+    const int point_block_idx = FindBlock(parameter_blocks, "point3D");
+    std::optional<Eigen::Matrix<double, Eigen::Dynamic, 3>> frame_jacobian;
+    std::optional<Eigen::Matrix<double, Eigen::Dynamic, 3>> point_jacobian;
+    if (frame_block_idx >= 0 &&
+        parameter_blocks[static_cast<size_t>(frame_block_idx)].size == 3) {
+      frame_jacobian = Eigen::Map<
+          const Eigen::
+              Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>(
+          jacobian_storage[static_cast<size_t>(frame_block_idx)].data(),
+          residual_dim,
+          3);
+    }
+    if (point_block_idx >= 0 &&
+        parameter_blocks[static_cast<size_t>(point_block_idx)].size == 3) {
+      point_jacobian = Eigen::Map<
+          const Eigen::
+              Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>(
+          jacobian_storage[static_cast<size_t>(point_block_idx)].data(),
+          residual_dim,
+          3);
+    }
+
+    for (const py::handle membership_handle : memberships) {
+      const py::tuple membership = py::cast<py::tuple>(membership_handle);
+      if (membership.size() != 3) {
+        throw std::runtime_error(
+            "membership must be (edge_key, side, point_id)");
+      }
+      AddMembership(py::cast<std::string>(membership[0]),
+                    py::cast<std::string>(membership[1]),
+                    py::cast<uint64_t>(membership[2]),
+                    residuals,
+                    raw_cost,
+                    robust_cost,
+                    rho1,
+                    rho2,
+                    attrs,
+                    frame_jacobian,
+                    point_jacobian);
+    }
+  }
+
+  static int FindBlock(const std::vector<NativeParameterBlock>& blocks,
+                       const std::string& role) {
+    for (size_t idx = 0; idx < blocks.size(); ++idx) {
+      if (blocks[idx].role == role) {
+        return static_cast<int>(idx);
+      }
+    }
+    return -1;
+  }
+
+  void AddMembership(
+      const std::string& edge_key,
+      const std::string& side,
+      const uint64_t point_id,
+      const Eigen::VectorXd& residuals,
+      const double raw_cost,
+      const double robust_cost,
+      const double rho1,
+      const double rho2,
+      const py::dict& attrs,
+      const std::optional<Eigen::Matrix<double, Eigen::Dynamic, 3>>&
+          frame_jacobian,
+      const std::optional<Eigen::Matrix<double, Eigen::Dynamic, 3>>&
+          point_jacobian) {
+    NativeEdgeJacobianAccumulator& edge = accumulators_[edge_key];
+    edge.residual_ids_selected += 1;
+    edge.residuals_replayed += 1;
+    edge.raw_cost_sum += raw_cost;
+    edge.robust_cost_sum += robust_cost;
+    edge.rho1_sum += rho1;
+    edge.rho2_sum += rho2;
+    edge.rho2_min = std::min(edge.rho2_min, rho2);
+    edge.rho2_max = std::max(edge.rho2_max, rho2);
+    if (rho1 < 0.999) {
+      edge.rho1_downweighted_count += 1;
+    }
+    if (frame_jacobian.has_value()) {
+      edge.residuals_with_frame_jacobian += 1;
+      const Eigen::Vector3d gradient = frame_jacobian->transpose() * residuals;
+      const Eigen::Vector3d robust_gradient = rho1 * gradient;
+      if (side == "left") {
+        edge.left_gradient_raw += gradient;
+        edge.left_gradient_robust += robust_gradient;
+      } else if (side == "right") {
+        edge.right_gradient_raw += gradient;
+        edge.right_gradient_robust += robust_gradient;
+      } else if (side == "point") {
+        // Point-only memberships contribute to the eliminated point state
+        // but are intentionally not assigned to either camera block.
+      } else {
+        throw std::runtime_error(
+            "membership side must be 'left', 'right', or 'point'");
+      }
+      if (side != "point") {
+        AddTopOpposingResidual(edge,
+                               attrs,
+                               side,
+                               point_id,
+                               gradient,
+                               robust_gradient,
+                               raw_cost,
+                               robust_cost,
+                               rho1);
+        AddTopPinningResidual(edge,
+                              attrs,
+                              side,
+                              point_id,
+                              gradient,
+                              robust_gradient,
+                              *frame_jacobian,
+                              raw_cost,
+                              robust_cost,
+                              rho1,
+                              rho2);
+      }
+    }
+    if (!accumulate_point_schur_ || !frame_jacobian.has_value() ||
+        !point_jacobian.has_value()) {
+      return;
+    }
+    edge.residuals_with_frame_point_jacobians += 1;
+    NativePointSchurAccumulator& point = edge.point_accumulators[point_id];
+    const Eigen::Matrix3d hpp = point_jacobian->transpose() * *point_jacobian;
+    const Eigen::Matrix3d cross = frame_jacobian->transpose() * *point_jacobian;
+    const Eigen::Matrix3d hff = frame_jacobian->transpose() * *frame_jacobian;
+    const Eigen::Vector3d frame_gradient =
+        frame_jacobian->transpose() * residuals;
+    const Eigen::Vector3d point_gradient =
+        point_jacobian->transpose() * residuals;
+    const Eigen::Matrix3d analytic_hpp =
+        rho1 * hpp + 2.0 * rho2 * point_gradient * point_gradient.transpose();
+    const Eigen::Matrix3d analytic_cross =
+        rho1 * cross + 2.0 * rho2 * frame_gradient * point_gradient.transpose();
+    const Eigen::Matrix3d analytic_hff =
+        rho1 * hff + 2.0 * rho2 * frame_gradient * frame_gradient.transpose();
+    point.hpp_raw += hpp;
+    point.hpp_rho1 += rho1 * hpp;
+    point.hpp_analytic += analytic_hpp;
+    point.point_gradient_raw += point_gradient;
+    point.point_gradient_robust += rho1 * point_gradient;
+    const std::string source =
+        attrs.contains("is_lc_observation") &&
+                py::cast<bool>(attrs[py::str("is_lc_observation")])
+            ? "lc"
+            : "local";
+    if (projection_direction_.has_value() && top_k_residuals_ > 0 &&
+        side != "point" &&
+        (schur_residual_source_filter_.empty() ||
+         source == schur_residual_source_filter_)) {
+      NativeSchurResidualRow row;
+      row.residual_id = OptionalStringFromPy(attrs, "residual_id", "");
+      row.side = side;
+      row.frame_id = OptionalUInt64FromPy(attrs, "frame_id", 0);
+      row.image_id = OptionalUInt64FromPy(attrs, "image_id", 0);
+      row.point2D_idx = OptionalUInt64FromPy(attrs, "point2D_idx", 0);
+      row.point3D_id = point_id;
+      row.residual_type =
+          OptionalStringFromPy(attrs, "residual_type", "unknown");
+      row.loss_bucket = OptionalStringFromPy(attrs, "loss_bucket", "unknown");
+      row.source = source;
+      row.raw_cost = raw_cost;
+      row.robust_cost = robust_cost;
+      row.rho1 = rho1;
+      row.robust_frame_gradient = rho1 * frame_gradient;
+      row.robust_point_gradient = rho1 * point_gradient;
+      row.analytic_cross = analytic_cross;
+      row.analytic_hff = analytic_hff;
+      edge.schur_residuals.push_back(row);
+    }
+    if (side == "left") {
+      point.left_count += 1;
+      point.left_raw += cross;
+      point.left_rho1 += rho1 * cross;
+      point.left_analytic += analytic_cross;
+      point.left_hff_analytic += analytic_hff;
+      point.left_gradient_raw += frame_gradient;
+      point.left_gradient_robust += rho1 * frame_gradient;
+    } else if (side == "right") {
+      point.right_count += 1;
+      point.right_raw += cross;
+      point.right_rho1 += rho1 * cross;
+      point.right_analytic += analytic_cross;
+      point.right_hff_analytic += analytic_hff;
+      point.right_gradient_raw += frame_gradient;
+      point.right_gradient_robust += rho1 * frame_gradient;
+    } else if (side == "point") {
+      // The residual only conditions the eliminated point for this two-block
+      // cut analysis. It should not add a left/right camera coupling row.
+    } else {
+      throw std::runtime_error(
+          "membership side must be 'left', 'right', or 'point'");
+    }
+  }
+
+  void AddTopOpposingResidual(NativeEdgeJacobianAccumulator& edge,
+                              const py::dict& attrs,
+                              const std::string& side,
+                              const uint64_t point_id,
+                              const Eigen::Vector3d& raw_gradient,
+                              const Eigen::Vector3d& robust_gradient,
+                              const double raw_cost,
+                              const double robust_cost,
+                              const double rho1) const {
+    if (!projection_direction_.has_value() || top_k_residuals_ == 0) {
+      return;
+    }
+    const double descent_projection =
+        (-robust_gradient).dot(*projection_direction_);
+    const double opposing_projection = -descent_projection;
+    if (opposing_projection <= 0.0) {
+      return;
+    }
+
+    NativeTopResidualRow row;
+    row.residual_id = OptionalStringFromPy(attrs, "residual_id", "");
+    row.side = side;
+    row.frame_id = OptionalUInt64FromPy(attrs, "frame_id", 0);
+    row.image_id = OptionalUInt64FromPy(attrs, "image_id", 0);
+    row.point2D_idx = OptionalUInt64FromPy(attrs, "point2D_idx", 0);
+    row.point3D_id = point_id;
+    row.residual_type =
+        OptionalStringFromPy(attrs, "residual_type", "unknown");
+    row.loss_bucket = OptionalStringFromPy(attrs, "loss_bucket", "unknown");
+    row.source = attrs.contains("is_lc_observation") &&
+                         py::cast<bool>(attrs[py::str("is_lc_observation")])
+                     ? "lc"
+                     : "local";
+    row.descent_projection = descent_projection;
+    row.opposing_projection = opposing_projection;
+    row.raw_gradient_norm = raw_gradient.norm();
+    row.robust_gradient_norm = robust_gradient.norm();
+    row.raw_cost = raw_cost;
+    row.robust_cost = robust_cost;
+    row.rho1 = rho1;
+    row.raw_gradient = raw_gradient;
+    row.robust_gradient = robust_gradient;
+
+    if (edge.top_opposing_residuals.size() < top_k_residuals_) {
+      edge.top_opposing_residuals.push_back(row);
+      return;
+    }
+    const auto min_it = std::min_element(
+        edge.top_opposing_residuals.begin(),
+        edge.top_opposing_residuals.end(),
+        [](const NativeTopResidualRow& lhs, const NativeTopResidualRow& rhs) {
+          return lhs.opposing_projection < rhs.opposing_projection;
+        });
+    if (min_it != edge.top_opposing_residuals.end() &&
+        row.opposing_projection > min_it->opposing_projection) {
+      *min_it = row;
+    }
+  }
+
+  void AddTopPinningResidual(
+      NativeEdgeJacobianAccumulator& edge,
+      const py::dict& attrs,
+      const std::string& side,
+      const uint64_t point_id,
+      const Eigen::Vector3d& raw_gradient,
+      const Eigen::Vector3d& robust_gradient,
+      const Eigen::Matrix<double, Eigen::Dynamic, 3>& frame_jacobian,
+      const double raw_cost,
+      const double robust_cost,
+      const double rho1,
+      const double rho2) const {
+    if (!projection_direction_.has_value() || top_k_residuals_ == 0) {
+      return;
+    }
+    const Eigen::Matrix3d hff = frame_jacobian.transpose() * frame_jacobian;
+    const Eigen::Matrix3d analytic_hff =
+        rho1 * hff + 2.0 * rho2 * raw_gradient * raw_gradient.transpose();
+    const double descent_projection =
+        (-robust_gradient).dot(*projection_direction_);
+    const double directional_curvature =
+        projection_direction_->dot(analytic_hff * *projection_direction_);
+    if (!std::isfinite(directional_curvature) ||
+        directional_curvature <= 0.0) {
+      return;
+    }
+    const double newton_step =
+        std::abs(directional_curvature) < 1e-12
+            ? std::numeric_limits<double>::quiet_NaN()
+            : descent_projection / directional_curvature;
+
+    NativeTopResidualRow row;
+    row.residual_id = OptionalStringFromPy(attrs, "residual_id", "");
+    row.side = side;
+    row.frame_id = OptionalUInt64FromPy(attrs, "frame_id", 0);
+    row.image_id = OptionalUInt64FromPy(attrs, "image_id", 0);
+    row.point2D_idx = OptionalUInt64FromPy(attrs, "point2D_idx", 0);
+    row.point3D_id = point_id;
+    row.residual_type =
+        OptionalStringFromPy(attrs, "residual_type", "unknown");
+    row.loss_bucket = OptionalStringFromPy(attrs, "loss_bucket", "unknown");
+    row.source = attrs.contains("is_lc_observation") &&
+                         py::cast<bool>(attrs[py::str("is_lc_observation")])
+                     ? "lc"
+                     : "local";
+    row.descent_projection = descent_projection;
+    row.opposing_projection = -descent_projection;
+    row.raw_gradient_norm = raw_gradient.norm();
+    row.robust_gradient_norm = robust_gradient.norm();
+    row.raw_cost = raw_cost;
+    row.robust_cost = robust_cost;
+    row.rho1 = rho1;
+    row.directional_curvature = directional_curvature;
+    row.newton_step_along_projection =
+        std::isfinite(newton_step) ? std::optional<double>(newton_step)
+                                   : std::nullopt;
+    row.raw_gradient = raw_gradient;
+    row.robust_gradient = robust_gradient;
+
+    if (edge.top_pinning_residuals.size() < top_k_residuals_) {
+      edge.top_pinning_residuals.push_back(row);
+      return;
+    }
+    const auto min_it = std::min_element(
+        edge.top_pinning_residuals.begin(),
+        edge.top_pinning_residuals.end(),
+        [](const NativeTopResidualRow& lhs, const NativeTopResidualRow& rhs) {
+          return lhs.directional_curvature.value_or(0.0) <
+                 rhs.directional_curvature.value_or(0.0);
+        });
+    if (min_it != edge.top_pinning_residuals.end() &&
+        directional_curvature >
+            min_it->directional_curvature.value_or(0.0)) {
+      *min_it = row;
+    }
+  }
+
+  static std::optional<Eigen::Vector3d> ProjectionDirectionFromPy(
+      const py::object& value) {
+    if (value.is_none()) {
+      return std::nullopt;
+    }
+    const py::array_t<double, py::array::c_style | py::array::forcecast> array(
+        value);
+    if (array.ndim() != 1 || array.shape(0) != 3) {
+      throw std::runtime_error(
+          "projection_direction must be None or a length-3 vector");
+    }
+    Eigen::Vector3d direction(array.data()[0], array.data()[1], array.data()[2]);
+    const double norm = direction.norm();
+    if (!(norm > 0.0) || !std::isfinite(norm)) {
+      throw std::runtime_error(
+          "projection_direction must have finite nonzero norm");
+    }
+    return direction / norm;
+  }
+
+  static std::optional<double> OptionalPositiveDoubleFromPy(
+      const py::object& value, const std::string& name) {
+    if (value.is_none()) {
+      return std::nullopt;
+    }
+    const double parsed = py::cast<double>(value);
+    if (!std::isfinite(parsed) || parsed <= 0.0) {
+      throw std::runtime_error(name + " must be None or finite and positive");
+    }
+    return parsed;
+  }
+
+  static double PinningScore(
+      const std::optional<double>& curvature,
+      const double descent_projection,
+      const std::optional<double>& newton_step,
+      const std::optional<double>& target_step) {
+    if (!curvature.has_value() || !std::isfinite(*curvature) ||
+        *curvature <= 0.0 || !std::isfinite(descent_projection) ||
+        descent_projection <= 0.0 || !newton_step.has_value() ||
+        !std::isfinite(*newton_step) || *newton_step <= 0.0) {
+      return 0.0;
+    }
+    if (!target_step.has_value()) {
+      return *curvature / std::max(std::abs(*newton_step), 1.0);
+    }
+    if (*newton_step >= *target_step) {
+      return 0.0;
+    }
+    const double blocked_fraction =
+        (*target_step - *newton_step) / *target_step;
+    return *curvature * blocked_fraction;
+  }
+
+  static py::list TopResidualsSummary(
+      const std::vector<NativeTopResidualRow>& rows) {
+    std::vector<NativeTopResidualRow> sorted = rows;
+    std::sort(sorted.begin(),
+              sorted.end(),
+              [](const NativeTopResidualRow& lhs,
+                 const NativeTopResidualRow& rhs) {
+                if (lhs.opposing_projection == rhs.opposing_projection) {
+                  return lhs.residual_id < rhs.residual_id;
+                }
+                return lhs.opposing_projection > rhs.opposing_projection;
+              });
+    py::list result;
+    for (const NativeTopResidualRow& row : sorted) {
+      py::dict item;
+      item["residual_id"] = row.residual_id;
+      item["side"] = row.side;
+      item["frame_id"] = row.frame_id;
+      item["image_id"] = row.image_id;
+      item["point2D_idx"] = row.point2D_idx;
+      item["point3D_id"] = row.point3D_id;
+      item["residual_type"] = row.residual_type;
+      item["loss_bucket"] = row.loss_bucket;
+      item["source"] = row.source;
+      item["descent_projection"] = row.descent_projection;
+      item["opposing_projection"] = row.opposing_projection;
+      item["raw_gradient_norm"] = row.raw_gradient_norm;
+      item["robust_gradient_norm"] = row.robust_gradient_norm;
+      item["raw_cost"] = row.raw_cost;
+      item["robust_cost"] = row.robust_cost;
+      item["rho1"] = row.rho1;
+      item["directional_curvature_analytic"] =
+          row.directional_curvature.has_value()
+              ? py::cast(*row.directional_curvature)
+              : py::none();
+      item["newton_step_along_projection"] =
+          row.newton_step_along_projection.has_value()
+              ? py::cast(*row.newton_step_along_projection)
+              : py::none();
+      item["raw_gradient"] = Vector3ToList(row.raw_gradient);
+      item["robust_gradient"] = Vector3ToList(row.robust_gradient);
+      result.append(item);
+    }
+    return result;
+  }
+
+  static py::list TopSchurPinningResidualsSummary(
+      const NativeEdgeJacobianAccumulator& edge,
+      const double damping,
+      const size_t top_k_residuals,
+      const std::optional<Eigen::Vector3d>& projection_direction,
+      const std::optional<double>& pinning_target_step) {
+    py::list result;
+    if (!projection_direction.has_value() || top_k_residuals == 0) {
+      return result;
+    }
+    const Eigen::Vector3d& direction = *projection_direction;
+    const Eigen::Matrix3d eye = Eigen::Matrix3d::Identity();
+    struct ScoredRow {
+      const NativeSchurResidualRow* row = nullptr;
+      double right_reduced_descent_projection = 0.0;
+      std::optional<double> right_reduced_directional_curvature;
+      std::optional<double> right_reduced_newton_step;
+      double pinning_score = 0.0;
+      Eigen::Vector3d right_reduced_gradient = Eigen::Vector3d::Zero();
+    };
+    std::vector<ScoredRow> scored;
+    scored.reserve(edge.schur_residuals.size());
+    for (const NativeSchurResidualRow& row : edge.schur_residuals) {
+      const auto point_it = edge.point_accumulators.find(row.point3D_id);
+      if (point_it == edge.point_accumulators.end()) {
+        continue;
+      }
+      const NativePointSchurAccumulator& point = point_it->second;
+      if (point.left_count == 0 || point.right_count == 0) {
+        continue;
+      }
+      Eigen::FullPivLU<Eigen::Matrix3d> analytic_lu(point.hpp_analytic +
+                                                    damping * eye);
+      if (!analytic_lu.isInvertible()) {
+        continue;
+      }
+
+      Eigen::Vector3d right_reduced_gradient;
+      std::optional<double> right_reduced_directional_curvature;
+      if (row.side == "right") {
+        right_reduced_gradient =
+            row.robust_frame_gradient -
+            row.analytic_cross *
+                analytic_lu.solve(point.point_gradient_robust);
+        const Eigen::Matrix3d right_reduced_hessian =
+            row.analytic_hff -
+            row.analytic_cross *
+                analytic_lu.solve(point.right_analytic.transpose());
+        right_reduced_directional_curvature =
+            direction.dot(right_reduced_hessian * direction);
+      } else if (row.side == "left") {
+        // A pre-side residual has no direct post-frame parameter block. It
+        // still changes the Schur-reduced post gradient through the eliminated
+        // point gradient. We deliberately do not assign a directional
+        // curvature to this row: curvature attribution through Hpp is not a
+        // unique per-residual decomposition.
+        right_reduced_gradient =
+            -point.right_analytic *
+            analytic_lu.solve(row.robust_point_gradient);
+        right_reduced_directional_curvature = std::nullopt;
+      } else {
+        continue;
+      }
+      const double descent_projection = (-right_reduced_gradient).dot(direction);
+      if (!std::isfinite(descent_projection)) {
+        continue;
+      }
+      if (right_reduced_directional_curvature.has_value() &&
+          !std::isfinite(*right_reduced_directional_curvature)) {
+        continue;
+      }
+      std::optional<double> newton_step;
+      if (right_reduced_directional_curvature.has_value() &&
+          std::abs(*right_reduced_directional_curvature) >= 1e-12) {
+        newton_step =
+            descent_projection / *right_reduced_directional_curvature;
+      }
+      const double pinning_score =
+          PinningScore(right_reduced_directional_curvature,
+                       descent_projection,
+                       newton_step,
+                       pinning_target_step);
+      if (pinning_score <= 0.0) {
+        continue;
+      }
+      scored.push_back({&row,
+                        descent_projection,
+                        right_reduced_directional_curvature,
+                        newton_step,
+                        pinning_score,
+                        right_reduced_gradient});
+    }
+    std::sort(scored.begin(),
+              scored.end(),
+              [](const ScoredRow& lhs, const ScoredRow& rhs) {
+                if (lhs.pinning_score == rhs.pinning_score) {
+                  return lhs.row->residual_id < rhs.row->residual_id;
+                }
+                return lhs.pinning_score > rhs.pinning_score;
+              });
+    for (size_t idx = 0; idx < std::min(top_k_residuals, scored.size());
+         ++idx) {
+      const ScoredRow& scored_row = scored[idx];
+      const NativeSchurResidualRow& row = *scored_row.row;
+      py::dict item;
+      item["residual_id"] = row.residual_id;
+      item["side"] = row.side;
+      item["frame_id"] = row.frame_id;
+      item["image_id"] = row.image_id;
+      item["point2D_idx"] = row.point2D_idx;
+      item["point3D_id"] = row.point3D_id;
+      item["residual_type"] = row.residual_type;
+      item["loss_bucket"] = row.loss_bucket;
+      item["source"] = row.source;
+      item["raw_cost"] = row.raw_cost;
+      item["robust_cost"] = row.robust_cost;
+      item["rho1"] = row.rho1;
+      item["right_reduced_descent_projection"] =
+          scored_row.right_reduced_descent_projection;
+      item["right_reduced_directional_curvature_contribution_analytic"] =
+          scored_row.right_reduced_directional_curvature.has_value()
+              ? py::cast(*scored_row.right_reduced_directional_curvature)
+              : py::none();
+      item["right_reduced_newton_step_along_projection"] =
+          scored_row.right_reduced_newton_step.has_value()
+              ? py::cast(*scored_row.right_reduced_newton_step)
+              : py::none();
+      item["pinning_score"] = scored_row.pinning_score;
+      item["right_reduced_gradient"] =
+          Vector3ToList(scored_row.right_reduced_gradient);
+      result.append(item);
+    }
+    return result;
+  }
+
+  static py::dict EdgeSummary(
+      const NativeEdgeJacobianAccumulator& edge,
+      const double damping,
+      const size_t top_k_points,
+      const size_t top_k_residuals,
+      const std::optional<Eigen::Vector3d>& projection_direction,
+      const std::optional<double>& pinning_target_step) {
+    double raw_fro_sum = 0.0;
+    double rho1_fro_sum = 0.0;
+    double analytic_fro_sum = 0.0;
+    double raw_spectral_max = 0.0;
+    double rho1_spectral_max = 0.0;
+    double analytic_spectral_max = 0.0;
+    Eigen::Vector3d left_reduced_gradient_analytic =
+        Eigen::Vector3d::Zero();
+    Eigen::Vector3d right_reduced_gradient_analytic =
+        Eigen::Vector3d::Zero();
+    Eigen::Matrix3d left_reduced_hessian_analytic =
+        Eigen::Matrix3d::Zero();
+    Eigen::Matrix3d right_reduced_hessian_analytic =
+        Eigen::Matrix3d::Zero();
+    uint64_t contributing_points = 0;
+    uint64_t singular_points = 0;
+    struct PointRow {
+      uint64_t point_id;
+      uint64_t left_count;
+      uint64_t right_count;
+      double raw_fro;
+      double rho1_fro;
+      double analytic_fro;
+      double raw_spectral;
+      double rho1_spectral;
+      double analytic_spectral;
+      std::optional<double> left_descent_projection;
+      std::optional<double> right_descent_projection;
+      std::optional<double> left_directional_curvature;
+      std::optional<double> right_directional_curvature;
+      std::optional<double> left_newton_step;
+      std::optional<double> right_newton_step;
+      double right_pinning_score = 0.0;
+    };
+    std::vector<PointRow> point_rows;
+    const Eigen::Matrix3d eye = Eigen::Matrix3d::Identity();
+    for (const auto& [point_id, point] : edge.point_accumulators) {
+      if (point.left_count == 0 || point.right_count == 0) {
+        continue;
+      }
+      contributing_points += 1;
+      Eigen::FullPivLU<Eigen::Matrix3d> raw_lu(point.hpp_raw + damping * eye);
+      Eigen::FullPivLU<Eigen::Matrix3d> rho1_lu(point.hpp_rho1 + damping * eye);
+      Eigen::FullPivLU<Eigen::Matrix3d> analytic_lu(point.hpp_analytic +
+                                                    damping * eye);
+      if (!raw_lu.isInvertible() || !rho1_lu.isInvertible() ||
+          !analytic_lu.isInvertible()) {
+        singular_points += 1;
+        continue;
+      }
+      const Eigen::Matrix3d raw_block =
+          point.left_raw * raw_lu.solve(point.right_raw.transpose());
+      const Eigen::Matrix3d rho1_block =
+          point.left_rho1 * rho1_lu.solve(point.right_rho1.transpose());
+      const Eigen::Matrix3d analytic_block =
+          point.left_analytic *
+          analytic_lu.solve(point.right_analytic.transpose());
+      left_reduced_gradient_analytic +=
+          point.left_gradient_robust -
+          point.left_analytic * analytic_lu.solve(point.point_gradient_robust);
+      right_reduced_gradient_analytic +=
+          point.right_gradient_robust -
+          point.right_analytic * analytic_lu.solve(point.point_gradient_robust);
+      const Eigen::Vector3d point_left_reduced_gradient =
+          point.left_gradient_robust -
+          point.left_analytic * analytic_lu.solve(point.point_gradient_robust);
+      const Eigen::Vector3d point_right_reduced_gradient =
+          point.right_gradient_robust -
+          point.right_analytic * analytic_lu.solve(point.point_gradient_robust);
+      const Eigen::Matrix3d point_left_reduced_hessian =
+          point.left_hff_analytic -
+          point.left_analytic * analytic_lu.solve(point.left_analytic.transpose());
+      const Eigen::Matrix3d point_right_reduced_hessian =
+          point.right_hff_analytic -
+          point.right_analytic * analytic_lu.solve(point.right_analytic.transpose());
+      left_reduced_hessian_analytic += point_left_reduced_hessian;
+      right_reduced_hessian_analytic += point_right_reduced_hessian;
+      const double raw_fro = raw_block.norm();
+      const double rho1_fro = rho1_block.norm();
+      const double analytic_fro = analytic_block.norm();
+      const double raw_spectral =
+          Eigen::JacobiSVD<Eigen::Matrix3d>(raw_block).singularValues()[0];
+      const double rho1_spectral =
+          Eigen::JacobiSVD<Eigen::Matrix3d>(rho1_block).singularValues()[0];
+      const double analytic_spectral =
+          Eigen::JacobiSVD<Eigen::Matrix3d>(analytic_block).singularValues()[0];
+      raw_fro_sum += raw_fro;
+      rho1_fro_sum += rho1_fro;
+      analytic_fro_sum += analytic_fro;
+      raw_spectral_max = std::max(raw_spectral_max, raw_spectral);
+      rho1_spectral_max = std::max(rho1_spectral_max, rho1_spectral);
+      analytic_spectral_max =
+          std::max(analytic_spectral_max, analytic_spectral);
+      std::optional<double> left_descent_projection;
+      std::optional<double> right_descent_projection;
+      std::optional<double> left_directional_curvature;
+      std::optional<double> right_directional_curvature;
+      std::optional<double> left_newton_step;
+      std::optional<double> right_newton_step;
+      double right_pinning_score = 0.0;
+      if (projection_direction.has_value()) {
+        const Eigen::Vector3d& direction = *projection_direction;
+        left_descent_projection =
+            (-point_left_reduced_gradient).dot(direction);
+        right_descent_projection =
+            (-point_right_reduced_gradient).dot(direction);
+        left_directional_curvature =
+            direction.dot(point_left_reduced_hessian * direction);
+        right_directional_curvature =
+            direction.dot(point_right_reduced_hessian * direction);
+        if (std::abs(*left_directional_curvature) >= 1e-12) {
+          left_newton_step =
+              *left_descent_projection / *left_directional_curvature;
+        }
+        if (std::abs(*right_directional_curvature) >= 1e-12) {
+          right_newton_step =
+              *right_descent_projection / *right_directional_curvature;
+        }
+        right_pinning_score = PinningScore(right_directional_curvature,
+                                           *right_descent_projection,
+                                           right_newton_step,
+                                           pinning_target_step);
+      }
+      point_rows.push_back({point_id,
+                            point.left_count,
+                            point.right_count,
+                            raw_fro,
+                            rho1_fro,
+                            analytic_fro,
+                            raw_spectral,
+                            rho1_spectral,
+                            analytic_spectral,
+                            left_descent_projection,
+                            right_descent_projection,
+                            left_directional_curvature,
+                            right_directional_curvature,
+                            left_newton_step,
+                            right_newton_step,
+                            right_pinning_score});
+    }
+    std::sort(point_rows.begin(),
+              point_rows.end(),
+              [](const PointRow& lhs, const PointRow& rhs) {
+                if (lhs.right_pinning_score != rhs.right_pinning_score) {
+                  return lhs.right_pinning_score > rhs.right_pinning_score;
+                }
+                if (lhs.analytic_fro == rhs.analytic_fro) {
+                  return lhs.point_id < rhs.point_id;
+                }
+                return lhs.analytic_fro > rhs.analytic_fro;
+              });
+    py::list top_points;
+    for (size_t idx = 0; idx < std::min(top_k_points, point_rows.size());
+         ++idx) {
+      const PointRow& row = point_rows[idx];
+      py::dict item;
+      item["point3D_id"] = row.point_id;
+      item["left_residual_count"] = row.left_count;
+      item["right_residual_count"] = row.right_count;
+      item["raw_schur_frobenius_norm"] = row.raw_fro;
+      item["rho1_schur_frobenius_norm"] = row.rho1_fro;
+      item["analytic_robust_schur_frobenius_norm"] = row.analytic_fro;
+      item["raw_schur_spectral_norm"] = row.raw_spectral;
+      item["rho1_schur_spectral_norm"] = row.rho1_spectral;
+      item["analytic_robust_schur_spectral_norm"] = row.analytic_spectral;
+      if (projection_direction.has_value()) {
+        item["left_reduced_descent_projection"] =
+            row.left_descent_projection.has_value()
+                ? py::cast(*row.left_descent_projection)
+                : py::none();
+        item["right_reduced_descent_projection"] =
+            row.right_descent_projection.has_value()
+                ? py::cast(*row.right_descent_projection)
+                : py::none();
+        item["left_reduced_directional_curvature_analytic"] =
+            row.left_directional_curvature.has_value()
+                ? py::cast(*row.left_directional_curvature)
+                : py::none();
+        item["right_reduced_directional_curvature_analytic"] =
+            row.right_directional_curvature.has_value()
+                ? py::cast(*row.right_directional_curvature)
+                : py::none();
+        item["left_reduced_newton_step_along_projection"] =
+            row.left_newton_step.has_value() ? py::cast(*row.left_newton_step)
+                                             : py::none();
+        item["right_reduced_newton_step_along_projection"] =
+            row.right_newton_step.has_value()
+                ? py::cast(*row.right_newton_step)
+                : py::none();
+        item["right_pinning_score"] = row.right_pinning_score;
+      }
+      top_points.append(item);
+    }
+
+    py::dict summary;
+    summary["residual_ids_selected"] = edge.residual_ids_selected;
+    summary["residuals_replayed"] = edge.residuals_replayed;
+    summary["residuals_with_frame_jacobian"] =
+        edge.residuals_with_frame_jacobian;
+    summary["residuals_with_frame_point_jacobians"] =
+        edge.residuals_with_frame_point_jacobians;
+    summary["raw_cost_sum"] = edge.raw_cost_sum;
+    summary["robust_cost_sum"] = edge.robust_cost_sum;
+    summary["rho1_mean"] =
+        edge.residuals_replayed == 0
+            ? py::none()
+            : py::cast(edge.rho1_sum /
+                       static_cast<double>(edge.residuals_replayed));
+    summary["rho2_mean"] =
+        edge.residuals_replayed == 0
+            ? py::none()
+            : py::cast(edge.rho2_sum /
+                       static_cast<double>(edge.residuals_replayed));
+    summary["rho2_min"] =
+        edge.residuals_replayed == 0 ? py::none() : py::cast(edge.rho2_min);
+    summary["rho2_max"] =
+        edge.residuals_replayed == 0 ? py::none() : py::cast(edge.rho2_max);
+    summary["rho1_downweighted_fraction"] =
+        edge.residuals_replayed == 0
+            ? py::none()
+            : py::cast(static_cast<double>(edge.rho1_downweighted_count) /
+                       static_cast<double>(edge.residuals_replayed));
+    summary["left_gradient_raw_norm"] = edge.left_gradient_raw.norm();
+    summary["right_gradient_raw_norm"] = edge.right_gradient_raw.norm();
+    summary["net_gradient_raw_norm"] =
+        (edge.left_gradient_raw + edge.right_gradient_raw).norm();
+    summary["left_gradient_robust_norm"] = edge.left_gradient_robust.norm();
+    summary["right_gradient_robust_norm"] = edge.right_gradient_robust.norm();
+    summary["net_gradient_robust_norm"] =
+        (edge.left_gradient_robust + edge.right_gradient_robust).norm();
+    summary["left_gradient_raw"] = Vector3ToList(edge.left_gradient_raw);
+    summary["right_gradient_raw"] = Vector3ToList(edge.right_gradient_raw);
+    summary["net_gradient_raw"] =
+        Vector3ToList(edge.left_gradient_raw + edge.right_gradient_raw);
+    summary["left_gradient_robust"] = Vector3ToList(edge.left_gradient_robust);
+    summary["right_gradient_robust"] =
+        Vector3ToList(edge.right_gradient_robust);
+    summary["net_gradient_robust"] =
+        Vector3ToList(edge.left_gradient_robust + edge.right_gradient_robust);
+    summary["left_reduced_gradient_analytic"] =
+        Vector3ToList(left_reduced_gradient_analytic);
+    summary["right_reduced_gradient_analytic"] =
+        Vector3ToList(right_reduced_gradient_analytic);
+    summary["net_reduced_gradient_analytic"] = Vector3ToList(
+        left_reduced_gradient_analytic + right_reduced_gradient_analytic);
+    summary["left_reduced_gradient_analytic_norm"] =
+        left_reduced_gradient_analytic.norm();
+    summary["right_reduced_gradient_analytic_norm"] =
+        right_reduced_gradient_analytic.norm();
+    summary["net_reduced_gradient_analytic_norm"] =
+        (left_reduced_gradient_analytic + right_reduced_gradient_analytic)
+            .norm();
+    summary["left_reduced_hessian_analytic_trace"] =
+        left_reduced_hessian_analytic.trace();
+    summary["right_reduced_hessian_analytic_trace"] =
+        right_reduced_hessian_analytic.trace();
+    if (projection_direction.has_value()) {
+      const Eigen::Vector3d& direction = *projection_direction;
+      const double left_descent_projection =
+          (-left_reduced_gradient_analytic).dot(direction);
+      const double right_descent_projection =
+          (-right_reduced_gradient_analytic).dot(direction);
+      const double net_descent_projection =
+          (-(left_reduced_gradient_analytic + right_reduced_gradient_analytic))
+              .dot(direction);
+      const double left_directional_curvature =
+          direction.dot(left_reduced_hessian_analytic * direction);
+      const double right_directional_curvature =
+          direction.dot(right_reduced_hessian_analytic * direction);
+      summary["left_reduced_descent_projection"] = left_descent_projection;
+      summary["right_reduced_descent_projection"] = right_descent_projection;
+      summary["net_reduced_descent_projection"] = net_descent_projection;
+      summary["left_reduced_directional_curvature_analytic"] =
+          left_directional_curvature;
+      summary["right_reduced_directional_curvature_analytic"] =
+          right_directional_curvature;
+      summary["left_reduced_newton_step_along_projection"] =
+          std::abs(left_directional_curvature) < 1e-12
+              ? py::none()
+              : py::cast(left_descent_projection / left_directional_curvature);
+      summary["right_reduced_newton_step_along_projection"] =
+          std::abs(right_directional_curvature) < 1e-12
+              ? py::none()
+              : py::cast(right_descent_projection /
+                         right_directional_curvature);
+    }
+    summary["schur_contributing_point_count"] = contributing_points;
+    summary["schur_singular_point_count"] = singular_points;
+    summary["raw_schur_frobenius_norm_sum"] = raw_fro_sum;
+    summary["rho1_schur_frobenius_norm_sum"] = rho1_fro_sum;
+    summary["analytic_robust_schur_frobenius_norm_sum"] = analytic_fro_sum;
+    summary["raw_schur_spectral_norm_max"] = raw_spectral_max;
+    summary["rho1_schur_spectral_norm_max"] = rho1_spectral_max;
+    summary["analytic_robust_schur_spectral_norm_max"] = analytic_spectral_max;
+    summary["top_points_by_analytic_robust_schur"] = top_points;
+    summary["top_opposing_residuals"] =
+        TopResidualsSummary(edge.top_opposing_residuals);
+    summary["top_pinning_residuals"] =
+        TopResidualsSummary(edge.top_pinning_residuals);
+    summary["top_schur_pinning_residuals"] =
+        TopSchurPinningResidualsSummary(
+            edge,
+            damping,
+            top_k_residuals,
+            projection_direction,
+            pinning_target_step);
+    return summary;
+  }
+
+  SnapshotTable snapshot_;
+  bool accumulate_point_schur_ = true;
+  std::optional<Eigen::Vector3d> projection_direction_;
+  size_t top_k_residuals_ = 0;
+  std::optional<double> pinning_target_step_;
+  std::string schur_residual_source_filter_;
+  std::unordered_map<std::string, NativeEdgeJacobianAccumulator> accumulators_;
+
+  static py::list Vector3ToList(const Eigen::Vector3d& vector) {
+    py::list result;
+    result.append(vector.x());
+    result.append(vector.y());
+    result.append(vector.z());
+    return result;
+  }
+};
+
+}  // namespace
+
+void BindGlobalPositioningTraceJacobianReducer(py::module& m) {
+  py::class_<NativeGlobalPositioningTraceJacobianReducer>(
+      m, "_GlobalPositioningTraceJacobianReducer")
+      .def(py::init<const py::dict&,
+                    bool,
+                    const py::object&,
+                    size_t,
+                    const py::object&,
+                    const std::string&>(),
+           "snapshot"_a,
+           "accumulate_point_schur"_a = true,
+           "projection_direction"_a = py::none(),
+           "top_k_residuals"_a = 0,
+           "pinning_target_step"_a = py::none(),
+           "schur_residual_source_filter"_a = "")
+      .def("add_chunk",
+           &NativeGlobalPositioningTraceJacobianReducer::AddChunk,
+           "records"_a,
+           "memberships"_a)
+      .def("summary",
+           &NativeGlobalPositioningTraceJacobianReducer::Summary,
+           "schur_damping"_a = 1e-8,
+           "top_k_points"_a = 20);
+}

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -13,6 +13,8 @@ using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
 
+void BindGlobalPositioningTraceJacobianReducer(py::module& m);
+
 void BindGlobalPositioner(py::module& m) {
   // ``LossConfig`` is bound by ``BindBundleAdjuster`` (estimators/
   // bundle_adjustment.cc), which runs earlier in ``BindEstimators``.
@@ -38,10 +40,11 @@ void BindGlobalPositioner(py::module& m) {
           .def_readwrite(
               "snapshot_every_n_iterations",
               &GlobalPositioningTraceOptions::snapshot_every_n_iterations)
-          .def_readwrite(
-              "max_snapshotted_points",
-              &GlobalPositioningTraceOptions::max_snapshotted_points);
+          .def_readwrite("write_legacy_jsonl",
+                         &GlobalPositioningTraceOptions::write_legacy_jsonl);
   MakeDataclass(PyGlobalPositioningTraceOptions);
+
+  BindGlobalPositioningTraceJacobianReducer(m);
 
   auto PyGlobalPositionerOptions =
       py::classh<GlobalPositionerOptions>(m, "GlobalPositionerOptions")

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -23,7 +23,8 @@ void BindGlobalPositioner(py::module& m) {
           .value("SUMMARY", TraceLevel::kSummary)
           .value("RESIDUAL_LEDGER", TraceLevel::kResidualLedger)
           .value("PARAMETER_SNAPSHOTS", TraceLevel::kParameterSnapshots)
-          .value("RESIDUAL_VALUES", TraceLevel::kResidualValues);
+          .value("RESIDUAL_VALUES", TraceLevel::kResidualValues)
+          .value("RESIDUAL_JACOBIANS", TraceLevel::kResidualJacobians);
   AddStringToEnumConstructor(PyGlobalPositioningTraceLevel);
 
   auto PyGlobalPositioningTraceOptions =

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -3,6 +3,7 @@
 #include "colmap/estimators/rotation_averaging.h"
 
 #include "pycolmap/helpers.h"
+#include "pycolmap/pybind11_extension.h"
 
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
@@ -15,6 +16,32 @@ namespace py = pybind11;
 void BindGlobalPositioner(py::module& m) {
   // ``LossConfig`` is bound by ``BindBundleAdjuster`` (estimators/
   // bundle_adjustment.cc), which runs earlier in ``BindEstimators``.
+  using TraceLevel = GlobalPositioningTraceLevel;
+  auto PyGlobalPositioningTraceLevel =
+      py::enum_<TraceLevel>(m, "GlobalPositioningTraceLevel")
+          .value("OFF", TraceLevel::kOff)
+          .value("SUMMARY", TraceLevel::kSummary)
+          .value("RESIDUAL_LEDGER", TraceLevel::kResidualLedger)
+          .value("PARAMETER_SNAPSHOTS", TraceLevel::kParameterSnapshots)
+          .value("RESIDUAL_VALUES", TraceLevel::kResidualValues);
+  AddStringToEnumConstructor(PyGlobalPositioningTraceLevel);
+
+  auto PyGlobalPositioningTraceOptions =
+      py::classh<GlobalPositioningTraceOptions>(m,
+                                                "GlobalPositioningTraceOptions")
+          .def(py::init<>())
+          .def_readwrite("level", &GlobalPositioningTraceOptions::level)
+          .def_readwrite("output_path",
+                         &GlobalPositioningTraceOptions::output_path)
+          .def_readwrite("run_label", &GlobalPositioningTraceOptions::run_label)
+          .def_readwrite(
+              "snapshot_every_n_iterations",
+              &GlobalPositioningTraceOptions::snapshot_every_n_iterations)
+          .def_readwrite(
+              "max_snapshotted_points",
+              &GlobalPositioningTraceOptions::max_snapshotted_points);
+  MakeDataclass(PyGlobalPositioningTraceOptions);
+
   auto PyGlobalPositionerOptions =
       py::classh<GlobalPositionerOptions>(m, "GlobalPositionerOptions")
           .def(py::init<>())
@@ -75,6 +102,10 @@ void BindGlobalPositioner(py::module& m) {
               &GlobalPositionerOptions::uncalibrated_loss_downweight,
               "Scale factor applied to the loss of uncalibrated cameras when "
               "apply_uncalibrated_loss_downweight is true. Default 0.5.")
+          .def_readwrite("trace",
+                         &GlobalPositionerOptions::trace,
+                         "File-backed trace recorder options for global "
+                         "positioning diagnostics.")
           .def_property(
               "num_threads",
               [](const GlobalPositionerOptions& self) {


### PR DESCRIPTION
## Summary
- add residual-value replay for global positioning trace level residual_values
- dump per-sampled-iteration raw residual vectors, raw costs, and robust costs as binary sidecars with JSON metadata
- join replay data back to residual_blocks.jsonl with stable residual_id values
- strengthen GlobalPositioning tests for replay bookkeeping, residual IDs, sidecar costs, and lower-level trace behavior

## Verification
- colmap/scripts/build.sh
- ./build/src/colmap/estimators/global_positioning_test --gtest_filter='GlobalPositioning.*' (19 passed)
- ctest --test-dir build -R '^estimators/global_positioning_test$' --output-on-failure
- clang-format --dry-run --Werror on touched C++ files
- git diff --check