### PR TITLE
Avoid repeated GP metric-depth option setup

### DIFF
--- a/src/colmap/estimators/cost_functions/metric_depth.h
+++ b/src/colmap/estimators/cost_functions/metric_depth.h
@@ -13,34 +13,30 @@ namespace colmap {
 
 enum class MetricDepthResidualType { kLinear, kLog, kLogLinear };
 
-struct MetricDepthOptions {
-  bool use_log_scale = false;
-  MetricDepthResidualType residual_type = MetricDepthResidualType::kLinear;
-  bool zero_residual_behind = false;
-  double log_linear_threshold = 0.1;
-
-  bool IsValid() const {
-    return residual_type != MetricDepthResidualType::kLogLinear ||
-           log_linear_threshold > 0.0;
-  }
-};
-
 // 1-D residual: camera-frame z-depth vs scaled depth prior (s_i * m_ik).
 // AutoDiff<1, 3, 3, 1> over (frame_center, point3D, dmap_scale).
 struct MetricDepthError {
-  MetricDepthError(const Eigen::Quaterniond& rotation,
-                   double depth_prior,
-                   double sigma_depth,
-                   const MetricDepthOptions& options = MetricDepthOptions())
+  MetricDepthError(
+      const Eigen::Quaterniond& rotation,
+      double depth_prior,
+      double sigma_depth,
+      bool use_log_scale = false,
+      MetricDepthResidualType residual_type = MetricDepthResidualType::kLinear,
+      bool zero_residual_behind = false,
+      double log_linear_threshold = 0.1)
       : rotation_(rotation),
         depth_prior_(depth_prior),
         sigma_depth_(sigma_depth),
-        options_(options) {
+        use_log_scale_(use_log_scale),
+        residual_type_(residual_type),
+        zero_residual_behind_(zero_residual_behind),
+        log_linear_threshold_(log_linear_threshold) {
     if (sigma_depth <= 1e-9) {
       throw std::invalid_argument(
           "MetricDepthError: Standard deviation must be positive.");
     }
-    if (!options.IsValid()) {
+    if (residual_type == MetricDepthResidualType::kLogLinear &&
+        log_linear_threshold <= 0.0) {
       throw std::invalid_argument(
           "MetricDepthError: log-linear threshold must be positive.");
     }
@@ -58,12 +54,11 @@ struct MetricDepthError {
         rotation_.cast<T>() * point_vec_world;
     const T z_est = point_vec_cam[2];
 
-    const T scale =
-        options_.use_log_scale ? ceres::exp(dmap_scale[0]) : dmap_scale[0];
+    const T scale = use_log_scale_ ? ceres::exp(dmap_scale[0]) : dmap_scale[0];
     const T scaled_prior = scale * T(depth_prior_);
     const T scaled_sigma = scale * T(sigma_depth_);
 
-    if (options_.zero_residual_behind && z_est <= T(0.0)) {
+    if (zero_residual_behind_ && z_est <= T(0.0)) {
       residuals[0] = T(0.0);
       return true;
     }
@@ -71,13 +66,13 @@ struct MetricDepthError {
     T r_depth;
     T weight;
 
-    if (options_.residual_type != MetricDepthResidualType::kLinear) {
+    if (residual_type_ != MetricDepthResidualType::kLinear) {
       const T depth_prior_safe = std::max(T(depth_prior_), T(1e-6));
       const T sigma_log = T(sigma_depth_) / depth_prior_safe;
       const T weight_log = T(1.0) / std::max(T(1e-6), sigma_log);
 
-      if (options_.residual_type == MetricDepthResidualType::kLogLinear) {
-        const T thresh = T(options_.log_linear_threshold);
+      if (residual_type_ == MetricDepthResidualType::kLogLinear) {
+        const T thresh = T(log_linear_threshold_);
         const T scaled_prior_safe = std::max(scaled_prior, T(1e-6));
         if (z_est > thresh) {
           const T z_est_safe = std::max(z_est, T(1e-6));
@@ -111,27 +106,40 @@ struct MetricDepthError {
       const Eigen::Quaterniond& rotation,
       double depth_prior,
       double sigma_depth,
-      const MetricDepthOptions& options = MetricDepthOptions()) {
+      bool use_log_scale = false,
+      MetricDepthResidualType residual_type = MetricDepthResidualType::kLinear,
+      bool zero_residual_behind = false,
+      double log_linear_threshold = 0.1) {
     if (sigma_depth <= 1e-9) {
       LOG(ERROR) << "Cannot create MetricDepthError: Standard deviation must "
                     "be positive.";
       return nullptr;
     }
-    if (!options.IsValid()) {
+    if (residual_type == MetricDepthResidualType::kLogLinear &&
+        log_linear_threshold <= 0.0) {
       LOG(ERROR)
           << "Cannot create MetricDepthError: log-linear threshold must be "
              "positive.";
       return nullptr;
     }
     return new ceres::AutoDiffCostFunction<MetricDepthError, 1, 3, 3, 1>(
-        new MetricDepthError(rotation, depth_prior, sigma_depth, options));
+        new MetricDepthError(rotation,
+                             depth_prior,
+                             sigma_depth,
+                             use_log_scale,
+                             residual_type,
+                             zero_residual_behind,
+                             log_linear_threshold));
   }
 
  private:
   const Eigen::Quaterniond rotation_;
   const double depth_prior_;
   const double sigma_depth_;
-  const MetricDepthOptions options_;
+  const bool use_log_scale_;
+  const MetricDepthResidualType residual_type_;
+  const bool zero_residual_behind_;
+  const double log_linear_threshold_;
 };
 
 // ScalePriorError + LogScalePriorError replaced by native

--- a/src/colmap/estimators/cost_functions/metric_depth_test.cc
+++ b/src/colmap/estimators/cost_functions/metric_depth_test.cc
@@ -28,17 +28,21 @@ Eigen::Vector3d MakePointWithDepth(const Eigen::Quaterniond& rotation,
   return camera_center + vec_world;
 }
 
-MetricDepthOptions MakeMetricDepthOptions(
+ceres::CostFunction* CreateMetricDepthCost(
+    const Eigen::Quaterniond& rotation,
+    double depth_prior,
+    double sigma_depth,
     MetricDepthResidualType residual_type = MetricDepthResidualType::kLinear,
     bool use_log_scale = false,
     bool zero_residual_behind = false,
     double log_linear_threshold = 0.1) {
-  MetricDepthOptions options;
-  options.use_log_scale = use_log_scale;
-  options.residual_type = residual_type;
-  options.zero_residual_behind = zero_residual_behind;
-  options.log_linear_threshold = log_linear_threshold;
-  return options;
+  return MetricDepthError::Create(rotation,
+                                  depth_prior,
+                                  sigma_depth,
+                                  use_log_scale,
+                                  residual_type,
+                                  zero_residual_behind,
+                                  log_linear_threshold);
 }
 
 TEST(MetricDepthError, ZeroResidualWhenPriorMatchesPredicted) {
@@ -95,11 +99,12 @@ TEST(MetricDepthError, LogResidualMatchesFormula) {
   const Eigen::Vector3d point3D =
       MakePointWithDepth(rotation, camera_center, z_est);
 
-  std::unique_ptr<ceres::CostFunction> cost_function(MetricDepthError::Create(
-      rotation,
-      depth_prior,
-      sigma_depth,
-      MakeMetricDepthOptions(MetricDepthResidualType::kLog)));
+  std::unique_ptr<ceres::CostFunction> cost_function(
+      MetricDepthError::Create(rotation,
+                               depth_prior,
+                               sigma_depth,
+                               /*use_log_scale=*/false,
+                               MetricDepthResidualType::kLog));
 
   // sigma_log = sigma_depth / depth_prior; residual = log(z / (s*m)) /
   // sigma_log
@@ -124,13 +129,13 @@ TEST(MetricDepthError, ZeroResidualBehindCameraGate) {
   const Eigen::Vector3d point3D =
       MakePointWithDepth(rotation, camera_center, -2.0);
 
-  std::unique_ptr<ceres::CostFunction> cost_function(MetricDepthError::Create(
-      rotation,
-      depth_prior,
-      sigma_depth,
-      MakeMetricDepthOptions(MetricDepthResidualType::kLinear,
-                             /*use_log_scale=*/false,
-                             /*zero_residual_behind=*/true)));
+  std::unique_ptr<ceres::CostFunction> cost_function(
+      MetricDepthError::Create(rotation,
+                               depth_prior,
+                               sigma_depth,
+                               /*use_log_scale=*/false,
+                               MetricDepthResidualType::kLinear,
+                               /*zero_residual_behind=*/true));
 
   double residual = std::numeric_limits<double>::quiet_NaN();
   const double* parameters[3] = {
@@ -140,8 +145,7 @@ TEST(MetricDepthError, ZeroResidualBehindCameraGate) {
 
   // Sanity: without the gate, the residual is non-zero for the same input.
   std::unique_ptr<ceres::CostFunction> cost_function_no_gate(
-      MetricDepthError::Create(
-          rotation, depth_prior, sigma_depth, MakeMetricDepthOptions()));
+      MetricDepthError::Create(rotation, depth_prior, sigma_depth));
   double residual_no_gate = std::numeric_limits<double>::quiet_NaN();
   EXPECT_TRUE(
       cost_function_no_gate->Evaluate(parameters, &residual_no_gate, nullptr));
@@ -160,12 +164,11 @@ TEST(MetricDepthError, LogScaleParameterization) {
       MakePointWithDepth(rotation, camera_center, linear_scale * depth_prior);
 
   std::unique_ptr<ceres::CostFunction> cost_function_log(
-      MetricDepthError::Create(
-          rotation,
-          depth_prior,
-          sigma_depth,
-          MakeMetricDepthOptions(MetricDepthResidualType::kLinear,
-                                 /*use_log_scale=*/true)));
+      MetricDepthError::Create(rotation,
+                               depth_prior,
+                               sigma_depth,
+                               /*use_log_scale=*/true,
+                               MetricDepthResidualType::kLinear));
 
   double residual = std::numeric_limits<double>::quiet_NaN();
   const double* parameters[3] = {
@@ -183,25 +186,41 @@ TEST(MetricDepthError, AllOptionsSmokeFinite) {
   const Eigen::Vector3d point3D =
       MakePointWithDepth(rotation, camera_center, 4.0);
 
-  const MetricDepthOptions options[] = {
-      MakeMetricDepthOptions(MetricDepthResidualType::kLinear,
-                             /*use_log_scale=*/true),
-      MakeMetricDepthOptions(MetricDepthResidualType::kLog),
-      MakeMetricDepthOptions(MetricDepthResidualType::kLinear,
-                             /*use_log_scale=*/false,
-                             /*zero_residual_behind=*/true),
-      MakeMetricDepthOptions(MetricDepthResidualType::kLogLinear),
-      MakeMetricDepthOptions(MetricDepthResidualType::kLogLinear,
-                             /*use_log_scale=*/true,
-                             /*zero_residual_behind=*/true),
+  struct SmokeCase {
+    MetricDepthResidualType residual_type;
+    bool use_log_scale;
+    bool zero_residual_behind;
   };
 
-  for (const MetricDepthOptions& option : options) {
+  const SmokeCase cases[] = {
+      {MetricDepthResidualType::kLinear,
+       /*use_log_scale=*/true,
+       /*zero_residual_behind=*/false},
+      {MetricDepthResidualType::kLog,
+       /*use_log_scale=*/false,
+       /*zero_residual_behind=*/false},
+      {MetricDepthResidualType::kLinear,
+       /*use_log_scale=*/false,
+       /*zero_residual_behind=*/true},
+      {MetricDepthResidualType::kLogLinear,
+       /*use_log_scale=*/false,
+       /*zero_residual_behind=*/false},
+      {MetricDepthResidualType::kLogLinear,
+       /*use_log_scale=*/true,
+       /*zero_residual_behind=*/true},
+  };
+
+  for (const SmokeCase& test_case : cases) {
     std::unique_ptr<ceres::CostFunction> cost_function(
-        MetricDepthError::Create(rotation, depth_prior, sigma_depth, option));
+        CreateMetricDepthCost(rotation,
+                              depth_prior,
+                              sigma_depth,
+                              test_case.residual_type,
+                              test_case.use_log_scale,
+                              test_case.zero_residual_behind));
     ASSERT_NE(cost_function, nullptr);
     // For the log-scale variants, dmap_scale must be log(scale); use 0 → s=1.
-    const double scale_param = option.use_log_scale ? 0.0 : dmap_scale;
+    const double scale_param = test_case.use_log_scale ? 0.0 : dmap_scale;
     const double* params[3] = {
         camera_center.data(), point3D.data(), &scale_param};
     double residual = std::numeric_limits<double>::quiet_NaN();
@@ -219,12 +238,14 @@ TEST(MetricDepthError, RejectsNonPositiveSigma) {
 
 TEST(MetricDepthError, RejectsNonPositiveLogLinearThreshold) {
   const Eigen::Quaterniond rotation = MakeRotation();
-  MetricDepthOptions options;
-  options.residual_type = MetricDepthResidualType::kLogLinear;
-  options.log_linear_threshold = 0.0;
-
-  ceres::CostFunction* cost_function = MetricDepthError::Create(
-      rotation, /*depth_prior=*/1.0, /*sigma_depth=*/0.5, options);
+  ceres::CostFunction* cost_function =
+      MetricDepthError::Create(rotation,
+                               /*depth_prior=*/1.0,
+                               /*sigma_depth=*/0.5,
+                               /*use_log_scale=*/false,
+                               MetricDepthResidualType::kLogLinear,
+                               /*zero_residual_behind=*/false,
+                               /*log_linear_threshold=*/0.0);
   EXPECT_EQ(cost_function, nullptr);
 }
 

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -25,8 +25,7 @@ std::string GpObservationKey(point3D_t point3D_id,
                              point2D_t point2D_idx,
                              bool is_lc_observation) {
   return std::to_string(point3D_id) + ":" + std::to_string(image_id) + ":" +
-         std::to_string(point2D_idx) + ":" +
-         (is_lc_observation ? "1" : "0");
+         std::to_string(point2D_idx) + ":" + (is_lc_observation ? "1" : "0");
 }
 
 Eigen::Vector3d RandVector3d(double low, double high) {
@@ -95,15 +94,14 @@ void GpObsDumpObservation(const char* tag,
   FILE* f = GpObsDumpFile();
   if (f == nullptr) return;
   const point2D_t feature_id = observation.point2D_idx;
-  const Eigen::Vector2d angular_std =
-      feature_id < image.angular_stddevs.size()
-          ? image.angular_stddevs[feature_id]
-          : Eigen::Vector2d::Constant(-1.0);
+  const Eigen::Vector2d angular_std = feature_id < image.angular_stddevs.size()
+                                          ? image.angular_stddevs[feature_id]
+                                          : Eigen::Vector2d::Constant(-1.0);
   const bool depth_valid = feature_id < image.depth_prior_validity.size() &&
                            image.depth_prior_validity[feature_id];
-  const double depth_prior =
-      feature_id < image.depth_priors.size() ? image.depth_priors[feature_id]
-                                             : -1.0;
+  const double depth_prior = feature_id < image.depth_priors.size()
+                                 ? image.depth_priors[feature_id]
+                                 : -1.0;
   const double depth_sigma = feature_id < image.depth_prior_stddevs.size()
                                  ? image.depth_prior_stddevs[feature_id]
                                  : -1.0;
@@ -174,28 +172,26 @@ void GpStateDump(
   for (const image_t image_id : image_ids) {
     const Image& image = reconstruction.Image(image_id);
     const auto frame_center_it = frame_centers.find(image.FrameId());
-    const Eigen::Vector3d center =
-        frame_center_it == frame_centers.end()
-            ? image.CamFromWorld().TgtOriginInSrc()
-            : frame_center_it->second;
+    const Eigen::Vector3d center = frame_center_it == frame_centers.end()
+                                       ? image.CamFromWorld().TgtOriginInSrc()
+                                       : frame_center_it->second;
     const Eigen::Vector4d q = image.CamFromWorld().rotation().coeffs();
-    std::fprintf(
-        f,
-        "%s|image|%llu|t=%.17g,%.17g,%.17g|q=%.17g,%.17g,%.17g,%.17g|"
-        "nfeat=%llu|ndepth=%llu|reg=%d|frame=%llu\n",
-        tag,
-        static_cast<unsigned long long>(image_id),
-        center(0),
-        center(1),
-        center(2),
-        q(0),
-        q(1),
-        q(2),
-        q(3),
-        static_cast<unsigned long long>(image.NumPoints2D()),
-        static_cast<unsigned long long>(image.depth_priors.size()),
-        image.HasPose() ? 1 : 0,
-        static_cast<unsigned long long>(image.FrameId()));
+    std::fprintf(f,
+                 "%s|image|%llu|t=%.17g,%.17g,%.17g|q=%.17g,%.17g,%.17g,%.17g|"
+                 "nfeat=%llu|ndepth=%llu|reg=%d|frame=%llu\n",
+                 tag,
+                 static_cast<unsigned long long>(image_id),
+                 center(0),
+                 center(1),
+                 center(2),
+                 q(0),
+                 q(1),
+                 q(2),
+                 q(3),
+                 static_cast<unsigned long long>(image.NumPoints2D()),
+                 static_cast<unsigned long long>(image.depth_priors.size()),
+                 image.HasPose() ? 1 : 0,
+                 static_cast<unsigned long long>(image.FrameId()));
   }
 
   std::vector<point3D_t> point3D_ids;
@@ -228,11 +224,8 @@ void GpStateDump(
   for (const std::string& key : scale_keys) {
     const size_t index = bata_scale_indices.at(key);
     if (index >= scales.size()) continue;
-    std::fprintf(f,
-                 "%s|bata_scale|%s|value=%.17g\n",
-                 tag,
-                 key.c_str(),
-                 scales[index]);
+    std::fprintf(
+        f, "%s|bata_scale|%s|value=%.17g\n", tag, key.c_str(), scales[index]);
   }
 
   for (const auto& [image_id, scale] : dmap_scales) {
@@ -250,24 +243,6 @@ uint64_t StableHashAppendDouble(uint64_t hash, const double value) {
   static_assert(sizeof(bits) == sizeof(value));
   std::memcpy(&bits, &value, sizeof(value));
   return StableHashAppend(hash, bits);
-}
-
-MetricDepthOptions CreateMetricDepthOptions(
-    const GlobalPositionerOptions& options) {
-  MetricDepthOptions metric_depth_options;
-  metric_depth_options.use_log_scale =
-      options.use_log_scale_for_depth_map_scales;
-  metric_depth_options.zero_residual_behind = options.zero_residual_behind;
-  metric_depth_options.log_linear_threshold = options.log_linear_threshold;
-
-  if (options.smooth_log_linear_transition) {
-    metric_depth_options.residual_type = MetricDepthResidualType::kLogLinear;
-  } else if (options.use_log_residual_for_depth) {
-    metric_depth_options.residual_type = MetricDepthResidualType::kLog;
-  } else {
-    metric_depth_options.residual_type = MetricDepthResidualType::kLinear;
-  }
-  return metric_depth_options;
 }
 
 // Per-observation depth outlier check. Returns true when the log-space
@@ -405,7 +380,8 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
       }
       uint64_t parameter_value_hash = kFnvOffset;
       for (const double scale : scales_) {
-        parameter_value_hash = StableHashAppendDouble(parameter_value_hash, scale);
+        parameter_value_hash =
+            StableHashAppendDouble(parameter_value_hash, scale);
       }
       std::vector<point3D_t> point3D_ids;
       point3D_ids.reserve(reconstruction.NumPoints3D());
@@ -433,7 +409,8 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
       for (const frame_t frame_id : frame_ids) {
         Eigen::Vector3d& center = frame_centers_.at(frame_id);
         if (problem_->HasParameterBlock(center.data())) {
-          parameter_value_hash = StableHashAppend(parameter_value_hash, frame_id);
+          parameter_value_hash =
+              StableHashAppend(parameter_value_hash, frame_id);
           for (int i = 0; i < 3; ++i) {
             parameter_value_hash =
                 StableHashAppendDouble(parameter_value_hash, center[i]);
@@ -493,8 +470,7 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
           << " MKL_NUM_THREADS=" << EnvValue("MKL_NUM_THREADS")
           << " BLIS_NUM_THREADS=" << EnvValue("BLIS_NUM_THREADS")
           << " VECLIB_MAXIMUM_THREADS=" << EnvValue("VECLIB_MAXIMUM_THREADS")
-          << " NUMEXPR_NUM_THREADS=" << EnvValue("NUMEXPR_NUM_THREADS")
-          << "\n";
+          << " NUMEXPR_NUM_THREADS=" << EnvValue("NUMEXPR_NUM_THREADS") << "\n";
     }
   }
   GpStateDump("pre_ceres_solve",
@@ -507,20 +483,21 @@ bool GlobalPositioner::Solve(const PoseGraph& pose_graph,
   if (const char* path = GpStateDumpPath()) {
     FILE* f = std::fopen(path, "a");
     if (f != nullptr) {
-      std::fprintf(f,
-                   "ceres_summary|init=%.17g|final=%.17g|iters=%d|term=%d|"
-                   "linear_solver=%d|preconditioner=%d|threading=%d|"
-                   "n_resid_blocks=%d|n_param_blocks=%d|n_params=%d\n",
-                   summary.initial_cost,
-                   summary.final_cost,
-                   static_cast<int>(summary.iterations.size()),
-                   static_cast<int>(summary.termination_type),
-                   static_cast<int>(options_.solver_options.linear_solver_type),
-                   static_cast<int>(options_.solver_options.preconditioner_type),
-                   options_.solver_options.num_threads,
-                   summary.num_residual_blocks,
-                   summary.num_parameter_blocks,
-                   summary.num_parameters);
+      std::fprintf(
+          f,
+          "ceres_summary|init=%.17g|final=%.17g|iters=%d|term=%d|"
+          "linear_solver=%d|preconditioner=%d|threading=%d|"
+          "n_resid_blocks=%d|n_param_blocks=%d|n_params=%d\n",
+          summary.initial_cost,
+          summary.final_cost,
+          static_cast<int>(summary.iterations.size()),
+          static_cast<int>(summary.termination_type),
+          static_cast<int>(options_.solver_options.linear_solver_type),
+          static_cast<int>(options_.solver_options.preconditioner_type),
+          options_.solver_options.num_threads,
+          summary.num_residual_blocks,
+          summary.num_parameter_blocks,
+          summary.num_parameters);
       for (size_t i = 0; i < summary.iterations.size() && i < 50; ++i) {
         std::fprintf(f,
                      "ceres_iter|%zu|cost=%.17g|step_size=%.17g|tr=%.17g\n",
@@ -877,7 +854,8 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
     feature_undist = image.features_undist[observation.point2D_idx];
   } else {
     const std::optional<Eigen::Vector2d> cam_point =
-        image.CameraPtr()->CamFromImg(image.Point2D(observation.point2D_idx).xy);
+        image.CameraPtr()->CamFromImg(
+            image.Point2D(observation.point2D_idx).xy);
     if (!cam_point.has_value()) {
       LOG(WARNING)
           << "Ignoring feature because it failed to project: point3D_id="
@@ -898,8 +876,10 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   const Eigen::Vector3d cam_from_point3D_dir =
       image.CamFromWorld().rotation().inverse() * feature_undist;
 
-  const std::string scale_key = GpObservationKey(
-      point3D_id, observation.image_id, observation.point2D_idx, is_lc_observation);
+  const std::string scale_key = GpObservationKey(point3D_id,
+                                                 observation.image_id,
+                                                 observation.point2D_idx,
+                                                 is_lc_observation);
   if (!options_.debug_initial_bata_scales.empty() &&
       options_.debug_initial_bata_scales.find(scale_key) ==
           options_.debug_initial_bata_scales.end()) {
@@ -938,8 +918,9 @@ void GlobalPositioner::AddObservationToProblem(point3D_t point3D_id,
   const bool image_is_track_anchor =
       observation.point2D_idx < image.is_track_anchor.size() &&
       image.is_track_anchor[observation.point2D_idx];
-  const bool image_is_inlier = observation.point2D_idx < image.is_inlier.size() &&
-                               image.is_inlier[observation.point2D_idx];
+  const bool image_is_inlier =
+      observation.point2D_idx < image.is_inlier.size() &&
+      image.is_inlier[observation.point2D_idx];
 
   // Match the pyglomap GP loss cascade: per-observation labels are stored on
   // Image masks, not on COLMAP TrackElement flags.
@@ -1149,7 +1130,10 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
       MetricDepthError::Create(image.CamFromWorld().rotation(),
                                depth_prior,
                                depth_sigma,
-                               CreateMetricDepthOptions(options_));
+                               options_.use_log_scale_for_depth_map_scales,
+                               options_.metric_depth_residual_type,
+                               options_.zero_residual_behind,
+                               options_.log_linear_threshold);
 
   if (metric_depth_cost == nullptr) return;
 
@@ -1177,8 +1161,9 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
   const bool image_is_track_anchor =
       observation.point2D_idx < image.is_track_anchor.size() &&
       image.is_track_anchor[observation.point2D_idx];
-  const bool image_is_inlier = observation.point2D_idx < image.is_inlier.size() &&
-                               image.is_inlier[observation.point2D_idx];
+  const bool image_is_inlier =
+      observation.point2D_idx < image.is_inlier.size() &&
+      image.is_inlier[observation.point2D_idx];
   const bool image_is_depth_outlier =
       observation.point2D_idx < image.is_depth_outlier.size() &&
       image.is_depth_outlier[observation.point2D_idx];
@@ -1213,9 +1198,8 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
                              point3D.xyz.data(),
                              &dmap_scales_[observation.image_id]);
   if (!options_.use_log_scale_for_depth_map_scales) {
-    problem_->SetParameterLowerBound(&dmap_scales_[observation.image_id],
-                                     0,
-                                     1e-5);
+    problem_->SetParameterLowerBound(
+        &dmap_scales_[observation.image_id], 0, 1e-5);
   }
   residual_order_hash_ = StableHashAppend(residual_order_hash_, 2);
   residual_order_hash_ = StableHashAppend(residual_order_hash_, point3D_id);
@@ -1238,12 +1222,12 @@ void GlobalPositioner::AddCamerasAndPointsToParameterGroups(
 
   const std::string ordering_mode = EnvValue("MPSFM_GP_ORDERING_MODE");
   const bool split_scales = ordering_mode == "per_block_all";
-  const bool split_points =
-      split_scales || ordering_mode == "per_block_non_scales" ||
-      ordering_mode == "per_block_points";
-  const bool split_camera_like =
-      split_scales || ordering_mode == "per_block_non_scales" ||
-      ordering_mode == "per_block_camera_like";
+  const bool split_points = split_scales ||
+                            ordering_mode == "per_block_non_scales" ||
+                            ordering_mode == "per_block_points";
+  const bool split_camera_like = split_scales ||
+                                 ordering_mode == "per_block_non_scales" ||
+                                 ordering_mode == "per_block_camera_like";
   const bool legacy_unordered = ordering_mode == "legacy_unordered";
 
   // Add scale parameters first. In the default mode, keep legacy coarse
@@ -1394,9 +1378,9 @@ void GlobalPositioner::AddCamerasAndPointsToParameterGroups(
         dmap_order_hash = StableHashAppend(dmap_order_hash, image_id);
       }
       log << "gp_parameter_ordering"
-          << " mode=" << (ordering_mode.empty() ? "legacy_coarse" : ordering_mode)
-          << " scales=" << scales_.size()
-          << " points=" << point3D_ids.size()
+          << " mode="
+          << (ordering_mode.empty() ? "legacy_coarse" : ordering_mode)
+          << " scales=" << scales_.size() << " points=" << point3D_ids.size()
           << " frame_centers=" << frame_ids.size()
           << " image_centers=" << image_ids.size()
           << " cams_in_rig=" << sensor_ids.size()
@@ -1404,8 +1388,7 @@ void GlobalPositioner::AddCamerasAndPointsToParameterGroups(
           << " point_order_hash=" << point_order_hash
           << " frame_order_hash=" << frame_order_hash
           << " sensor_order_hash=" << sensor_order_hash
-          << " dmap_order_hash=" << dmap_order_hash
-          << "\n";
+          << " dmap_order_hash=" << dmap_order_hash << "\n";
     }
   }
 }

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "colmap/estimators/ceres_loss.h"
+#include "colmap/estimators/cost_functions/metric_depth.h"
 #include "colmap/scene/pose_graph.h"
 #include "colmap/scene/reconstruction.h"
 
@@ -77,10 +78,9 @@ struct GlobalPositionerOptions {
   // --- Metric-depth path toggles (only consulted when
   //     use_metric_depth_constraint == true) ---
   bool use_log_scale_for_depth_map_scales = false;
-  bool use_log_residual_for_depth = false;
+  MetricDepthResidualType metric_depth_residual_type =
+      MetricDepthResidualType::kLinear;
   bool zero_residual_behind = false;
-  // Selects the log-linear residual shape and implies log residuals.
-  bool smooth_log_linear_transition = false;
   double log_linear_threshold = 0.1;
   double scale_prior_stddev = 1.0;
 

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -250,11 +250,13 @@ TEST(MetricDepthError, SmoothLogLinearTransitionC1Continuity) {
   const double sigma_depth = 0.2;
   const double threshold = 0.5;
 
-  MetricDepthOptions options;
-  options.residual_type = MetricDepthResidualType::kLogLinear;
-  options.log_linear_threshold = threshold;
-
-  MetricDepthError functor(identity, depth_prior, sigma_depth, options);
+  MetricDepthError functor(identity,
+                           depth_prior,
+                           sigma_depth,
+                           /*use_log_scale=*/false,
+                           MetricDepthResidualType::kLogLinear,
+                           /*zero_residual_behind=*/false,
+                           threshold);
 
   // Helper: evaluate residual at z_est with camera at origin, identity
   // rotation, point at (0, 0, z_est), dmap_scale = 1.0.

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -15,6 +15,13 @@ namespace py = pybind11;
 void BindGlobalPositioner(py::module& m) {
   // ``LossConfig`` is bound by ``BindBundleAdjuster`` (estimators/
   // bundle_adjustment.cc), which runs earlier in ``BindEstimators``.
+  auto PyMetricDepthResidualType =
+      py::enum_<MetricDepthResidualType>(m, "MetricDepthResidualType")
+          .value("LINEAR", MetricDepthResidualType::kLinear)
+          .value("LOG", MetricDepthResidualType::kLog)
+          .value("LOG_LINEAR", MetricDepthResidualType::kLogLinear);
+  AddStringToEnumConstructor(PyMetricDepthResidualType);
+
   auto PyGlobalPositionerOptions =
       py::classh<GlobalPositionerOptions>(m, "GlobalPositionerOptions")
           .def(py::init<>())
@@ -148,12 +155,10 @@ void BindGlobalPositioner(py::module& m) {
       .def_readwrite(
           "use_log_scale_for_depth_map_scales",
           &GlobalPositionerOptions::use_log_scale_for_depth_map_scales)
-      .def_readwrite("use_log_residual_for_depth",
-                     &GlobalPositionerOptions::use_log_residual_for_depth)
+      .def_readwrite("metric_depth_residual_type",
+                     &GlobalPositionerOptions::metric_depth_residual_type)
       .def_readwrite("zero_residual_behind",
                      &GlobalPositionerOptions::zero_residual_behind)
-      .def_readwrite("smooth_log_linear_transition",
-                     &GlobalPositionerOptions::smooth_log_linear_transition)
       .def_readwrite("log_linear_threshold",
                      &GlobalPositionerOptions::log_linear_threshold)
       .def_readwrite("scale_prior_stddev",
@@ -212,17 +217,13 @@ void BindGlobalPositioner(py::module& m) {
         output["dmap_scales"] = positioner.GetDmapScales();
         output["debug_initial_frame_centers"] =
             positioner.GetInitialFrameCenters();
-        output["debug_initial_point3D_xyz"] =
-            positioner.GetInitialPoint3DXYZ();
-        output["debug_initial_bata_scales"] =
-            positioner.GetInitialBataScales();
-        output["debug_final_bata_scales"] =
-            positioner.GetFinalBataScales();
+        output["debug_initial_point3D_xyz"] = positioner.GetInitialPoint3DXYZ();
+        output["debug_initial_bata_scales"] = positioner.GetInitialBataScales();
+        output["debug_final_bata_scales"] = positioner.GetFinalBataScales();
         const GlobalPositionerDiagnostics& diagnostics =
             positioner.GetDiagnostics();
         py::dict diagnostics_dict;
-        diagnostics_dict["num_bata_residuals"] =
-            diagnostics.num_bata_residuals;
+        diagnostics_dict["num_bata_residuals"] = diagnostics.num_bata_residuals;
         diagnostics_dict["num_metric_depth_residuals"] =
             diagnostics.num_metric_depth_residuals;
         diagnostics_dict["num_scale_prior_residuals"] =


### PR DESCRIPTION
## Summary

Small native GP setup cleanup on top of the dev-pinned byte-repro pycolmap line.

- expose metric-depth residual behavior as flat `GlobalPositionerOptions` fields
- bind `MetricDepthResidualType` in pycolmap
- remove `MetricDepthOptions` entirely and pass the flat fields directly into `MetricDepthError`

## Paired PR

Requires `Zador-Pataki/videosfm-private#129`, which sets the flat native GP fields from the existing VideoSfM GP config.

## Scope

This branch is based directly on `d41557f1f8c912119e343eaab585894ff2473b10` / `current-byte-repro-pycolmap-source`.

It intentionally does not include the GP trace/callback stack and does not move the VideoSfM COLMAP tag.

## Validation

Attempted:

```bash
source /home/zador/workspace/projects/VIDEOSFM/videosfm_venv/bin/activate
cmake --build pybuild --target _core -j16
```

The touched C++ files compile and `_core` links, but the build fails after linking when stub generation/import hits an existing unresolved symbol on this dev-pinned build line:

```text
undefined symbol: _ZN6colmap24FilterPairsByInlierRatioERNS_19CorrespondenceGraphEd
```

That symbol is unrelated to this patch; the PR diff only touches native GP metric-depth option setup/binding.
