### PR TITLE
Use covariance weighting for BATA residuals

### DIFF
--- a/src/colmap/estimators/cost_functions/motion_averaging.h
+++ b/src/colmap/estimators/cost_functions/motion_averaging.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "colmap/estimators/cost_functions/utils.h"
+
 #include <Eigen/Core>
 #include <ceres/ceres.h>
 #include <ceres/rotation.h>
@@ -13,7 +15,8 @@ namespace colmap {
 // 3D point.
 // Reference: Zhuang et al., "Baseline Desensitizing In Translation Averaging",
 // CVPR 2018.
-struct BATAPairwiseDirectionCostFunctor {
+struct BATAPairwiseDirectionCostFunctor
+    : public AutoDiffCostFunctor<BATAPairwiseDirectionCostFunctor, 3, 3, 3, 1> {
   explicit BATAPairwiseDirectionCostFunctor(
       const Eigen::Vector3d& pos2_from_pos1_dir)
       : pos2_from_pos1_dir_(pos2_from_pos1_dir) {}
@@ -30,59 +33,18 @@ struct BATAPairwiseDirectionCostFunctor {
     return true;
   }
 
-  static ceres::CostFunction* Create(
-      const Eigen::Vector3d& pos2_from_pos1_dir) {
-    return (
-        new ceres::
-            AutoDiffCostFunction<BATAPairwiseDirectionCostFunctor, 3, 3, 3, 1>(
-                new BATAPairwiseDirectionCostFunctor(pos2_from_pos1_dir)));
-  }
-
   const Eigen::Vector3d pos2_from_pos1_dir_;
-};
-
-// Covariance-weighted BATA residual with fixed camera rotation
-// (W = Sigma^(-1/2) * R_cam_from_world).
-struct WeightedBATAPairwiseDirectionCostFunctor {
-  WeightedBATAPairwiseDirectionCostFunctor(
-      const Eigen::Vector3d& pos2_from_pos1_dir,
-      const Eigen::Matrix3d& weight_matrix)
-      : pos2_from_pos1_dir_(pos2_from_pos1_dir),
-        weight_matrix_(weight_matrix) {}
-
-  template <typename T>
-  bool operator()(const T* pos1,
-                  const T* pos2,
-                  const T* scale,
-                  T* residuals) const {
-    using Vec3T = Eigen::Matrix<T, 3, 1>;
-    const Vec3T r_world = pos2_from_pos1_dir_.cast<T>() -
-                          scale[0] * (Eigen::Map<const Vec3T>(pos2) -
-                                      Eigen::Map<const Vec3T>(pos1));
-    Eigen::Map<Vec3T> residual_map(residuals);
-    residual_map = weight_matrix_.cast<T>() * r_world;
-    return true;
-  }
-
-  static ceres::CostFunction* Create(const Eigen::Vector3d& pos2_from_pos1_dir,
-                                     const Eigen::Matrix3d& weight_matrix) {
-    return new ceres::AutoDiffCostFunction<
-        WeightedBATAPairwiseDirectionCostFunctor,
-        3,
-        3,
-        3,
-        1>(new WeightedBATAPairwiseDirectionCostFunctor(pos2_from_pos1_dir,
-                                                        weight_matrix));
-  }
-
-  const Eigen::Vector3d pos2_from_pos1_dir_;
-  const Eigen::Matrix3d weight_matrix_;
 };
 
 // Computes the error between a translation direction and the direction formed
 // from a camera (c) and 3D point (p) with constant rig extrinsics, such that:
 // t_ij - scale * (p - c + t_rig) is minimized.
-struct RigBATAPairwiseDirectionConstantRigCostFunctor {
+struct RigBATAPairwiseDirectionConstantRigCostFunctor
+    : public AutoDiffCostFunctor<RigBATAPairwiseDirectionConstantRigCostFunctor,
+                                 3,
+                                 3,
+                                 3,
+                                 1> {
   RigBATAPairwiseDirectionConstantRigCostFunctor(
       const Eigen::Vector3d& cam_from_point3D_dir,
       const Eigen::Vector3d& cam_from_rig_translation)
@@ -103,18 +65,6 @@ struct RigBATAPairwiseDirectionConstantRigCostFunctor {
     return true;
   }
 
-  static ceres::CostFunction* Create(
-      const Eigen::Vector3d& cam_from_point3D_dir,
-      const Eigen::Vector3d& cam_from_rig_translation) {
-    return (new ceres::AutoDiffCostFunction<
-            RigBATAPairwiseDirectionConstantRigCostFunctor,
-            3,
-            3,
-            3,
-            1>(new RigBATAPairwiseDirectionConstantRigCostFunctor(
-        cam_from_point3D_dir, cam_from_rig_translation)));
-  }
-
   const Eigen::Vector3d cam_from_point3D_dir_;
   const Eigen::Vector3d cam_from_rig_translation_;
 };
@@ -122,7 +72,13 @@ struct RigBATAPairwiseDirectionConstantRigCostFunctor {
 // Computes the error between a translation direction and the direction formed
 // from a camera (c) and 3D point (p) with variable rig extrinsics, such that:
 // t_ij - scale * (p - c + t_rig) is minimized.
-struct RigBATAPairwiseDirectionCostFunctor {
+struct RigBATAPairwiseDirectionCostFunctor
+    : public AutoDiffCostFunctor<RigBATAPairwiseDirectionCostFunctor,
+                                 3,
+                                 3,
+                                 3,
+                                 3,
+                                 1> {
   RigBATAPairwiseDirectionCostFunctor(
       const Eigen::Vector3d& cam_from_point3D_dir,
       const Eigen::Quaterniond& rig_from_world_rot)
@@ -146,19 +102,6 @@ struct RigBATAPairwiseDirectionCostFunctor {
                     Eigen::Map<const Eigen::Matrix<T, 3, 1>>(rig_in_world) -
                     cam_from_rig_translation);
     return true;
-  }
-
-  static ceres::CostFunction* Create(
-      const Eigen::Vector3d& cam_from_point3D_dir,
-      const Eigen::Quaterniond& rig_from_world_rot) {
-    return (new ceres::AutoDiffCostFunction<RigBATAPairwiseDirectionCostFunctor,
-                                            3,
-                                            3,
-                                            3,
-                                            3,
-                                            1>(
-        new RigBATAPairwiseDirectionCostFunctor(cam_from_point3D_dir,
-                                                rig_from_world_rot)));
   }
 
   const Eigen::Vector3d cam_from_point3D_dir_;

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -1,11 +1,14 @@
 #include "colmap/estimators/global_positioning.h"
 
 #include "colmap/estimators/cost_functions/motion_averaging.h"
+#include "colmap/estimators/cost_functions/utils.h"
 #include "colmap/math/random.h"
 #include "colmap/util/cuda.h"
 #include "colmap/util/hash_containers.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/threading.h"
+
+#include <utility>
 
 namespace colmap {
 namespace {
@@ -14,6 +17,16 @@ Eigen::Vector3d RandVector3d(double low, double high) {
   return Eigen::Vector3d(RandomUniformReal(low, high),
                          RandomUniformReal(low, high),
                          RandomUniformReal(low, high));
+}
+
+template <typename CostFunctor, typename... Args>
+ceres::CostFunction* CreateBATACostFunction(const Eigen::Matrix3d* covariance,
+                                            Args&&... args) {
+  if (covariance == nullptr) {
+    return CostFunctor::Create(std::forward<Args>(args)...);
+  }
+  return CovarianceWeightedCostFunctor<CostFunctor>::Create(
+      *covariance, std::forward<Args>(args)...);
 }
 
 }  // namespace
@@ -47,7 +60,7 @@ bool GlobalPositioner::Finalize(const ceres::Solver::Summary& summary) {
 void GlobalPositioner::Prepare(
     const PoseGraph& pose_graph,
     Reconstruction& reconstruction,
-    const ObservationWhiteningMap& observation_whitening,
+    const ObservationCovarianceMap& observation_covariances,
     std::shared_ptr<ceres::LossFunction> loss_function) {
   if (reconstruction.NumImages() == 0) {
     LOG(ERROR) << "Number of images = " << reconstruction.NumImages();
@@ -69,7 +82,7 @@ void GlobalPositioner::Prepare(
   InitializeRandomPositions(pose_graph, reconstruction);
 
   // Add the point to camera constraints to the problem.
-  AddPointToCameraConstraints(reconstruction, observation_whitening);
+  AddPointToCameraConstraints(reconstruction, observation_covariances);
 
   // Parameterize the variables, set image poses / tracks / scales to be
   // constant if desired
@@ -143,7 +156,7 @@ void GlobalPositioner::InitializeRandomPositions(
 
 void GlobalPositioner::AddPointToCameraConstraints(
     Reconstruction& reconstruction,
-    const ObservationWhiteningMap& observation_whitening) {
+    const ObservationCovarianceMap& observation_covariances) {
   VLOG(2) << reconstruction.NumPoints3D()
           << " point to camera constraints were added to the position "
              "estimation problem.";
@@ -162,14 +175,14 @@ void GlobalPositioner::AddPointToCameraConstraints(
       continue;
     }
 
-    AddPoint3DToProblem(point3D_id, reconstruction, observation_whitening);
+    AddPoint3DToProblem(point3D_id, reconstruction, observation_covariances);
   }
 }
 
 void GlobalPositioner::AddPoint3DToProblem(
     point3D_t point3D_id,
     Reconstruction& reconstruction,
-    const ObservationWhiteningMap& observation_whitening) {
+    const ObservationCovarianceMap& observation_covariances) {
   const bool random_initialization =
       options_.optimize_points && options_.generate_random_points;
   Point3D& point3D = reconstruction.Point3D(point3D_id);
@@ -203,24 +216,20 @@ void GlobalPositioner::AddPoint3DToProblem(
     const Eigen::Vector3d cam_from_point3D_dir =
         image.CamFromWorld().rotation().inverse() * (*cam_ray);
     double& scale = scales_.emplace_back(1);
-    const Eigen::Matrix3d* whitening_matrix = nullptr;
-    if (!observation_whitening.empty()) {
+    const Eigen::Matrix3d* covariance = nullptr;
+    if (!observation_covariances.empty()) {
       const Point3DTrackElementKey key{
           point3D_id, static_cast<uint64_t>(track_element_index)};
-      const auto whitening_it = observation_whitening.find(key);
-      if (whitening_it == observation_whitening.end()) {
+      const auto covariance_it = observation_covariances.find(key);
+      if (covariance_it == observation_covariances.end()) {
         throw std::invalid_argument(
-            "observation whitening map is missing a reconstruction "
+            "observation covariance map is missing a reconstruction "
             "observation");
       }
-      if (!whitening_it->second.allFinite()) {
-        throw std::invalid_argument("observation weights must be finite");
+      if (!covariance_it->second.allFinite()) {
+        throw std::invalid_argument("observation covariance must be finite");
       }
-      whitening_matrix = &whitening_it->second;
-      if (!image.IsRefInFrame()) {
-        throw std::invalid_argument(
-            "weighted BATA does not support non-reference rig images");
-      }
+      covariance = &covariance_it->second;
     }
 
     if (!options_.generate_scales) {
@@ -242,12 +251,14 @@ void GlobalPositioner::AddPoint3DToProblem(
 
     // If the image is not part of a camera rig, use the standard BATA error
     if (image.IsRefInFrame()) {
-      AddObservationResidual(cam_from_point3D_dir,
-                             whitening_matrix,
-                             *loss_function,
-                             frame_centers_[image.FrameId()],
-                             point3D.xyz,
-                             scale);
+      ceres::CostFunction* cost_function =
+          CreateBATACostFunction<BATAPairwiseDirectionCostFunctor>(
+              covariance, cam_from_point3D_dir);
+      problem_->AddResidualBlock(cost_function,
+                                 loss_function,
+                                 frame_centers_[image.FrameId()].data(),
+                                 point3D.xyz.data(),
+                                 &scale);
     } else {
       // If the image is part of a camera rig, use the RigBATA error.
 
@@ -260,9 +271,9 @@ void GlobalPositioner::AddPoint3DToProblem(
             image.CamFromWorld().rotation().inverse() *
             cam_from_rig.translation();
 
-        ceres::CostFunction* cost_function =
-            RigBATAPairwiseDirectionConstantRigCostFunctor::Create(
-                cam_from_point3D_dir, cam_from_rig_dir);
+        ceres::CostFunction* cost_function = CreateBATACostFunction<
+            RigBATAPairwiseDirectionConstantRigCostFunctor>(
+            covariance, cam_from_point3D_dir, cam_from_rig_dir);
 
         problem_->AddResidualBlock(cost_function,
                                    loss_function,
@@ -283,7 +294,8 @@ void GlobalPositioner::AddPoint3DToProblem(
         }
 
         ceres::CostFunction* cost_function =
-            RigBATAPairwiseDirectionCostFunctor::Create(
+            CreateBATACostFunction<RigBATAPairwiseDirectionCostFunctor>(
+                covariance,
                 cam_from_point3D_dir,
                 image.FramePtr()->RigFromWorld().rotation());
 
@@ -294,27 +306,9 @@ void GlobalPositioner::AddPoint3DToProblem(
                                    cams_in_rig_[sensor_id].data(),
                                    &scale);
       }
-
-      problem_->SetParameterLowerBound(&scale, 0, 1e-5);
     }
+    problem_->SetParameterLowerBound(&scale, 0, 1e-5);
   }
-}
-
-void GlobalPositioner::AddObservationResidual(
-    const Eigen::Vector3d& point3D_bearing,
-    const Eigen::Matrix3d* observation_whitening_matrix,
-    ceres::LossFunction& loss_function,
-    Eigen::Vector3d& center,
-    Eigen::Vector3d& point3D,
-    double& scale) {
-  ceres::CostFunction* cost_function =
-      observation_whitening_matrix == nullptr
-          ? BATAPairwiseDirectionCostFunctor::Create(point3D_bearing)
-          : WeightedBATAPairwiseDirectionCostFunctor::Create(
-                point3D_bearing, *observation_whitening_matrix);
-  problem_->AddResidualBlock(
-      cost_function, &loss_function, center.data(), point3D.data(), &scale);
-  problem_->SetParameterLowerBound(&scale, 0, 1e-5);
 }
 
 void GlobalPositioner::ParameterizeVariables(Reconstruction& reconstruction) {
@@ -510,7 +504,7 @@ std::unique_ptr<GlobalPositioner> CreateDefaultGlobalPositioner(
     const GlobalPositionerOptions& options,
     const PoseGraph& pose_graph,
     Reconstruction* reconstruction,
-    const ObservationWhiteningMap& observation_whitening,
+    const ObservationCovarianceMap& observation_covariances,
     std::shared_ptr<ceres::LossFunction> loss_function) {
   if (reconstruction == nullptr) {
     throw std::invalid_argument("reconstruction must not be null");
@@ -518,7 +512,7 @@ std::unique_ptr<GlobalPositioner> CreateDefaultGlobalPositioner(
   std::unique_ptr<GlobalPositioner> positioner(new GlobalPositioner(options));
   positioner->Prepare(pose_graph,
                       *reconstruction,
-                      observation_whitening,
+                      observation_covariances,
                       std::move(loss_function));
   positioner->options_.solver_options.num_threads =
       GetEffectiveNumThreads(positioner->options_.solver_options.num_threads);

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -13,8 +13,9 @@
 
 namespace colmap {
 
-// Per-observation matrices that whiten default BATA residuals.
-using ObservationWhiteningMap =
+// Per-observation covariance matrices in world coordinates for default BATA
+// residuals.
+using ObservationCovarianceMap =
     FlatHashMap<Point3DTrackElementKey, Eigen::Matrix3d, PairHash>;
 
 struct GlobalPositionerOptions {
@@ -94,7 +95,7 @@ class GlobalPositioner {
   // Construct the problem without solving it.
   void Prepare(const PoseGraph& pose_graph,
                Reconstruction& reconstruction,
-               const ObservationWhiteningMap& observation_whitening,
+               const ObservationCovarianceMap& observation_covariances,
                std::shared_ptr<ceres::LossFunction> loss_function);
 
   void SetupProblem(std::shared_ptr<ceres::LossFunction> loss_function);
@@ -103,24 +104,16 @@ class GlobalPositioner {
   void InitializeRandomPositions(const PoseGraph& pose_graph,
                                  Reconstruction& reconstruction);
 
-  // Add regular constraints with optional keyed whitening.
+  // Add regular constraints with optional keyed covariances.
   void AddPointToCameraConstraints(
       Reconstruction& reconstruction,
-      const ObservationWhiteningMap& observation_whitening);
+      const ObservationCovarianceMap& observation_covariances);
 
   // Add a single point3D to the problem.
   void AddPoint3DToProblem(
       point3D_t point3D_id,
       Reconstruction& reconstruction,
-      const ObservationWhiteningMap& observation_whitening);
-
-  void AddObservationResidual(
-      const Eigen::Vector3d& point3D_bearing,
-      const Eigen::Matrix3d* observation_whitening_matrix,
-      ceres::LossFunction& loss_function,
-      Eigen::Vector3d& center,
-      Eigen::Vector3d& point3D,
-      double& scale);
+      const ObservationCovarianceMap& observation_covariances);
 
   // Parameterize the variables, set some variables to be constant if desired
   void ParameterizeVariables(Reconstruction& reconstruction);
@@ -158,7 +151,7 @@ class GlobalPositioner {
       const GlobalPositionerOptions&,
       const PoseGraph&,
       Reconstruction*,
-      const ObservationWhiteningMap&,
+      const ObservationCovarianceMap&,
       std::shared_ptr<ceres::LossFunction>);
 };
 
@@ -167,7 +160,7 @@ std::unique_ptr<GlobalPositioner> CreateDefaultGlobalPositioner(
     const GlobalPositionerOptions& options,
     const PoseGraph& pose_graph,
     Reconstruction* reconstruction,
-    const ObservationWhiteningMap& observation_whitening = {},
+    const ObservationCovarianceMap& observation_covariances = {},
     std::shared_ptr<ceres::LossFunction> loss_function = nullptr);
 
 // Solve global positioning using point-to-camera constraints.

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -111,10 +111,16 @@ std::pair<size_t, size_t> ObservationScaleConstantCounts(
   return {num_constant_scales, num_scales};
 }
 
-ObservationWhiteningMap IdentityObservationWhiteningMap(
+std::pair<ObservationCovarianceMap, double> ObservationCovariancesAndCost(
     const GlobalPositionerOptions& options,
     const Reconstruction& reconstruction) {
-  ObservationWhiteningMap whitening;
+  const Eigen::Vector3d standard_deviations(0.5, 1.0, 2.0);
+  const Eigen::Matrix3d camera_covariance =
+      standard_deviations.array().square().matrix().asDiagonal();
+  const Eigen::Matrix3d camera_whitening =
+      standard_deviations.cwiseInverse().asDiagonal();
+  ObservationCovarianceMap covariances;
+  double expected_cost = 0.0;
   for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
     if (point3D.track.Length() <
         static_cast<size_t>(options.min_num_view_per_track)) {
@@ -125,18 +131,36 @@ ObservationWhiteningMap IdentityObservationWhiteningMap(
       const TrackElement& observation = observations[index];
       if (!reconstruction.ExistsImage(observation.image_id)) continue;
       const Image& image = reconstruction.Image(observation.image_id);
-      if (!image.HasPose() ||
-          !image.CameraPtr()
-               ->CamRayFromImg(image.Point2D(observation.point2D_idx).xy)
-               .has_value()) {
+      const std::optional<Eigen::Vector3d> camera_ray =
+          image.CameraPtr()->CamRayFromImg(
+              image.Point2D(observation.point2D_idx).xy);
+      if (!image.HasPose() || !camera_ray.has_value()) {
         continue;
       }
-      whitening.emplace(
+      const Eigen::Matrix3d cam_from_world =
+          image.CamFromWorld().rotation().toRotationMatrix();
+      covariances.emplace(
           Point3DTrackElementKey{point3D_id, static_cast<uint64_t>(index)},
-          Eigen::Matrix3d::Identity());
+          cam_from_world.transpose() * camera_covariance * cam_from_world);
+
+      const Eigen::Vector3d frame_center =
+          image.FramePtr()->RigFromWorld().TgtOriginInSrc();
+      Eigen::Vector3d point_from_center = point3D.xyz - frame_center;
+      if (!image.IsRefInFrame()) {
+        const Rig& rig = reconstruction.Rig(image.FramePtr()->RigId());
+        const Rigid3d& cam_from_rig =
+            rig.SensorFromRig(image.CameraPtr()->SensorId());
+        point_from_center += image.CamFromWorld().rotation().inverse() *
+                             cam_from_rig.translation();
+      }
+      const Eigen::Vector3d residual =
+          image.CamFromWorld().rotation().inverse() * (*camera_ray) -
+          point_from_center;
+      expected_cost +=
+          0.5 * (camera_whitening * cam_from_world * residual).squaredNorm();
     }
   }
-  return whitening;
+  return {std::move(covariances), expected_cost};
 }
 
 Reconstruction CreateGlobalPositioningTestReconstruction() {
@@ -304,11 +328,11 @@ TEST(GlobalPositioning, InitializesWarmStartScalesFromCurrentScene) {
   EXPECT_EQ(ObservationScaleValues(positioner->Problem()), expected_scales);
 }
 
-TEST(GlobalPositioning, KeyedObservationWhitening) {
+TEST(GlobalPositioning, KeyedObservationCovariances) {
   Reconstruction reconstruction;
   SyntheticDatasetOptions dataset_options;
   dataset_options.num_rigs = 1;
-  dataset_options.num_cameras_per_rig = 1;
+  dataset_options.num_cameras_per_rig = 2;
   dataset_options.num_frames_per_rig = 4;
   dataset_options.num_points3D = 30;
   SynthesizeDataset(dataset_options, &reconstruction);
@@ -317,32 +341,27 @@ TEST(GlobalPositioning, KeyedObservationWhitening) {
   options.use_gpu = false;
   options.generate_random_positions = false;
   options.generate_random_points = false;
-  const ObservationWhiteningMap whitening =
-      IdentityObservationWhiteningMap(options, reconstruction);
-  ASSERT_FALSE(whitening.empty());
-
-  Reconstruction unweighted_reconstruction = reconstruction;
-  auto unweighted = CreateDefaultGlobalPositioner(
-      options, PoseGraph(), &unweighted_reconstruction);
-  double unweighted_cost = 0.0;
-  ASSERT_TRUE(unweighted->Problem().Evaluate(ceres::Problem::EvaluateOptions(),
-                                             &unweighted_cost,
-                                             nullptr,
-                                             nullptr,
-                                             nullptr));
+  options.downweight_uncalibrated_observations = false;
+  auto [covariances, expected_cost] =
+      ObservationCovariancesAndCost(options, reconstruction);
+  ASSERT_FALSE(covariances.empty());
 
   Reconstruction weighted_reconstruction = reconstruction;
-  auto weighted = CreateDefaultGlobalPositioner(
-      options, PoseGraph(), &weighted_reconstruction, whitening);
+  auto weighted =
+      CreateDefaultGlobalPositioner(options,
+                                    PoseGraph(),
+                                    &weighted_reconstruction,
+                                    covariances,
+                                    std::make_shared<ceres::TrivialLoss>());
   double weighted_cost = 0.0;
   ASSERT_TRUE(weighted->Problem().Evaluate(ceres::Problem::EvaluateOptions(),
                                            &weighted_cost,
                                            nullptr,
                                            nullptr,
                                            nullptr));
-  EXPECT_NEAR(weighted_cost, unweighted_cost, 1e-12);
+  EXPECT_NEAR(weighted_cost, expected_cost, 1e-10);
 
-  ObservationWhiteningMap missing = whitening;
+  ObservationCovarianceMap missing = covariances;
   missing.erase(missing.begin());
   Reconstruction missing_reconstruction = reconstruction;
   EXPECT_THROW(CreateDefaultGlobalPositioner(

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -8,7 +8,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-PYBIND11_MAKE_OPAQUE(colmap::ObservationWhiteningMap);
+PYBIND11_MAKE_OPAQUE(colmap::ObservationCovarianceMap);
 
 using namespace colmap;
 using namespace pybind11::literals;
@@ -88,14 +88,14 @@ void BindGlobalPositioner(py::module& m) {
            &GlobalPositioner::SetParameterBlockOrdering)
       .def("finalize", &GlobalPositioner::Finalize, "summary"_a);
 
-  py::class_<ObservationWhiteningMap>(m, "_ObservationWhiteningMap");
+  py::class_<ObservationCovarianceMap>(m, "_ObservationCovarianceMap");
 
   m.def("create_default_global_positioner",
         &CreateDefaultGlobalPositioner,
         "options"_a,
         "pose_graph"_a,
         "reconstruction"_a,
-        "observation_whitening"_a = ObservationWhiteningMap(),
+        "observation_covariances"_a = ObservationCovarianceMap(),
         "loss_function"_a = nullptr,
         py::keep_alive<0, 3>());
 


### PR DESCRIPTION
## Summary

Replace the dedicated weighted BATA functor with COLMAP's shared covariance-weighting wrapper.

- Make the reference and rig BATA functors compatible with `CovarianceWeightedCostFunctor`.
- Accept optional per-observation covariance matrices in world coordinates when constructing the default global-positioning problem.
- Apply covariance weighting consistently to reference, fixed-rig, and variable-rig residuals.
- Keep the empty-map path on the original unweighted BATA functors.
- Remove the now-redundant weighted BATA implementation.

This is a fork-only review PR stacked on the branch backing `colmap/colmap#4670`. It does not update that PR or any upstream COLMAP branch.

## Validation

- Global-positioning native tests pass: 8/8.
- The covariance test uses anisotropic uncertainty and nontrivial camera rotations, and checks the objective against the previous whitening formulation.
- A complete local COLMAP/PyCOLMAP stack built successfully.
- HGE10 mapping completed end to end with 11/11 registered images and 2,661 points.
