### PR TITLE
Avoid copying triangulation filter point IDs

### DIFF
--- a/src/colmap/estimators/ceres_loss.cc
+++ b/src/colmap/estimators/ceres_loss.cc
@@ -11,11 +11,11 @@
 namespace colmap {
 
 bool IsValidCeresLossFunction(const CeresLossFunctionType type,
-                              const double scale,
+                              const double robust_scale,
                               const double weight) {
   // Preserve the pre-centralization bundle-adjustment contract: non-negative
   // infinite scales were accepted, while NaN and negative scales were not.
-  if (std::isnan(scale) || !std::isfinite(weight)) {
+  if (std::isnan(robust_scale) || !std::isfinite(weight)) {
     return false;
   }
   switch (type) {
@@ -23,14 +23,16 @@ bool IsValidCeresLossFunction(const CeresLossFunctionType type,
     case CeresLossFunctionType::SOFT_L1:
     case CeresLossFunctionType::CAUCHY:
     case CeresLossFunctionType::HUBER:
-      return scale >= 0.0 && weight > 0.0;
+      return robust_scale >= 0.0 && weight > 0.0;
   }
   return false;
 }
 
 std::unique_ptr<ceres::LossFunction> CreateCeresLossFunction(
-    const CeresLossFunctionType type, const double scale, const double weight) {
-  if (!IsValidCeresLossFunction(type, scale, weight)) {
+    const CeresLossFunctionType type,
+    const double robust_scale,
+    const double weight) {
+  if (!IsValidCeresLossFunction(type, robust_scale, weight)) {
     throw std::invalid_argument("invalid Ceres loss configuration");
   }
 
@@ -40,13 +42,13 @@ std::unique_ptr<ceres::LossFunction> CreateCeresLossFunction(
       loss = std::make_unique<ceres::TrivialLoss>();
       break;
     case CeresLossFunctionType::SOFT_L1:
-      loss = std::make_unique<ceres::SoftLOneLoss>(scale);
+      loss = std::make_unique<ceres::SoftLOneLoss>(robust_scale);
       break;
     case CeresLossFunctionType::CAUCHY:
-      loss = std::make_unique<ceres::CauchyLoss>(scale);
+      loss = std::make_unique<ceres::CauchyLoss>(robust_scale);
       break;
     case CeresLossFunctionType::HUBER:
-      loss = std::make_unique<ceres::HuberLoss>(scale);
+      loss = std::make_unique<ceres::HuberLoss>(robust_scale);
       break;
   }
   if (weight == 1.0) return loss;

--- a/src/colmap/estimators/ceres_loss.h
+++ b/src/colmap/estimators/ceres_loss.h
@@ -11,15 +11,16 @@ namespace colmap {
 
 enum class CeresLossFunctionType { TRIVIAL, SOFT_L1, CAUCHY, HUBER };
 
-// Standard construction accepts non-negative scale (including positive
-// infinity for compatibility) and finite positive weight.
+// Standard construction accepts a non-negative `robust_scale` (including
+// positive infinity for compatibility) and finite positive `weight`.
 bool IsValidCeresLossFunction(CeresLossFunctionType type,
-                              double scale,
+                              double robust_scale,
                               double weight = 1.0);
 
-// Constructs a standard Ceres loss and wraps it in an owning ScaledLoss when
-// weight differs from one.
+// Create a standard Ceres loss function. For robust losses, `robust_scale`
+// determines the residual at which robustification takes place. The weight
+// multiplies the loss function output.
 std::unique_ptr<ceres::LossFunction> CreateCeresLossFunction(
-    CeresLossFunctionType type, double scale, double weight = 1.0);
+    CeresLossFunctionType type, double robust_scale, double weight = 1.0);
 
 }  // namespace colmap

--- a/src/colmap/estimators/ceres_loss.h
+++ b/src/colmap/estimators/ceres_loss.h
@@ -11,8 +11,8 @@ namespace colmap {
 
 enum class CeresLossFunctionType { TRIVIAL, SOFT_L1, CAUCHY, HUBER };
 
-// Standard construction accepts a non-negative `robust_scale` (including
-// positive infinity for compatibility) and finite positive `weight`.
+// Standard construction accepts a non-negative `robust_scale` and finite
+// positive `weight`.
 bool IsValidCeresLossFunction(CeresLossFunctionType type,
                               double robust_scale,
                               double weight = 1.0);

--- a/src/colmap/sfm/observation_manager.cc
+++ b/src/colmap/sfm/observation_manager.cc
@@ -435,7 +435,7 @@ size_t ObservationManager::FilterObservationsWithNegativeDepth() {
 std::vector<point3D_t>
 ObservationManager::FindPoints3DWithSmallTriangulationAngle(
     const double min_tri_angle,
-    const std::vector<point3D_t>& point3D_ids) const {
+    const FlatHashSet<point3D_t>& point3D_ids) const {
   // Minimum triangulation angle in radians.
   const double min_tri_angle_rad = DegToRad(min_tri_angle);
 
@@ -494,11 +494,8 @@ ObservationManager::FindPoints3DWithSmallTriangulationAngle(
 
 size_t ObservationManager::FilterPoints3DWithSmallTriangulationAngle(
     const double min_tri_angle, const FlatHashSet<point3D_t>& point3D_ids) {
-  const std::vector<point3D_t> ordered_point3D_ids(point3D_ids.begin(),
-                                                   point3D_ids.end());
   const std::vector<point3D_t> small_angle_point3D_ids =
-      FindPoints3DWithSmallTriangulationAngle(min_tri_angle,
-                                              ordered_point3D_ids);
+      FindPoints3DWithSmallTriangulationAngle(min_tri_angle, point3D_ids);
 
   size_t num_filtered_observations = 0;
   for (const point3D_t point3D_id : small_angle_point3D_ids) {

--- a/src/colmap/sfm/observation_manager.h
+++ b/src/colmap/sfm/observation_manager.h
@@ -128,9 +128,9 @@ class ObservationManager {
   // @param point3D_ids      The points to be checked.
   //
   // @return                 The point identifiers with insufficient
-  //                         triangulation angle, in input order.
+  //                         triangulation angle.
   std::vector<point3D_t> FindPoints3DWithSmallTriangulationAngle(
-      double min_tri_angle, const std::vector<point3D_t>& point3D_ids) const;
+      double min_tri_angle, const FlatHashSet<point3D_t>& point3D_ids) const;
 
   size_t FilterPoints3DWithSmallTriangulationAngle(
       double min_tri_angle, const FlatHashSet<point3D_t>& point3D_ids);

--- a/src/colmap/sfm/observation_manager_test.cc
+++ b/src/colmap/sfm/observation_manager_test.cc
@@ -134,6 +134,21 @@ TEST(ObservationManager, FilterPoints3D) {
   EXPECT_EQ(reconstruction.NumPoints3D(), 0);
 }
 
+TEST(ObservationManager, FindPoints3DWithSmallTriangulationAngle) {
+  Reconstruction reconstruction;
+  GenerateReconstruction(2, reconstruction);
+  const point3D_t point3D_id =
+      reconstruction.AddPoint3D(Eigen::Vector3d(0, 0, 1), Track());
+  reconstruction.AddObservation(point3D_id, TrackElement(1, 0));
+  reconstruction.AddObservation(point3D_id, TrackElement(2, 0));
+
+  ObservationManager obs_manager(reconstruction);
+  const auto point3D_ids = obs_manager.FindPoints3DWithSmallTriangulationAngle(
+      1e-3, FlatHashSet<point3D_t>{point3D_id});
+  EXPECT_EQ(point3D_ids, std::vector<point3D_t>{point3D_id});
+  EXPECT_TRUE(reconstruction.ExistsPoint3D(point3D_id));
+}
+
 TEST(ObservationManager, FilterPoints3DWithLargeReprojectionErrorTypes) {
   Reconstruction reconstruction;
   const camera_t kCameraId = 1;

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -187,6 +187,17 @@ void BindBundleAdjuster(py::module& m) {
           .value("CAUCHY", CeresLossFunctionType::CAUCHY)
           .value("HUBER", CeresLossFunctionType::HUBER);
   AddStringToEnumConstructor(PyCeresLossFunctionType);
+  m.def(
+      "create_ceres_loss_function",
+      [](const CeresLossFunctionType type,
+         const double scale,
+         const double weight) {
+        return std::shared_ptr<ceres::LossFunction>(
+            CreateCeresLossFunction(type, scale, weight));
+      },
+      "loss_function_type"_a,
+      "scale"_a,
+      "weight"_a = 1.0);
 
   auto PyCeresBundleAdjustmentOptions =
       py::classh<CeresBAOpts>(m, "CeresBundleAdjustmentOptions")

--- a/src/pycolmap/estimators/bundle_adjustment.cc
+++ b/src/pycolmap/estimators/bundle_adjustment.cc
@@ -190,13 +190,13 @@ void BindBundleAdjuster(py::module& m) {
   m.def(
       "create_ceres_loss_function",
       [](const CeresLossFunctionType type,
-         const double scale,
+         const double robust_scale,
          const double weight) {
         return std::shared_ptr<ceres::LossFunction>(
-            CreateCeresLossFunction(type, scale, weight));
+            CreateCeresLossFunction(type, robust_scale, weight));
       },
       "loss_function_type"_a,
-      "scale"_a,
+      "robust_scale"_a,
       "weight"_a = 1.0);
 
   auto PyCeresBundleAdjustmentOptions =


### PR DESCRIPTION
Review follow-up for colmap/colmap#4669.

- Accept the existing `FlatHashSet<point3D_t>` directly in `FindPoints3DWithSmallTriangulationAngle()`.
- Remove the intermediate set-to-vector copy from the mutating filter.
- Add a minimal test that verifies the query classifies without deleting the point.
- Expose the shared Ceres loss factory as `pycolmap.create_ceres_loss_function()`.
- Rename the standalone loss parameter to `robust_scale` and document the scale and weight semantics.
- Avoid advertising infinite robust-loss scales while preserving existing validation behavior.

Tests:
- `observation_manager_test`: 15/15 passed.
- Existing `bundle_adjustment_test.py`: 35/35 passed.