### PR TITLE
Refine global positioner construction

### DIFF
--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -29,6 +29,25 @@ ceres::CostFunction* CreateBATACostFunction(const Eigen::Matrix3d* covariance,
       *covariance, std::forward<Args>(args)...);
 }
 
+class DefaultGlobalPositioner final : public GlobalPositioner {
+ public:
+  DefaultGlobalPositioner(
+      const GlobalPositionerOptions& options,
+      const PoseGraph& pose_graph,
+      Reconstruction& reconstruction,
+      const ObservationCovarianceMap& observation_covariances,
+      std::shared_ptr<ceres::LossFunction> loss_function)
+      : GlobalPositioner(options) {
+    Prepare(pose_graph,
+            reconstruction,
+            observation_covariances,
+            std::move(loss_function));
+    options_.solver_options.num_threads =
+        GetEffectiveNumThreads(options_.solver_options.num_threads);
+    options_.solver_options.minimizer_progress_to_stdout = VLOG_IS_ON(2);
+  }
+};
+
 }  // namespace
 
 GlobalPositioner::GlobalPositioner(const GlobalPositionerOptions& options)
@@ -62,14 +81,6 @@ void GlobalPositioner::Prepare(
     Reconstruction& reconstruction,
     const ObservationCovarianceMap& observation_covariances,
     std::shared_ptr<ceres::LossFunction> loss_function) {
-  if (reconstruction.NumImages() == 0) {
-    LOG(ERROR) << "Number of images = " << reconstruction.NumImages();
-    throw std::runtime_error("global positioning requires images");
-  }
-  if (reconstruction.NumPoints3D() == 0) {
-    LOG(ERROR) << "Number of tracks = " << reconstruction.NumPoints3D();
-    throw std::runtime_error("global positioning requires 3D points");
-  }
   reconstruction_ = &reconstruction;
 
   LOG(INFO) << "Setting up the global positioner problem";
@@ -500,40 +511,33 @@ void GlobalPositioner::SetParameterBlockOrdering() {
   options_.solver_options.linear_solver_ordering = std::move(ordering);
 }
 
-std::unique_ptr<GlobalPositioner> CreateDefaultGlobalPositioner(
+std::unique_ptr<GlobalPositioner> GlobalPositioner::CreateDefault(
     const GlobalPositionerOptions& options,
     const PoseGraph& pose_graph,
-    Reconstruction* reconstruction,
+    Reconstruction& reconstruction,
     const ObservationCovarianceMap& observation_covariances,
     std::shared_ptr<ceres::LossFunction> loss_function) {
-  if (reconstruction == nullptr) {
-    throw std::invalid_argument("reconstruction must not be null");
+  if (reconstruction.NumImages() == 0 || reconstruction.NumPoints3D() == 0) {
+    LOG(ERROR) << "Failed to run global positioning for incomplete "
+                  "reconstruction: "
+               << reconstruction;
+    return nullptr;
   }
-  std::unique_ptr<GlobalPositioner> positioner(new GlobalPositioner(options));
-  positioner->Prepare(pose_graph,
-                      *reconstruction,
-                      observation_covariances,
-                      std::move(loss_function));
-  positioner->options_.solver_options.num_threads =
-      GetEffectiveNumThreads(positioner->options_.solver_options.num_threads);
-  positioner->options_.solver_options.minimizer_progress_to_stdout =
-      VLOG_IS_ON(2);
-  return positioner;
+  return std::make_unique<DefaultGlobalPositioner>(options,
+                                                   pose_graph,
+                                                   reconstruction,
+                                                   observation_covariances,
+                                                   std::move(loss_function));
 }
 
 bool RunGlobalPositioning(const GlobalPositionerOptions& options,
                           const PoseGraph& pose_graph,
                           Reconstruction& reconstruction) {
-  if (reconstruction.NumImages() == 0) {
-    LOG(ERROR) << "Number of images = " << reconstruction.NumImages();
-    return false;
-  }
-  if (reconstruction.NumPoints3D() == 0) {
-    LOG(ERROR) << "Number of tracks = " << reconstruction.NumPoints3D();
-    return false;
-  }
   auto positioner =
-      CreateDefaultGlobalPositioner(options, pose_graph, &reconstruction);
+      GlobalPositioner::CreateDefault(options, pose_graph, reconstruction);
+  if (positioner == nullptr) {
+    return false;
+  }
   if (options.use_parameter_block_ordering) {
     positioner->SetParameterBlockOrdering();
   }

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -75,6 +75,17 @@ struct GlobalPositionerOptions {
 
 class GlobalPositioner {
  public:
+  virtual ~GlobalPositioner() = default;
+
+  // Returns nullptr for an incomplete reconstruction. The reconstruction must
+  // outlive the returned positioner.
+  static std::unique_ptr<GlobalPositioner> CreateDefault(
+      const GlobalPositionerOptions& options,
+      const PoseGraph& pose_graph,
+      Reconstruction& reconstruction,
+      const ObservationCovarianceMap& observation_covariances = {},
+      std::shared_ptr<ceres::LossFunction> loss_function = nullptr);
+
   // Solve the prepared problem and publish its results.
   ceres::Solver::Summary Solve();
 
@@ -145,23 +156,7 @@ class GlobalPositioner {
   // Retained for late parameter ordering and Finalize().
   Reconstruction* reconstruction_ = nullptr;
   std::unique_ptr<ceres::Problem> problem_;
-
- private:
-  friend std::unique_ptr<GlobalPositioner> CreateDefaultGlobalPositioner(
-      const GlobalPositionerOptions&,
-      const PoseGraph&,
-      Reconstruction*,
-      const ObservationCovarianceMap&,
-      std::shared_ptr<ceres::LossFunction>);
 };
-
-// The reconstruction must outlive the returned positioner.
-std::unique_ptr<GlobalPositioner> CreateDefaultGlobalPositioner(
-    const GlobalPositionerOptions& options,
-    const PoseGraph& pose_graph,
-    Reconstruction* reconstruction,
-    const ObservationCovarianceMap& observation_covariances = {},
-    std::shared_ptr<ceres::LossFunction> loss_function = nullptr);
 
 // Solve global positioning using point-to-camera constraints.
 bool RunGlobalPositioning(const GlobalPositionerOptions& options,

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -95,7 +95,7 @@ std::pair<size_t, size_t> ObservationScaleConstantCounts(
   SynthesizeDataset(dataset_options, &reconstruction);
 
   auto positioner =
-      CreateDefaultGlobalPositioner(options, PoseGraph(), &reconstruction);
+      GlobalPositioner::CreateDefault(options, PoseGraph(), reconstruction);
   ceres::Problem& problem = positioner->Problem();
   std::vector<double*> parameter_blocks;
   problem.GetParameterBlocks(&parameter_blocks);
@@ -225,8 +225,8 @@ TEST(GlobalPositioning, ComposableProblem) {
   GlobalPositionerOptions options;
   options.use_gpu = false;
   auto loss = std::make_shared<ceres::CauchyLoss>(0.1);
-  auto positioner = CreateDefaultGlobalPositioner(
-      options, PoseGraph(), &reconstruction, {}, loss);
+  auto positioner = GlobalPositioner::CreateDefault(
+      options, PoseGraph(), reconstruction, {}, loss);
   loss.reset();
 
   const frame_t frame_id = reconstruction.Images().begin()->second.FrameId();
@@ -289,11 +289,11 @@ TEST(GlobalPositioning, UncalibratedObservationDownweightOption) {
     options.downweight_uncalibrated_observations =
         downweight_uncalibrated_observations;
     auto positioner =
-        CreateDefaultGlobalPositioner(options,
-                                      PoseGraph(),
-                                      &test_reconstruction,
-                                      {},
-                                      std::make_shared<ceres::TrivialLoss>());
+        GlobalPositioner::CreateDefault(options,
+                                        PoseGraph(),
+                                        test_reconstruction,
+                                        {},
+                                        std::make_shared<ceres::TrivialLoss>());
     double cost = 0.0;
     EXPECT_TRUE(positioner->Problem().Evaluate(
         ceres::Problem::EvaluateOptions(), &cost, nullptr, nullptr, nullptr));
@@ -324,7 +324,7 @@ TEST(GlobalPositioning, InitializesWarmStartScalesFromCurrentScene) {
   std::sort(expected_scales.begin(), expected_scales.end());
 
   auto positioner =
-      CreateDefaultGlobalPositioner(options, PoseGraph(), &reconstruction);
+      GlobalPositioner::CreateDefault(options, PoseGraph(), reconstruction);
   EXPECT_EQ(ObservationScaleValues(positioner->Problem()), expected_scales);
 }
 
@@ -348,11 +348,11 @@ TEST(GlobalPositioning, KeyedObservationCovariances) {
 
   Reconstruction weighted_reconstruction = reconstruction;
   auto weighted =
-      CreateDefaultGlobalPositioner(options,
-                                    PoseGraph(),
-                                    &weighted_reconstruction,
-                                    covariances,
-                                    std::make_shared<ceres::TrivialLoss>());
+      GlobalPositioner::CreateDefault(options,
+                                      PoseGraph(),
+                                      weighted_reconstruction,
+                                      covariances,
+                                      std::make_shared<ceres::TrivialLoss>());
   double weighted_cost = 0.0;
   ASSERT_TRUE(weighted->Problem().Evaluate(ceres::Problem::EvaluateOptions(),
                                            &weighted_cost,
@@ -364,8 +364,8 @@ TEST(GlobalPositioning, KeyedObservationCovariances) {
   ObservationCovarianceMap missing = covariances;
   missing.erase(missing.begin());
   Reconstruction missing_reconstruction = reconstruction;
-  EXPECT_THROW(CreateDefaultGlobalPositioner(
-                   options, PoseGraph(), &missing_reconstruction, missing),
+  EXPECT_THROW(GlobalPositioner::CreateDefault(
+                   options, PoseGraph(), missing_reconstruction, missing),
                std::invalid_argument);
 }
 

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -91,7 +91,7 @@ void BindGlobalPositioner(py::module& m) {
   py::class_<ObservationCovarianceMap>(m, "_ObservationCovarianceMap");
 
   m.def("create_default_global_positioner",
-        &CreateDefaultGlobalPositioner,
+        &GlobalPositioner::CreateDefault,
         "options"_a,
         "pose_graph"_a,
         "reconstruction"_a,


### PR DESCRIPTION
## Summary

- move default construction to `GlobalPositioner::CreateDefault` and remove the friend factory
- use an internal default implementation with `std::make_unique`
- pass reconstruction by reference and return `nullptr` for incomplete inputs
- share the same validation path with `RunGlobalPositioning`

## Validation

- `global_positioning_test`: 8/8 passed
- PyCOLMAP build and factory/solve smoke test passed