### PR TITLE
Pass reconstruction by reference

### DIFF
--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -503,15 +503,12 @@ void GlobalPositioner::SetParameterBlockOrdering() {
 std::unique_ptr<GlobalPositioner> GlobalPositioner::CreateDefault(
     const GlobalPositionerOptions& options,
     const PoseGraph& pose_graph,
-    Reconstruction* reconstruction,
+    Reconstruction& reconstruction,
     const ObservationCovarianceMap& observation_covariances,
     std::shared_ptr<ceres::LossFunction> loss_function) {
-  if (reconstruction == nullptr) {
-    throw std::invalid_argument("reconstruction must not be null");
-  }
   std::unique_ptr<GlobalPositioner> positioner(new GlobalPositioner(options));
   positioner->Prepare(pose_graph,
-                      *reconstruction,
+                      reconstruction,
                       observation_covariances,
                       std::move(loss_function));
   positioner->options_.solver_options.num_threads =
@@ -533,7 +530,7 @@ bool RunGlobalPositioning(const GlobalPositionerOptions& options,
     return false;
   }
   auto positioner =
-      GlobalPositioner::CreateDefault(options, pose_graph, &reconstruction);
+      GlobalPositioner::CreateDefault(options, pose_graph, reconstruction);
   if (options.use_parameter_block_ordering) {
     positioner->SetParameterBlockOrdering();
   }

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -79,7 +79,7 @@ class GlobalPositioner {
   static std::unique_ptr<GlobalPositioner> CreateDefault(
       const GlobalPositionerOptions& options,
       const PoseGraph& pose_graph,
-      Reconstruction* reconstruction,
+      Reconstruction& reconstruction,
       const ObservationCovarianceMap& observation_covariances = {},
       std::shared_ptr<ceres::LossFunction> loss_function = nullptr);
 

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -95,7 +95,7 @@ std::pair<size_t, size_t> ObservationScaleConstantCounts(
   SynthesizeDataset(dataset_options, &reconstruction);
 
   auto positioner =
-      GlobalPositioner::CreateDefault(options, PoseGraph(), &reconstruction);
+      GlobalPositioner::CreateDefault(options, PoseGraph(), reconstruction);
   ceres::Problem& problem = positioner->Problem();
   std::vector<double*> parameter_blocks;
   problem.GetParameterBlocks(&parameter_blocks);
@@ -226,7 +226,7 @@ TEST(GlobalPositioning, ComposableProblem) {
   options.use_gpu = false;
   auto loss = std::make_shared<ceres::CauchyLoss>(0.1);
   auto positioner = GlobalPositioner::CreateDefault(
-      options, PoseGraph(), &reconstruction, {}, loss);
+      options, PoseGraph(), reconstruction, {}, loss);
   loss.reset();
 
   const frame_t frame_id = reconstruction.Images().begin()->second.FrameId();
@@ -291,7 +291,7 @@ TEST(GlobalPositioning, UncalibratedObservationDownweightOption) {
     auto positioner =
         GlobalPositioner::CreateDefault(options,
                                         PoseGraph(),
-                                        &test_reconstruction,
+                                        test_reconstruction,
                                         {},
                                         std::make_shared<ceres::TrivialLoss>());
     double cost = 0.0;
@@ -324,7 +324,7 @@ TEST(GlobalPositioning, InitializesWarmStartScalesFromCurrentScene) {
   std::sort(expected_scales.begin(), expected_scales.end());
 
   auto positioner =
-      GlobalPositioner::CreateDefault(options, PoseGraph(), &reconstruction);
+      GlobalPositioner::CreateDefault(options, PoseGraph(), reconstruction);
   EXPECT_EQ(ObservationScaleValues(positioner->Problem()), expected_scales);
 }
 
@@ -350,7 +350,7 @@ TEST(GlobalPositioning, KeyedObservationCovariances) {
   auto weighted =
       GlobalPositioner::CreateDefault(options,
                                       PoseGraph(),
-                                      &weighted_reconstruction,
+                                      weighted_reconstruction,
                                       covariances,
                                       std::make_shared<ceres::TrivialLoss>());
   double weighted_cost = 0.0;
@@ -365,7 +365,7 @@ TEST(GlobalPositioning, KeyedObservationCovariances) {
   missing.erase(missing.begin());
   Reconstruction missing_reconstruction = reconstruction;
   EXPECT_THROW(GlobalPositioner::CreateDefault(
-                   options, PoseGraph(), &missing_reconstruction, missing),
+                   options, PoseGraph(), missing_reconstruction, missing),
                std::invalid_argument);
 }
 


### PR DESCRIPTION
Addresses https://github.com/colmap/colmap/pull/4670#discussion_r3911901066 by passing the required reconstruction by reference.

Validation: focused global-positioning target builds successfully.