### PR TITLE
Preserve incomplete reconstruction handling

### DIFF
--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -29,6 +29,25 @@ ceres::CostFunction* CreateBATACostFunction(const Eigen::Matrix3d* covariance,
       *covariance, std::forward<Args>(args)...);
 }
 
+class DefaultGlobalPositioner final : public GlobalPositioner {
+ public:
+  DefaultGlobalPositioner(
+      const GlobalPositionerOptions& options,
+      const PoseGraph& pose_graph,
+      Reconstruction& reconstruction,
+      const ObservationCovarianceMap& observation_covariances,
+      std::shared_ptr<ceres::LossFunction> loss_function)
+      : GlobalPositioner(options) {
+    Prepare(pose_graph,
+            reconstruction,
+            observation_covariances,
+            std::move(loss_function));
+    options_.solver_options.num_threads =
+        GetEffectiveNumThreads(options_.solver_options.num_threads);
+    options_.solver_options.minimizer_progress_to_stdout = VLOG_IS_ON(2);
+  }
+};
+
 }  // namespace
 
 GlobalPositioner::GlobalPositioner(const GlobalPositionerOptions& options)
@@ -506,16 +525,11 @@ std::unique_ptr<GlobalPositioner> GlobalPositioner::CreateDefault(
     Reconstruction& reconstruction,
     const ObservationCovarianceMap& observation_covariances,
     std::shared_ptr<ceres::LossFunction> loss_function) {
-  std::unique_ptr<GlobalPositioner> positioner(new GlobalPositioner(options));
-  positioner->Prepare(pose_graph,
-                      reconstruction,
-                      observation_covariances,
-                      std::move(loss_function));
-  positioner->options_.solver_options.num_threads =
-      GetEffectiveNumThreads(positioner->options_.solver_options.num_threads);
-  positioner->options_.solver_options.minimizer_progress_to_stdout =
-      VLOG_IS_ON(2);
-  return positioner;
+  return std::make_unique<DefaultGlobalPositioner>(options,
+                                                   pose_graph,
+                                                   reconstruction,
+                                                   observation_covariances,
+                                                   std::move(loss_function));
 }
 
 bool RunGlobalPositioning(const GlobalPositionerOptions& options,

--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -81,14 +81,6 @@ void GlobalPositioner::Prepare(
     Reconstruction& reconstruction,
     const ObservationCovarianceMap& observation_covariances,
     std::shared_ptr<ceres::LossFunction> loss_function) {
-  if (reconstruction.NumImages() == 0) {
-    LOG(ERROR) << "Number of images = " << reconstruction.NumImages();
-    throw std::runtime_error("global positioning requires images");
-  }
-  if (reconstruction.NumPoints3D() == 0) {
-    LOG(ERROR) << "Number of tracks = " << reconstruction.NumPoints3D();
-    throw std::runtime_error("global positioning requires 3D points");
-  }
   reconstruction_ = &reconstruction;
 
   LOG(INFO) << "Setting up the global positioner problem";
@@ -525,6 +517,12 @@ std::unique_ptr<GlobalPositioner> GlobalPositioner::CreateDefault(
     Reconstruction& reconstruction,
     const ObservationCovarianceMap& observation_covariances,
     std::shared_ptr<ceres::LossFunction> loss_function) {
+  if (reconstruction.NumImages() == 0 || reconstruction.NumPoints3D() == 0) {
+    LOG(ERROR) << "Failed to run global positioning for incomplete "
+                  "reconstruction: "
+               << reconstruction;
+    return nullptr;
+  }
   return std::make_unique<DefaultGlobalPositioner>(options,
                                                    pose_graph,
                                                    reconstruction,
@@ -535,16 +533,11 @@ std::unique_ptr<GlobalPositioner> GlobalPositioner::CreateDefault(
 bool RunGlobalPositioning(const GlobalPositionerOptions& options,
                           const PoseGraph& pose_graph,
                           Reconstruction& reconstruction) {
-  if (reconstruction.NumImages() == 0) {
-    LOG(ERROR) << "Number of images = " << reconstruction.NumImages();
-    return false;
-  }
-  if (reconstruction.NumPoints3D() == 0) {
-    LOG(ERROR) << "Number of tracks = " << reconstruction.NumPoints3D();
-    return false;
-  }
   auto positioner =
       GlobalPositioner::CreateDefault(options, pose_graph, reconstruction);
+  if (positioner == nullptr) {
+    return false;
+  }
   if (options.use_parameter_block_ordering) {
     positioner->SetParameterBlockOrdering();
   }

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -75,6 +75,8 @@ struct GlobalPositionerOptions {
 
 class GlobalPositioner {
  public:
+  virtual ~GlobalPositioner() = default;
+
   // The reconstruction must outlive the returned positioner.
   static std::unique_ptr<GlobalPositioner> CreateDefault(
       const GlobalPositionerOptions& options,

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -77,7 +77,8 @@ class GlobalPositioner {
  public:
   virtual ~GlobalPositioner() = default;
 
-  // The reconstruction must outlive the returned positioner.
+  // Returns nullptr for an incomplete reconstruction. The reconstruction must
+  // outlive the returned positioner.
   static std::unique_ptr<GlobalPositioner> CreateDefault(
       const GlobalPositionerOptions& options,
       const PoseGraph& pose_graph,


### PR DESCRIPTION
Addresses https://github.com/colmap/colmap/pull/4670#discussion_r3911954442 by preserving the boolean failure path for incomplete reconstructions without duplicate checks.

Validation: global-positioning tests pass 8/8 and the rebuilt PyCOLMAP binding passes a focused solve and incomplete-input smoke test.