### PR TITLE
Add temporal acceleration priors to global positioning

### DIFF
--- a/src/colmap/estimators/cost_functions/motion_averaging.h
+++ b/src/colmap/estimators/cost_functions/motion_averaging.h
@@ -68,10 +68,9 @@ struct WeightedBATAPairwiseDirectionCostFunctor {
                   const T* scale,
                   T* residuals) const {
     using Vec3T = Eigen::Matrix<T, 3, 1>;
-    const Vec3T r_world =
-        pos2_from_pos1_dir_.cast<T>() -
-        scale[0] * (Eigen::Map<const Vec3T>(pos2) -
-                    Eigen::Map<const Vec3T>(pos1));
+    const Vec3T r_world = pos2_from_pos1_dir_.cast<T>() -
+                          scale[0] * (Eigen::Map<const Vec3T>(pos2) -
+                                      Eigen::Map<const Vec3T>(pos1));
     const Vec3T r_cam = rotation_.cast<T>() * r_world;
     residuals[0] = T(inv_sigma_x_) * r_cam[0];
     residuals[1] = T(inv_sigma_y_) * r_cam[1];
@@ -79,12 +78,11 @@ struct WeightedBATAPairwiseDirectionCostFunctor {
     return true;
   }
 
-  static ceres::CostFunction* Create(
-      const Eigen::Vector3d& pos2_from_pos1_dir,
-      const Eigen::Quaterniond& rotation,
-      double sigma_x,
-      double sigma_y,
-      double sigma_z) {
+  static ceres::CostFunction* Create(const Eigen::Vector3d& pos2_from_pos1_dir,
+                                     const Eigen::Quaterniond& rotation,
+                                     double sigma_x,
+                                     double sigma_y,
+                                     double sigma_z) {
     return (new ceres::AutoDiffCostFunction<
             WeightedBATAPairwiseDirectionCostFunctor,
             3,
@@ -99,6 +97,51 @@ struct WeightedBATAPairwiseDirectionCostFunctor {
   const double inv_sigma_x_;
   const double inv_sigma_y_;
   const double inv_sigma_z_;
+};
+
+// Penalizes changes in camera velocity over three consecutive camera centers.
+// The residual is:
+//   scale * 2/(dt_prev + dt_next) *
+//   ((center_next - center_curr) / dt_next -
+//    (center_curr - center_prev) / dt_prev)
+struct TemporalAccelerationCostFunctor {
+  TemporalAccelerationCostFunctor(double dt_prev,
+                                  double dt_next,
+                                  double residual_scale)
+      : dt_prev_(dt_prev), dt_next_(dt_next), residual_scale_(residual_scale) {}
+
+  template <typename T>
+  bool operator()(const T* center_prev,
+                  const T* center_curr,
+                  const T* center_next,
+                  T* residuals) const {
+    using Vec3T = Eigen::Matrix<T, 3, 1>;
+    const Vec3T prev = Eigen::Map<const Vec3T>(center_prev);
+    const Vec3T curr = Eigen::Map<const Vec3T>(center_curr);
+    const Vec3T next = Eigen::Map<const Vec3T>(center_next);
+    const Vec3T acceleration =
+        T(2.0) / (T(dt_prev_) + T(dt_next_)) *
+        ((next - curr) / T(dt_next_) - (curr - prev) / T(dt_prev_));
+    Eigen::Map<Vec3T> residuals_vec(residuals);
+    residuals_vec = T(residual_scale_) * acceleration;
+    return true;
+  }
+
+  static ceres::CostFunction* Create(double dt_prev,
+                                     double dt_next,
+                                     double residual_scale) {
+    if (dt_prev <= 0.0 || dt_next <= 0.0 || residual_scale <= 0.0) {
+      return nullptr;
+    }
+    return new ceres::
+        AutoDiffCostFunction<TemporalAccelerationCostFunctor, 3, 3, 3, 3>(
+            new TemporalAccelerationCostFunctor(
+                dt_prev, dt_next, residual_scale));
+  }
+
+  const double dt_prev_;
+  const double dt_next_;
+  const double residual_scale_;
 };
 
 // Computes the error between a translation direction and the direction formed

--- a/src/colmap/estimators/cost_functions/motion_averaging_test.cc
+++ b/src/colmap/estimators/cost_functions/motion_averaging_test.cc
@@ -89,6 +89,50 @@ TEST(BATAPairwiseDirectionCostFunctor, Create) {
   ASSERT_NE(cost_function, nullptr);
 }
 
+TEST(TemporalAccelerationCostFunctor, ZeroForConstantVelocity) {
+  const Eigen::Vector3d center_prev(0, 0, 0);
+  const Eigen::Vector3d center_curr(1, 2, 3);
+  const Eigen::Vector3d center_next(2, 4, 6);
+
+  TemporalAccelerationCostFunctor cost_functor(
+      /*dt_prev=*/1.0, /*dt_next=*/1.0, /*residual_scale=*/2.0);
+
+  Eigen::Vector3d residuals;
+  EXPECT_TRUE(cost_functor(center_prev.data(),
+                           center_curr.data(),
+                           center_next.data(),
+                           residuals.data()));
+
+  EXPECT_THAT(residuals, EigenMatrixNear(Eigen::Vector3d::Zero(), 1e-10));
+}
+
+TEST(TemporalAccelerationCostFunctor, NonZeroForAcceleration) {
+  const Eigen::Vector3d center_prev(0, 0, 0);
+  const Eigen::Vector3d center_curr(1, 0, 0);
+  const Eigen::Vector3d center_next(3, 0, 0);
+
+  TemporalAccelerationCostFunctor cost_functor(
+      /*dt_prev=*/1.0, /*dt_next=*/1.0, /*residual_scale=*/0.5);
+
+  Eigen::Vector3d residuals;
+  EXPECT_TRUE(cost_functor(center_prev.data(),
+                           center_curr.data(),
+                           center_next.data(),
+                           residuals.data()));
+
+  EXPECT_THAT(residuals,
+              EigenMatrixNear(Eigen::Vector3d(0.5, 0.0, 0.0), 1e-10));
+}
+
+TEST(TemporalAccelerationCostFunctor, CreateRejectsInvalidInputs) {
+  std::unique_ptr<ceres::CostFunction> valid(
+      TemporalAccelerationCostFunctor::Create(1.0, 1.0, 1.0));
+  EXPECT_NE(valid, nullptr);
+  EXPECT_EQ(TemporalAccelerationCostFunctor::Create(0.0, 1.0, 1.0), nullptr);
+  EXPECT_EQ(TemporalAccelerationCostFunctor::Create(1.0, 0.0, 1.0), nullptr);
+  EXPECT_EQ(TemporalAccelerationCostFunctor::Create(1.0, 1.0, 0.0), nullptr);
+}
+
 TEST(RigBATAPairwiseDirectionConstantRigCostFunctor, ZeroResidual) {
   const Eigen::Vector3d point3D(1, 2, 3);
   const Eigen::Vector3d rig_in_world(3, 2, 1);
@@ -228,8 +272,7 @@ TEST(CovarianceWeightedBATAPairwiseDirection, MatchesPerAxisWhitened) {
         sigma_x * sigma_x, sigma_y * sigma_y, sigma_z * sigma_z);
 
     // cov_world = R^T diag(sigma^2) R (the encoding the call site uses).
-    const Eigen::Matrix3d cov_world =
-        R.transpose() * sigma2.asDiagonal() * R;
+    const Eigen::Matrix3d cov_world = R.transpose() * sigma2.asDiagonal() * R;
 
     // Random parameters.
     Eigen::Vector3d c1(uni(rng), uni(rng), uni(rng));
@@ -238,14 +281,13 @@ TEST(CovarianceWeightedBATAPairwiseDirection, MatchesPerAxisWhitened) {
 
     // Evaluate native CWCF<BATA>(cov_world, t_obs).
     std::unique_ptr<ceres::CostFunction> cost_function(
-        CovarianceWeightedCostFunctor<
-            BATAPairwiseDirectionCostFunctor>::Create(cov_world, t_obs));
+        CovarianceWeightedCostFunctor<BATAPairwiseDirectionCostFunctor>::Create(
+            cov_world, t_obs));
     ASSERT_NE(cost_function, nullptr);
 
-    Eigen::Vector3d residuals(
-        std::numeric_limits<double>::quiet_NaN(),
-        std::numeric_limits<double>::quiet_NaN(),
-        std::numeric_limits<double>::quiet_NaN());
+    Eigen::Vector3d residuals(std::numeric_limits<double>::quiet_NaN(),
+                              std::numeric_limits<double>::quiet_NaN(),
+                              std::numeric_limits<double>::quiet_NaN());
     const double* parameters[3] = {c1.data(), c2.data(), &scale};
     EXPECT_TRUE(cost_function->Evaluate(parameters, residuals.data(), nullptr));
     const double native_sqnorm = residuals.squaredNorm();
@@ -277,8 +319,8 @@ TEST(CovarianceWeightedBATAPairwiseDirection, IdentityRotationIsotropicSigma) {
       (sigma * sigma) * Eigen::Matrix3d::Identity();
 
   std::unique_ptr<ceres::CostFunction> weighted(
-      CovarianceWeightedCostFunctor<
-          BATAPairwiseDirectionCostFunctor>::Create(cov_world, t_obs));
+      CovarianceWeightedCostFunctor<BATAPairwiseDirectionCostFunctor>::Create(
+          cov_world, t_obs));
   std::unique_ptr<ceres::CostFunction> plain(
       BATAPairwiseDirectionCostFunctor::Create(t_obs));
 
@@ -300,18 +342,15 @@ TEST(CovarianceWeightedBATAPairwiseDirection, ZeroResidualWhenAligned) {
   const Eigen::Vector3d t_obs = scale * (c2 - c1);
 
   // Arbitrary non-isotropic, non-axis-aligned covariance.
-  const Eigen::Quaterniond q =
-      Eigen::Quaterniond(Eigen::AngleAxisd(0.6,
-                                           Eigen::Vector3d(1, 2, 3)
-                                               .normalized()));
+  const Eigen::Quaterniond q = Eigen::Quaterniond(
+      Eigen::AngleAxisd(0.6, Eigen::Vector3d(1, 2, 3).normalized()));
   const Eigen::Matrix3d R = q.toRotationMatrix();
   const Eigen::Vector3d sigma2(0.04, 0.25, 0.09);
-  const Eigen::Matrix3d cov_world =
-      R.transpose() * sigma2.asDiagonal() * R;
+  const Eigen::Matrix3d cov_world = R.transpose() * sigma2.asDiagonal() * R;
 
   std::unique_ptr<ceres::CostFunction> cost_function(
-      CovarianceWeightedCostFunctor<
-          BATAPairwiseDirectionCostFunctor>::Create(cov_world, t_obs));
+      CovarianceWeightedCostFunctor<BATAPairwiseDirectionCostFunctor>::Create(
+          cov_world, t_obs));
 
   Eigen::Vector3d residuals;
   const double* parameters[3] = {c1.data(), c2.data(), &scale};

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -70,6 +71,48 @@ class ScopedAccumulatedTimer {
  private:
   double* target_;
   std::chrono::steady_clock::time_point start_;
+};
+
+class DeadZoneHuberLoss final : public ceres::LossFunction {
+ public:
+  DeadZoneHuberLoss(double dead_zone, double huber_width)
+      : dead_zone_(dead_zone), huber_width_(huber_width) {
+    THROW_CHECK_GE(dead_zone_, 0.0);
+    THROW_CHECK_GT(huber_width_, 0.0);
+  }
+
+  void Evaluate(double sq_norm, double rho[3]) const override {
+    const double r = std::sqrt(std::max(0.0, sq_norm));
+    if (r <= dead_zone_) {
+      rho[0] = 0.0;
+      rho[1] = 0.0;
+      rho[2] = 0.0;
+      return;
+    }
+
+    if (r <= 0.0) {
+      rho[0] = 0.0;
+      rho[1] = 0.0;
+      rho[2] = 0.0;
+      return;
+    }
+
+    const double shifted = r - dead_zone_;
+    if (shifted <= huber_width_) {
+      rho[0] = shifted * shifted;
+      rho[1] = shifted / r;
+      rho[2] = dead_zone_ / (2.0 * r * r * r);
+      return;
+    }
+
+    rho[0] = 2.0 * huber_width_ * shifted - huber_width_ * huber_width_;
+    rho[1] = huber_width_ / r;
+    rho[2] = -huber_width_ / (2.0 * r * r * r);
+  }
+
+ private:
+  const double dead_zone_;
+  const double huber_width_;
 };
 
 template <typename MapT>
@@ -383,12 +426,11 @@ MetricDepthOptions CreateMetricDepthOptions(
   metric_depth_options.zero_residual_behind = options.zero_residual_behind;
   metric_depth_options.log_linear_threshold = options.log_linear_threshold;
 
+  metric_depth_options.residual_type = options.metric_depth_residual_type;
   if (options.smooth_log_linear_transition) {
     metric_depth_options.residual_type = MetricDepthResidualType::kLogLinear;
   } else if (options.use_log_residual_for_depth) {
     metric_depth_options.residual_type = MetricDepthResidualType::kLog;
-  } else {
-    metric_depth_options.residual_type = MetricDepthResidualType::kLinear;
   }
   return metric_depth_options;
 }
@@ -862,6 +904,7 @@ void GlobalPositioner::SetupProblem(const PoseGraph& pose_graph,
   bata_scale_indices_.clear();
   cams_in_rig_.clear();
   per_image_scale_losses_.clear();
+  temporal_acceleration_loss_.reset();
   if (tracer_ == nullptr) {
     tracer_ = std::make_unique<GlobalPositioningTracer>(options_.trace);
   }
@@ -1194,6 +1237,10 @@ void GlobalPositioner::AddPointToCameraConstraints(
     }
     diagnostics_.time_add_ptcam_scale_priors += SecondsSince(timing_start);
   }
+  timing_start = NowForTiming();
+  AddTemporalAccelerationConstraints(reconstruction);
+  diagnostics_.time_add_temporal_acceleration_constraints +=
+      SecondsSince(timing_start);
   if (tracer_->ResidualLedgerEnabled()) {
     timing_start = NowForTiming();
     tracer_->RecordBucketSummaries();
@@ -1204,6 +1251,141 @@ void GlobalPositioner::AddPointToCameraConstraints(
           << ", scales=" << scales_.size()
           << ", frame_centers=" << frame_centers_.size()
           << ", dmap_scales=" << dmap_scales_.size();
+}
+
+void GlobalPositioner::AddTemporalAccelerationConstraints(
+    Reconstruction& reconstruction) {
+  if (!options_.use_temporal_acceleration_prior ||
+      options_.temporal_acceleration_priors.empty()) {
+    return;
+  }
+  THROW_CHECK_GT(options_.temporal_acceleration_prior_stddev, 0.0);
+  THROW_CHECK_GT(options_.temporal_acceleration_prior_weight, 0.0);
+  THROW_CHECK_GE(options_.temporal_acceleration_prior_loss_dead_zone, 0.0);
+  THROW_CHECK_GT(options_.temporal_acceleration_prior_loss_huber_width, 0.0);
+
+  temporal_acceleration_loss_ = std::make_unique<DeadZoneHuberLoss>(
+      options_.temporal_acceleration_prior_loss_dead_zone,
+      options_.temporal_acceleration_prior_loss_huber_width);
+
+  for (const TemporalAccelerationPrior& prior :
+       options_.temporal_acceleration_priors) {
+    if (!reconstruction.ExistsImage(prior.prev_image_id) ||
+        !reconstruction.ExistsImage(prior.image_id) ||
+        !reconstruction.ExistsImage(prior.next_image_id)) {
+      if (tracer_->ResidualLedgerEnabled()) {
+        GlobalPositioningResidualDescriptor skip;
+        skip.residual_type = "temporal_acceleration";
+        skip.image_id = prior.image_id;
+        skip.loss_bucket = "temporal_dead_zone_huber";
+        tracer_->RecordSkip(skip, "image_missing");
+      }
+      continue;
+    }
+    const Image& prev_image = reconstruction.Image(prior.prev_image_id);
+    const Image& image = reconstruction.Image(prior.image_id);
+    const Image& next_image = reconstruction.Image(prior.next_image_id);
+    if (!prev_image.HasPose() || !image.HasPose() || !next_image.HasPose()) {
+      if (tracer_->ResidualLedgerEnabled()) {
+        GlobalPositioningResidualDescriptor skip;
+        skip.residual_type = "temporal_acceleration";
+        skip.image_id = prior.image_id;
+        skip.loss_bucket = "temporal_dead_zone_huber";
+        tracer_->RecordSkip(skip, "image_pose_missing");
+      }
+      continue;
+    }
+    if (prior.dt_prev <= 0.0 || prior.dt_next <= 0.0 ||
+        prior.sqrt_observation_count <= 0.0) {
+      if (tracer_->ResidualLedgerEnabled()) {
+        GlobalPositioningResidualDescriptor skip;
+        skip.residual_type = "temporal_acceleration";
+        skip.image_id = prior.image_id;
+        skip.loss_bucket = "temporal_dead_zone_huber";
+        tracer_->RecordSkip(skip, "invalid_temporal_prior");
+      }
+      continue;
+    }
+    const auto has_center_block = [this](const Image& candidate) {
+      if (UseFrameInplaceCenterBlocks()) {
+        return true;
+      }
+      if (UseImageCenterBlocks()) {
+        return image_centers_.find(candidate.ImageId()) != image_centers_.end();
+      }
+      return frame_centers_.find(candidate.FrameId()) != frame_centers_.end();
+    };
+    if (!has_center_block(prev_image) || !has_center_block(image) ||
+        !has_center_block(next_image)) {
+      if (tracer_->ResidualLedgerEnabled()) {
+        GlobalPositioningResidualDescriptor skip;
+        skip.residual_type = "temporal_acceleration";
+        skip.image_id = prior.image_id;
+        skip.loss_bucket = "temporal_dead_zone_huber";
+        tracer_->RecordSkip(skip, "center_block_missing");
+      }
+      continue;
+    }
+
+    const double residual_scale = options_.temporal_acceleration_prior_weight *
+                                  prior.sqrt_observation_count /
+                                  options_.temporal_acceleration_prior_stddev;
+    ceres::CostFunction* cost_function =
+        TemporalAccelerationCostFunctor::Create(
+            prior.dt_prev, prior.dt_next, residual_scale);
+    if (cost_function == nullptr) {
+      if (tracer_->ResidualLedgerEnabled()) {
+        GlobalPositioningResidualDescriptor skip;
+        skip.residual_type = "temporal_acceleration";
+        skip.image_id = prior.image_id;
+        skip.loss_bucket = "temporal_dead_zone_huber";
+        tracer_->RecordSkip(skip, "cost_create_failed");
+      }
+      continue;
+    }
+
+    double* prev_center = MutableCenterDataForImage(prev_image);
+    double* center = MutableCenterDataForImage(image);
+    double* next_center = MutableCenterDataForImage(next_image);
+    problem_->AddResidualBlock(cost_function,
+                               temporal_acceleration_loss_.get(),
+                               prev_center,
+                               center,
+                               next_center);
+    residual_order_hash_ = StableHashAppend(residual_order_hash_, 4);
+    residual_order_hash_ =
+        StableHashAppend(residual_order_hash_, prior.prev_image_id);
+    residual_order_hash_ =
+        StableHashAppend(residual_order_hash_, prior.image_id);
+    residual_order_hash_ =
+        StableHashAppend(residual_order_hash_, prior.next_image_id);
+    ++diagnostics_.num_temporal_acceleration_residuals;
+
+    if (tracer_->ResidualLedgerEnabled()) {
+      GlobalPositioningResidualDescriptor residual;
+      residual.residual_type = "temporal_acceleration";
+      residual.image_id = prior.image_id;
+      residual.frame_id = image.FrameId();
+      residual.loss_bucket = "temporal_dead_zone_huber";
+      residual.loss = GlobalPositioningTraceLossConfig{
+          "temporal_dead_zone_huber",
+          "dead_zone_huber",
+          options_.temporal_acceleration_prior_loss_huber_width,
+          options_.temporal_acceleration_prior_weight,
+          "GlobalPositionerOptions.temporal_acceleration_prior",
+          prior.sqrt_observation_count};
+      tracer_->RecordResidual(
+          residual,
+          cost_function,
+          temporal_acceleration_loss_.get(),
+          {prev_center, center, next_center},
+          {TraceParameterBlock(
+               "prev_center", "frame_center", prev_image.FrameId()),
+           TraceParameterBlock("center", "frame_center", image.FrameId()),
+           TraceParameterBlock(
+               "next_center", "frame_center", next_image.FrameId())});
+    }
+  }
 }
 
 void GlobalPositioner::AddPoint3DToProblem(
@@ -1771,12 +1953,6 @@ void GlobalPositioner::AddMetricDepthResidual(
     residual.depth_sigma = depth_sigma;
   }
 
-  if (depth_prior <= 0.0) {
-    if (trace_residual_ledger) {
-      tracer_->RecordSkip(residual, "invalid_depth_prior");
-    }
-    return;
-  }
   if (depth_sigma <= 1e-9) {
     if (trace_residual_ledger) {
       tracer_->RecordSkip(residual, "invalid_depth_sigma");

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -21,6 +21,15 @@
 
 namespace colmap {
 
+struct TemporalAccelerationPrior {
+  image_t prev_image_id = kInvalidImageId;
+  image_t image_id = kInvalidImageId;
+  image_t next_image_id = kInvalidImageId;
+  double dt_prev = 1.0;
+  double dt_next = 1.0;
+  double sqrt_observation_count = 1.0;
+};
+
 struct GlobalPositionerOptions {
   // Whether to initialize the camera and track positions randomly.
   bool generate_random_positions = true;
@@ -82,6 +91,15 @@ struct GlobalPositionerOptions {
   // Cube half-extent for random initialization of positions and points.
   double random_init_scale = 100.0;
 
+  // Add temporal acceleration priors over consecutive image triplets. The
+  // caller owns sequence/gap policy and supplies valid triplets explicitly.
+  bool use_temporal_acceleration_prior = false;
+  std::vector<TemporalAccelerationPrior> temporal_acceleration_priors;
+  double temporal_acceleration_prior_stddev = 1.0;
+  double temporal_acceleration_prior_weight = 1.0;
+  double temporal_acceleration_prior_loss_dead_zone = 0.0;
+  double temporal_acceleration_prior_loss_huber_width = 1.0;
+
   // --- Metric-depth path toggles (only consulted when
   //     use_metric_depth_constraint == true) ---
   bool use_log_scale_for_depth_map_scales = false;
@@ -89,6 +107,8 @@ struct GlobalPositionerOptions {
   bool zero_residual_behind = false;
   // Selects the log-linear residual shape and implies log residuals.
   bool smooth_log_linear_transition = false;
+  MetricDepthResidualType metric_depth_residual_type =
+      MetricDepthResidualType::kLinear;
   double log_linear_threshold = 0.1;
   double scale_prior_stddev = 1.0;
 
@@ -140,6 +160,7 @@ struct GlobalPositionerDiagnostics {
   int num_bata_residuals = 0;
   int num_metric_depth_residuals = 0;
   int num_scale_prior_residuals = 0;
+  int num_temporal_acceleration_residuals = 0;
   int num_regular_observations_used = 0;
   int num_lc_observations_used = 0;
   int num_bata_scales = 0;
@@ -157,6 +178,7 @@ struct GlobalPositionerDiagnostics {
   double time_initialize_random_positions = 0.0;
   double time_initialize_dmap_scales = 0.0;
   double time_add_point_to_camera_constraints = 0.0;
+  double time_add_temporal_acceleration_constraints = 0.0;
   double time_add_ptcam_setup = 0.0;
   double time_add_ptcam_filter_depth_outliers = 0.0;
   double time_add_ptcam_collect_sort_points = 0.0;
@@ -219,6 +241,9 @@ class GlobalPositioner {
 
   // Add tracks to the problem
   void AddPointToCameraConstraints(Reconstruction& reconstruction);
+
+  // Add temporal acceleration priors over caller-supplied image triplets.
+  void AddTemporalAccelerationConstraints(Reconstruction& reconstruction);
 
   // Add a single point3D to the problem
   void AddPoint3DToProblem(point3D_t point3D_id,
@@ -311,6 +336,7 @@ class GlobalPositioner {
   std::shared_ptr<ceres::LossFunction> cached_loss_normal_geometry_trackstart_;
   std::shared_ptr<ceres::LossFunction> cached_loss_normal_depth_trackstart_;
   std::shared_ptr<ceres::LossFunction> cached_loss_scale_prior_;
+  std::unique_ptr<ceres::LossFunction> temporal_acceleration_loss_;
 
   // Soft fallback loss for non-LC depth outliers. Lazily allocated from
   // options_.loss_soft_outlier_fallback.

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -488,8 +488,7 @@ std::tuple<uint32_t, uint64_t, uint64_t> ReadRawPointIndexIdentityForTest(
       ReadRawLittleEndianForTest<uint32_t>(file, path);
   const uint64_t ledger_count =
       ReadRawLittleEndianForTest<uint64_t>(file, path);
-  const uint64_t ledger_size =
-      ReadRawLittleEndianForTest<uint64_t>(file, path);
+  const uint64_t ledger_size = ReadRawLittleEndianForTest<uint64_t>(file, path);
   return {ledger_version, ledger_count, ledger_size};
 }
 
@@ -1748,6 +1747,55 @@ TEST(GlobalPositioning, Gate_UseLcObservations_On_IteratesLcElements) {
   EXPECT_EQ(positioner.NumScales(), expected_regular + expected_lc);
 }
 
+TEST(GlobalPositioning, TemporalAccelerationPriorOffOnResidualCounts) {
+  {
+    SetPRNGSeed(0);
+    GpTestData data = BuildGpTestData();
+
+    GlobalPositionerOptions options = BaselineGpOptions();
+    options.solver_options.max_num_iterations = 0;
+
+    TestableGlobalPositioner positioner(options);
+    ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+    EXPECT_EQ(positioner.GetDiagnostics().num_temporal_acceleration_residuals,
+              0);
+  }
+
+  {
+    SetPRNGSeed(0);
+    GpTestData data = BuildGpTestData();
+    std::vector<image_t> image_ids;
+    image_ids.reserve(data.reconstruction.Images().size());
+    for (const auto& [image_id, image] : data.reconstruction.Images()) {
+      image_ids.push_back(image_id);
+    }
+    std::sort(image_ids.begin(), image_ids.end());
+    ASSERT_GE(image_ids.size(), 3);
+
+    TemporalAccelerationPrior prior;
+    prior.prev_image_id = image_ids[0];
+    prior.image_id = image_ids[1];
+    prior.next_image_id = image_ids[2];
+    prior.dt_prev = 1.0;
+    prior.dt_next = 1.0;
+    prior.sqrt_observation_count = 1.0;
+
+    GlobalPositionerOptions options = BaselineGpOptions();
+    options.solver_options.max_num_iterations = 0;
+    options.use_temporal_acceleration_prior = true;
+    options.temporal_acceleration_priors = {prior};
+    options.temporal_acceleration_prior_stddev = 1.0;
+    options.temporal_acceleration_prior_weight = 1.0;
+    options.temporal_acceleration_prior_loss_dead_zone = 0.0;
+    options.temporal_acceleration_prior_loss_huber_width = 1.0;
+
+    TestableGlobalPositioner positioner(options);
+    ASSERT_TRUE(positioner.Solve(data.pose_graph, data.reconstruction));
+    EXPECT_EQ(positioner.GetDiagnostics().num_temporal_acceleration_residuals,
+              1);
+  }
+}
+
 TEST(GlobalPositioning, MinViewGate_UseLcObservationsOff_IgnoresLcElements) {
   SetPRNGSeed(0);
   GpTestData data = BuildGpTestData();
@@ -1865,11 +1913,13 @@ TEST(GlobalPositioning, ResidualLedgerTraceCanDisableLegacyJsonlBlocks) {
   const std::filesystem::path raw_point_index_path =
       raw_binary_dir / "static" / "residual_point_index.bin";
   ASSERT_TRUE(ExistsFile(raw_ledger_path));
-  ASSERT_TRUE(
-      ExistsFile(raw_point_index_path));
-  const uint64_t ledger_count = ReadRawLedgerRecordCountForTest(raw_ledger_path);
+  ASSERT_TRUE(ExistsFile(raw_point_index_path));
+  const uint64_t ledger_count =
+      ReadRawLedgerRecordCountForTest(raw_ledger_path);
   EXPECT_GT(ledger_count, uint64_t{0});
-  const auto [indexed_ledger_version, indexed_ledger_count, indexed_ledger_size] =
+  const auto [indexed_ledger_version,
+              indexed_ledger_count,
+              indexed_ledger_size] =
       ReadRawPointIndexIdentityForTest(raw_point_index_path);
   EXPECT_EQ(indexed_ledger_version, uint32_t{2});
   EXPECT_EQ(indexed_ledger_count, ledger_count);

--- a/src/colmap/estimators/global_positioning_tracer.cc
+++ b/src/colmap/estimators/global_positioning_tracer.cc
@@ -56,6 +56,9 @@ std::vector<std::string> DeferredFixedParametersForReplay(
   if (residual.residual_type == "scale_prior") {
     return {"scale_prior_target", "scale_prior_stddev"};
   }
+  if (residual.residual_type == "temporal_acceleration") {
+    return {"dt_prev", "dt_next", "residual_scale"};
+  }
   return {"unclassified_fixed_parameters"};
 }
 

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -201,6 +201,27 @@ void BindGlobalPositioner(py::module& m) {
           .value("RESIDUAL_JACOBIANS", TraceLevel::kResidualJacobians);
   AddStringToEnumConstructor(PyGlobalPositioningTraceLevel);
 
+  auto PyMetricDepthResidualType =
+      py::enum_<MetricDepthResidualType>(m, "MetricDepthResidualType")
+          .value("LINEAR", MetricDepthResidualType::kLinear)
+          .value("LOG", MetricDepthResidualType::kLog)
+          .value("LOG_LINEAR", MetricDepthResidualType::kLogLinear);
+  AddStringToEnumConstructor(PyMetricDepthResidualType);
+
+  auto PyTemporalAccelerationPrior =
+      py::classh<TemporalAccelerationPrior>(m, "TemporalAccelerationPrior")
+          .def(py::init<>())
+          .def_readwrite("prev_image_id",
+                         &TemporalAccelerationPrior::prev_image_id)
+          .def_readwrite("image_id", &TemporalAccelerationPrior::image_id)
+          .def_readwrite("next_image_id",
+                         &TemporalAccelerationPrior::next_image_id)
+          .def_readwrite("dt_prev", &TemporalAccelerationPrior::dt_prev)
+          .def_readwrite("dt_next", &TemporalAccelerationPrior::dt_next)
+          .def_readwrite("sqrt_observation_count",
+                         &TemporalAccelerationPrior::sqrt_observation_count);
+  MakeDataclass(PyTemporalAccelerationPrior);
+
   auto PyGlobalPositioningTraceOptions =
       py::classh<GlobalPositioningTraceOptions>(m,
                                                 "GlobalPositioningTraceOptions")
@@ -361,6 +382,8 @@ void BindGlobalPositioner(py::module& m) {
                      &GlobalPositionerOptions::zero_residual_behind)
       .def_readwrite("smooth_log_linear_transition",
                      &GlobalPositionerOptions::smooth_log_linear_transition)
+      .def_readwrite("metric_depth_residual_type",
+                     &GlobalPositionerOptions::metric_depth_residual_type)
       .def_readwrite("log_linear_threshold",
                      &GlobalPositionerOptions::log_linear_threshold)
       .def_readwrite("scale_prior_stddev",
@@ -377,6 +400,22 @@ void BindGlobalPositioner(py::module& m) {
                      &GlobalPositionerOptions::debug_initial_bata_scales)
       .def_readwrite("record_debug_bata_scales",
                      &GlobalPositionerOptions::record_debug_bata_scales)
+      .def_readwrite("use_temporal_acceleration_prior",
+                     &GlobalPositionerOptions::use_temporal_acceleration_prior)
+      .def_readwrite("temporal_acceleration_priors",
+                     &GlobalPositionerOptions::temporal_acceleration_priors)
+      .def_readwrite(
+          "temporal_acceleration_prior_stddev",
+          &GlobalPositionerOptions::temporal_acceleration_prior_stddev)
+      .def_readwrite(
+          "temporal_acceleration_prior_weight",
+          &GlobalPositionerOptions::temporal_acceleration_prior_weight)
+      .def_readwrite(
+          "temporal_acceleration_prior_loss_dead_zone",
+          &GlobalPositionerOptions::temporal_acceleration_prior_loss_dead_zone)
+      .def_readwrite("temporal_acceleration_prior_loss_huber_width",
+                     &GlobalPositionerOptions::
+                         temporal_acceleration_prior_loss_huber_width)
       .def_readwrite("loss_normal_geometry",
                      &GlobalPositionerOptions::loss_normal_geometry)
       .def_readwrite("loss_normal_depth",
@@ -448,6 +487,8 @@ void BindGlobalPositioner(py::module& m) {
             diagnostics.num_metric_depth_residuals;
         diagnostics_dict["num_scale_prior_residuals"] =
             diagnostics.num_scale_prior_residuals;
+        diagnostics_dict["num_temporal_acceleration_residuals"] =
+            diagnostics.num_temporal_acceleration_residuals;
         diagnostics_dict["num_regular_observations_used"] =
             diagnostics.num_regular_observations_used;
         diagnostics_dict["num_lc_observations_used"] =
@@ -472,6 +513,8 @@ void BindGlobalPositioner(py::module& m) {
             diagnostics.time_initialize_dmap_scales;
         diagnostics_dict["time_add_point_to_camera_constraints"] =
             diagnostics.time_add_point_to_camera_constraints;
+        diagnostics_dict["time_add_temporal_acceleration_constraints"] =
+            diagnostics.time_add_temporal_acceleration_constraints;
         diagnostics_dict["time_add_ptcam_setup"] =
             diagnostics.time_add_ptcam_setup;
         diagnostics_dict["time_add_ptcam_filter_depth_outliers"] =


### PR DESCRIPTION
Adds optional temporal velocity/acceleration priors to native global positioning.

Scope:
- extend global positioning options with temporal prior controls
- add temporal residual wiring in the GP setup
- expose the options through pycolmap
- cover the residual path with native tests

This is intended as the paired COLMAP/pycolmap side for the VideoSfM GP temporal prior knob.