### PR TITLE
Use make_unique for global positioner

### DIFF
--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -29,6 +29,25 @@ ceres::CostFunction* CreateBATACostFunction(const Eigen::Matrix3d* covariance,
       *covariance, std::forward<Args>(args)...);
 }
 
+class DefaultGlobalPositioner final : public GlobalPositioner {
+ public:
+  DefaultGlobalPositioner(
+      const GlobalPositionerOptions& options,
+      const PoseGraph& pose_graph,
+      Reconstruction& reconstruction,
+      const ObservationCovarianceMap& observation_covariances,
+      std::shared_ptr<ceres::LossFunction> loss_function)
+      : GlobalPositioner(options) {
+    Prepare(pose_graph,
+            reconstruction,
+            observation_covariances,
+            std::move(loss_function));
+    options_.solver_options.num_threads =
+        GetEffectiveNumThreads(options_.solver_options.num_threads);
+    options_.solver_options.minimizer_progress_to_stdout = VLOG_IS_ON(2);
+  }
+};
+
 }  // namespace
 
 GlobalPositioner::GlobalPositioner(const GlobalPositionerOptions& options)
@@ -506,16 +525,11 @@ std::unique_ptr<GlobalPositioner> GlobalPositioner::CreateDefault(
     Reconstruction& reconstruction,
     const ObservationCovarianceMap& observation_covariances,
     std::shared_ptr<ceres::LossFunction> loss_function) {
-  std::unique_ptr<GlobalPositioner> positioner(new GlobalPositioner(options));
-  positioner->Prepare(pose_graph,
-                      reconstruction,
-                      observation_covariances,
-                      std::move(loss_function));
-  positioner->options_.solver_options.num_threads =
-      GetEffectiveNumThreads(positioner->options_.solver_options.num_threads);
-  positioner->options_.solver_options.minimizer_progress_to_stdout =
-      VLOG_IS_ON(2);
-  return positioner;
+  return std::make_unique<DefaultGlobalPositioner>(options,
+                                                   pose_graph,
+                                                   reconstruction,
+                                                   observation_covariances,
+                                                   std::move(loss_function));
 }
 
 bool RunGlobalPositioning(const GlobalPositionerOptions& options,

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -75,6 +75,8 @@ struct GlobalPositionerOptions {
 
 class GlobalPositioner {
  public:
+  virtual ~GlobalPositioner() = default;
+
   // The reconstruction must outlive the returned positioner.
   static std::unique_ptr<GlobalPositioner> CreateDefault(
       const GlobalPositionerOptions& options,


### PR DESCRIPTION
Addresses https://github.com/colmap/colmap/pull/4670#discussion_r3911894731 by constructing the prepared global positioner with `std::make_unique`.

Validation: focused global-positioning target builds successfully.