### PR TITLE
Make global positioner factory static

### DIFF
--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -500,7 +500,7 @@ void GlobalPositioner::SetParameterBlockOrdering() {
   options_.solver_options.linear_solver_ordering = std::move(ordering);
 }
 
-std::unique_ptr<GlobalPositioner> CreateDefaultGlobalPositioner(
+std::unique_ptr<GlobalPositioner> GlobalPositioner::CreateDefault(
     const GlobalPositionerOptions& options,
     const PoseGraph& pose_graph,
     Reconstruction* reconstruction,
@@ -533,7 +533,7 @@ bool RunGlobalPositioning(const GlobalPositionerOptions& options,
     return false;
   }
   auto positioner =
-      CreateDefaultGlobalPositioner(options, pose_graph, &reconstruction);
+      GlobalPositioner::CreateDefault(options, pose_graph, &reconstruction);
   if (options.use_parameter_block_ordering) {
     positioner->SetParameterBlockOrdering();
   }

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -75,6 +75,14 @@ struct GlobalPositionerOptions {
 
 class GlobalPositioner {
  public:
+  // The reconstruction must outlive the returned positioner.
+  static std::unique_ptr<GlobalPositioner> CreateDefault(
+      const GlobalPositionerOptions& options,
+      const PoseGraph& pose_graph,
+      Reconstruction* reconstruction,
+      const ObservationCovarianceMap& observation_covariances = {},
+      std::shared_ptr<ceres::LossFunction> loss_function = nullptr);
+
   // Solve the prepared problem and publish its results.
   ceres::Solver::Summary Solve();
 
@@ -145,23 +153,7 @@ class GlobalPositioner {
   // Retained for late parameter ordering and Finalize().
   Reconstruction* reconstruction_ = nullptr;
   std::unique_ptr<ceres::Problem> problem_;
-
- private:
-  friend std::unique_ptr<GlobalPositioner> CreateDefaultGlobalPositioner(
-      const GlobalPositionerOptions&,
-      const PoseGraph&,
-      Reconstruction*,
-      const ObservationCovarianceMap&,
-      std::shared_ptr<ceres::LossFunction>);
 };
-
-// The reconstruction must outlive the returned positioner.
-std::unique_ptr<GlobalPositioner> CreateDefaultGlobalPositioner(
-    const GlobalPositionerOptions& options,
-    const PoseGraph& pose_graph,
-    Reconstruction* reconstruction,
-    const ObservationCovarianceMap& observation_covariances = {},
-    std::shared_ptr<ceres::LossFunction> loss_function = nullptr);
 
 // Solve global positioning using point-to-camera constraints.
 bool RunGlobalPositioning(const GlobalPositionerOptions& options,

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -95,7 +95,7 @@ std::pair<size_t, size_t> ObservationScaleConstantCounts(
   SynthesizeDataset(dataset_options, &reconstruction);
 
   auto positioner =
-      CreateDefaultGlobalPositioner(options, PoseGraph(), &reconstruction);
+      GlobalPositioner::CreateDefault(options, PoseGraph(), &reconstruction);
   ceres::Problem& problem = positioner->Problem();
   std::vector<double*> parameter_blocks;
   problem.GetParameterBlocks(&parameter_blocks);
@@ -225,7 +225,7 @@ TEST(GlobalPositioning, ComposableProblem) {
   GlobalPositionerOptions options;
   options.use_gpu = false;
   auto loss = std::make_shared<ceres::CauchyLoss>(0.1);
-  auto positioner = CreateDefaultGlobalPositioner(
+  auto positioner = GlobalPositioner::CreateDefault(
       options, PoseGraph(), &reconstruction, {}, loss);
   loss.reset();
 
@@ -289,11 +289,11 @@ TEST(GlobalPositioning, UncalibratedObservationDownweightOption) {
     options.downweight_uncalibrated_observations =
         downweight_uncalibrated_observations;
     auto positioner =
-        CreateDefaultGlobalPositioner(options,
-                                      PoseGraph(),
-                                      &test_reconstruction,
-                                      {},
-                                      std::make_shared<ceres::TrivialLoss>());
+        GlobalPositioner::CreateDefault(options,
+                                        PoseGraph(),
+                                        &test_reconstruction,
+                                        {},
+                                        std::make_shared<ceres::TrivialLoss>());
     double cost = 0.0;
     EXPECT_TRUE(positioner->Problem().Evaluate(
         ceres::Problem::EvaluateOptions(), &cost, nullptr, nullptr, nullptr));
@@ -324,7 +324,7 @@ TEST(GlobalPositioning, InitializesWarmStartScalesFromCurrentScene) {
   std::sort(expected_scales.begin(), expected_scales.end());
 
   auto positioner =
-      CreateDefaultGlobalPositioner(options, PoseGraph(), &reconstruction);
+      GlobalPositioner::CreateDefault(options, PoseGraph(), &reconstruction);
   EXPECT_EQ(ObservationScaleValues(positioner->Problem()), expected_scales);
 }
 
@@ -348,11 +348,11 @@ TEST(GlobalPositioning, KeyedObservationCovariances) {
 
   Reconstruction weighted_reconstruction = reconstruction;
   auto weighted =
-      CreateDefaultGlobalPositioner(options,
-                                    PoseGraph(),
-                                    &weighted_reconstruction,
-                                    covariances,
-                                    std::make_shared<ceres::TrivialLoss>());
+      GlobalPositioner::CreateDefault(options,
+                                      PoseGraph(),
+                                      &weighted_reconstruction,
+                                      covariances,
+                                      std::make_shared<ceres::TrivialLoss>());
   double weighted_cost = 0.0;
   ASSERT_TRUE(weighted->Problem().Evaluate(ceres::Problem::EvaluateOptions(),
                                            &weighted_cost,
@@ -364,7 +364,7 @@ TEST(GlobalPositioning, KeyedObservationCovariances) {
   ObservationCovarianceMap missing = covariances;
   missing.erase(missing.begin());
   Reconstruction missing_reconstruction = reconstruction;
-  EXPECT_THROW(CreateDefaultGlobalPositioner(
+  EXPECT_THROW(GlobalPositioner::CreateDefault(
                    options, PoseGraph(), &missing_reconstruction, missing),
                std::invalid_argument);
 }

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -91,7 +91,7 @@ void BindGlobalPositioner(py::module& m) {
   py::class_<ObservationCovarianceMap>(m, "_ObservationCovarianceMap");
 
   m.def("create_default_global_positioner",
-        &CreateDefaultGlobalPositioner,
+        &GlobalPositioner::CreateDefault,
         "options"_a,
         "pose_graph"_a,
         "reconstruction"_a,


### PR DESCRIPTION
Addresses https://github.com/colmap/colmap/pull/4670#discussion_r3911923258 by making the reusable global-positioner factory a static member and removing the friend declaration.

Validation: focused global-positioning target builds successfully.