### PR TITLE
Skip nonpositive GP metric depth priors

### DIFF
--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -1106,6 +1106,9 @@ void GlobalPositioner::AddMetricDepthResidual(point3D_t point3D_id,
   const double depth_prior = image.depth_priors[observation.point2D_idx];
   const double depth_sigma = image.depth_prior_stddevs[observation.point2D_idx];
 
+  if (options_.skip_nonpositive_metric_depth_priors && depth_prior <= 0.0) {
+    return;
+  }
   if (depth_sigma <= 1e-9) return;
 
   // Lazy-insert dmap_scales_ on first valid observation per image.

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -66,8 +66,8 @@ struct GlobalPositionerOptions {
   // Add per-observation MetricDepthError residual alongside BATA.
   bool use_metric_depth_constraint = false;
   // Ignore valid-mask observations with nonpositive metric-depth priors.
-  // Default false preserves existing behavior; enable to sanitize GP inputs.
-  bool skip_nonpositive_metric_depth_priors = false;
+  // Disable only to reproduce legacy behavior that kept them in GP.
+  bool skip_nonpositive_metric_depth_priors = true;
 
   // Include loop-closure observations in point3D problems.
   bool use_lc_observations = false;

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -65,6 +65,9 @@ struct GlobalPositionerOptions {
 
   // Add per-observation MetricDepthError residual alongside BATA.
   bool use_metric_depth_constraint = false;
+  // Ignore valid-mask observations with nonpositive metric-depth priors.
+  // Default false preserves existing behavior; enable to sanitize GP inputs.
+  bool skip_nonpositive_metric_depth_priors = false;
 
   // Include loop-closure observations in point3D problems.
   bool use_lc_observations = false;

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -665,6 +665,82 @@ void StampGtDepthPriors(Reconstruction& reconstruction) {
   }
 }
 
+size_t CountValidDepthObservations(const Reconstruction& reconstruction,
+                                   int min_num_view_per_track) {
+  size_t total = 0;
+  for (const auto& [_, point3D] : reconstruction.Points3D()) {
+    if (static_cast<int>(point3D.track.Length()) < min_num_view_per_track) {
+      continue;
+    }
+    for (const TrackElement& observation : point3D.track.Elements()) {
+      const Image& image = reconstruction.Image(observation.image_id);
+      if (observation.point2D_idx < image.depth_prior_validity.size() &&
+          image.depth_prior_validity[observation.point2D_idx] &&
+          observation.point2D_idx < image.depth_prior_stddevs.size() &&
+          image.depth_prior_stddevs[observation.point2D_idx] > 1e-9) {
+        ++total;
+      }
+    }
+  }
+  return total;
+}
+
+void SetFirstValidDepthPrior(Reconstruction& reconstruction,
+                             double depth_prior) {
+  for (const auto& [_, point3D] : reconstruction.Points3D()) {
+    for (const TrackElement& observation : point3D.track.Elements()) {
+      Image& image = reconstruction.Image(observation.image_id);
+      if (observation.point2D_idx < image.depth_prior_validity.size() &&
+          image.depth_prior_validity[observation.point2D_idx]) {
+        image.depth_priors[observation.point2D_idx] = depth_prior;
+        image.depth_prior_stddevs[observation.point2D_idx] = 1.0;
+        return;
+      }
+    }
+  }
+  FAIL() << "No valid depth prior found";
+}
+
+TEST(GlobalPositioning, KeepsNonpositiveMetricDepthPriorsByDefault) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  StampGtDepthPriors(data.reconstruction);
+  const size_t valid_depth_observations = CountValidDepthObservations(
+      data.reconstruction, BaselineGpOptions().min_num_view_per_track);
+  ASSERT_GT(valid_depth_observations, 0u);
+  SetFirstValidDepthPrior(data.reconstruction, 0.0);
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  ASSERT_FALSE(options.skip_nonpositive_metric_depth_priors);
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  EXPECT_EQ(positioner.GetDiagnostics().num_metric_depth_residuals,
+            static_cast<int>(valid_depth_observations));
+}
+
+TEST(GlobalPositioning, CanSkipNonpositiveMetricDepthPriors) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  StampGtDepthPriors(data.reconstruction);
+  const size_t valid_depth_observations = CountValidDepthObservations(
+      data.reconstruction, BaselineGpOptions().min_num_view_per_track);
+  ASSERT_GT(valid_depth_observations, 0u);
+  SetFirstValidDepthPrior(data.reconstruction, 0.0);
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  options.skip_nonpositive_metric_depth_priors = true;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  EXPECT_EQ(positioner.GetDiagnostics().num_metric_depth_residuals,
+            static_cast<int>(valid_depth_observations - 1));
+}
+
 TEST(GlobalPositioning, FilterDepthOutliersRoutesSoftFallback) {
   SetPRNGSeed(0);
   GpTestData data = BuildGpTestData();

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -701,7 +701,7 @@ void SetFirstValidDepthPrior(Reconstruction& reconstruction,
   FAIL() << "No valid depth prior found";
 }
 
-TEST(GlobalPositioning, KeepsNonpositiveMetricDepthPriorsByDefault) {
+TEST(GlobalPositioning, SkipsNonpositiveMetricDepthPriorsByDefault) {
   SetPRNGSeed(0);
   GpTestData data = BuildGpTestData();
   StampGtDepthPriors(data.reconstruction);
@@ -712,33 +712,33 @@ TEST(GlobalPositioning, KeepsNonpositiveMetricDepthPriorsByDefault) {
 
   GlobalPositionerOptions options = BaselineGpOptions();
   options.use_metric_depth_constraint = true;
-  ASSERT_FALSE(options.skip_nonpositive_metric_depth_priors);
-
-  TestableGlobalPositioner positioner(options);
-  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
-
-  EXPECT_EQ(positioner.GetDiagnostics().num_metric_depth_residuals,
-            static_cast<int>(valid_depth_observations));
-}
-
-TEST(GlobalPositioning, CanSkipNonpositiveMetricDepthPriors) {
-  SetPRNGSeed(0);
-  GpTestData data = BuildGpTestData();
-  StampGtDepthPriors(data.reconstruction);
-  const size_t valid_depth_observations = CountValidDepthObservations(
-      data.reconstruction, BaselineGpOptions().min_num_view_per_track);
-  ASSERT_GT(valid_depth_observations, 0u);
-  SetFirstValidDepthPrior(data.reconstruction, 0.0);
-
-  GlobalPositionerOptions options = BaselineGpOptions();
-  options.use_metric_depth_constraint = true;
-  options.skip_nonpositive_metric_depth_priors = true;
+  ASSERT_TRUE(options.skip_nonpositive_metric_depth_priors);
 
   TestableGlobalPositioner positioner(options);
   ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
 
   EXPECT_EQ(positioner.GetDiagnostics().num_metric_depth_residuals,
             static_cast<int>(valid_depth_observations - 1));
+}
+
+TEST(GlobalPositioning, CanKeepNonpositiveMetricDepthPriorsForLegacyRuns) {
+  SetPRNGSeed(0);
+  GpTestData data = BuildGpTestData();
+  StampGtDepthPriors(data.reconstruction);
+  const size_t valid_depth_observations = CountValidDepthObservations(
+      data.reconstruction, BaselineGpOptions().min_num_view_per_track);
+  ASSERT_GT(valid_depth_observations, 0u);
+  SetFirstValidDepthPrior(data.reconstruction, 0.0);
+
+  GlobalPositionerOptions options = BaselineGpOptions();
+  options.use_metric_depth_constraint = true;
+  options.skip_nonpositive_metric_depth_priors = false;
+
+  TestableGlobalPositioner positioner(options);
+  ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+
+  EXPECT_EQ(positioner.GetDiagnostics().num_metric_depth_residuals,
+            static_cast<int>(valid_depth_observations));
 }
 
 TEST(GlobalPositioning, FilterDepthOutliersRoutesSoftFallback) {

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -156,7 +156,7 @@ void BindGlobalPositioner(py::module& m) {
           "skip_nonpositive_metric_depth_priors",
           &GlobalPositionerOptions::skip_nonpositive_metric_depth_priors,
           "Skip valid-mask metric-depth observations whose depth prior is "
-          "nonpositive. Default false preserves existing behavior.")
+          "nonpositive. Default true; set false for legacy behavior.")
       .def_readwrite(
           "use_log_scale_for_depth_map_scales",
           &GlobalPositionerOptions::use_log_scale_for_depth_map_scales)

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -153,6 +153,11 @@ void BindGlobalPositioner(py::module& m) {
       .def_readwrite("use_metric_depth_constraint",
                      &GlobalPositionerOptions::use_metric_depth_constraint)
       .def_readwrite(
+          "skip_nonpositive_metric_depth_priors",
+          &GlobalPositionerOptions::skip_nonpositive_metric_depth_priors,
+          "Skip valid-mask metric-depth observations whose depth prior is "
+          "nonpositive. Default false preserves existing behavior.")
+      .def_readwrite(
           "use_log_scale_for_depth_map_scales",
           &GlobalPositionerOptions::use_log_scale_for_depth_map_scales)
       .def_readwrite("metric_depth_residual_type",


### PR DESCRIPTION
## Summary

- Add `GlobalPositionerOptions::skip_nonpositive_metric_depth_priors`, defaulting to `false` to preserve current behavior.
- When enabled, skip metric-depth GP residuals for valid-mask observations whose depth prior is nonpositive.
- Expose the option through `pycolmap.GlobalPositionerOptions` so callers can enable it from Python/config plumbing.
- Add focused tests for current default behavior and the explicit skip mode.

## Root Cause

Current GP accepts metric-depth residuals for nonpositive depth priors whenever `depth_prior_validity` is true and sigma is valid. Those priors can be skipped by enabling the new option.

## Validation

- `cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DGUI_ENABLED=OFF -DCUDA_ENABLED=OFF -DTESTS_ENABLED=ON`
- `cmake --build build --target colmap_estimators_global_positioning_test -j8`
- `./build/src/colmap/estimators/global_positioning_test --gtest_filter='GlobalPositioning.*NonpositiveMetricDepthPriors*'`

Note: `/usr/bin/ctest --test-dir build -R 'estimators/global_positioning_test' --output-on-failure` currently fails in existing `MetricDepthError.SmoothLogLinearTransitionC1Continuity`, unrelated to this change. The two nonpositive-depth tests pass.