### PR TITLE
Make global positioning behavior configurable

### DIFF
--- a/src/colmap/estimators/global_positioning.cc
+++ b/src/colmap/estimators/global_positioning.cc
@@ -180,9 +180,12 @@ void GlobalPositioner::AddPointToCameraConstraints(
           << " point to camera constraints were added to the position "
              "estimation problem.";
 
-  // Down-weight uncalibrated cameras.
-  loss_function_ptcam_uncalibrated_ = std::make_shared<ceres::ScaledLoss>(
-      loss_function_.get(), 0.5, ceres::DO_NOT_TAKE_OWNERSHIP);
+  if (options_.downweight_uncalibrated_observations) {
+    loss_function_ptcam_uncalibrated_ = std::make_shared<ceres::ScaledLoss>(
+        loss_function_.get(), 0.5, ceres::DO_NOT_TAKE_OWNERSHIP);
+  } else {
+    loss_function_ptcam_uncalibrated_ = loss_function_;
+  }
   loss_function_ptcam_calibrated_ = loss_function_;
 
   for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
@@ -248,7 +251,7 @@ void GlobalPositioner::AddPoint3DToProblem(
       covariance = &covariance_it->second;
     }
 
-    if (!options_.generate_scales && random_initialization) {
+    if (!options_.generate_scales) {
       const Eigen::Vector3d cam_from_point3D_translation =
           point3D.xyz - frame_centers_[image.FrameId()];
       scale = std::max(1e-5,
@@ -366,12 +369,13 @@ void GlobalPositioner::ParameterizeVariables(Reconstruction& reconstruction) {
         problem_->SetParameterBlockConstant(&scale);
       }
     }
-  }
-  // Set the first scale to be constant to remove the gauge ambiguity.
-  for (double& scale : scales_) {
-    if (problem_->HasParameterBlock(&scale)) {
-      problem_->SetParameterBlockConstant(&scale);
-      break;
+  } else if (options_.fix_observation_scale_gauge) {
+    // Set the first scale to be constant to remove the gauge ambiguity.
+    for (double& scale : scales_) {
+      if (problem_->HasParameterBlock(&scale)) {
+        problem_->SetParameterBlockConstant(&scale);
+        break;
+      }
     }
   }
 

--- a/src/colmap/estimators/global_positioning.h
+++ b/src/colmap/estimators/global_positioning.h
@@ -30,6 +30,12 @@ struct GlobalPositionerOptions {
   bool optimize_positions = true;
   bool optimize_points = true;
   bool optimize_scales = true;
+  // Whether to fix the first active observation scale to remove the gauge
+  // ambiguity when optimizing scales.
+  bool fix_observation_scale_gauge = true;
+  // Whether to down-weight observations from cameras without a focal-length
+  // prior, preserving the stock global-positioning objective by default.
+  bool downweight_uncalibrated_observations = true;
 
   // When false, treat sensor_from_rig as a fixed (pre-calibrated) parameter.
   bool refine_sensor_from_rig = true;

--- a/src/colmap/estimators/global_positioning_test.cc
+++ b/src/colmap/estimators/global_positioning_test.cc
@@ -35,13 +35,81 @@
 #include "colmap/scene/synthetic.h"
 #include "colmap/util/testing.h"
 
-#include <map>
+#include <algorithm>
 #include <utility>
 
 #include <gtest/gtest.h>
 
 namespace colmap {
 namespace {
+
+std::vector<double> ExpectedObservationScales(
+    const GlobalPositionerOptions& options,
+    const Reconstruction& reconstruction) {
+  std::vector<double> values;
+  for (const auto& [point3D_id, point3D] : reconstruction.Points3D()) {
+    if (point3D.track.Length() <
+        static_cast<size_t>(options.min_num_view_per_track)) {
+      continue;
+    }
+    for (const TrackElement& observation : point3D.track.Elements()) {
+      if (!reconstruction.ExistsImage(observation.image_id)) continue;
+      const Image& image = reconstruction.Image(observation.image_id);
+      if (!image.HasPose()) continue;
+      const std::optional<Eigen::Vector3d> cam_ray =
+          image.CameraPtr()->CamRayFromImg(
+              image.Point2D(observation.point2D_idx).xy);
+      if (!cam_ray.has_value()) continue;
+      const Eigen::Vector3d direction =
+          image.CamFromWorld().rotation().inverse() * *cam_ray;
+      const Eigen::Vector3d translation =
+          point3D.xyz - image.FramePtr()->RigFromWorld().TgtOriginInSrc();
+      values.push_back(std::max(
+          1e-5, direction.dot(translation) / translation.squaredNorm()));
+    }
+  }
+  return values;
+}
+
+std::vector<double> ObservationScaleValues(ceres::Problem& problem) {
+  std::vector<double*> parameter_blocks;
+  problem.GetParameterBlocks(&parameter_blocks);
+  std::vector<double> values;
+  for (double* parameter_block : parameter_blocks) {
+    if (problem.ParameterBlockSize(parameter_block) == 1) {
+      values.push_back(*parameter_block);
+    }
+  }
+  std::sort(values.begin(), values.end());
+  return values;
+}
+
+std::pair<size_t, size_t> ObservationScaleConstantCounts(
+    const GlobalPositionerOptions& options) {
+  Reconstruction reconstruction;
+  SyntheticDatasetOptions dataset_options;
+  dataset_options.num_rigs = 1;
+  dataset_options.num_cameras_per_rig = 1;
+  dataset_options.num_frames_per_rig = 4;
+  dataset_options.num_points3D = 30;
+  SynthesizeDataset(dataset_options, &reconstruction);
+
+  auto positioner =
+      GlobalPositioner::CreateDefault(options, PoseGraph(), reconstruction);
+  ceres::Problem& problem = positioner->Problem();
+  std::vector<double*> parameter_blocks;
+  problem.GetParameterBlocks(&parameter_blocks);
+  size_t num_scales = 0;
+  size_t num_constant_scales = 0;
+  for (double* parameter_block : parameter_blocks) {
+    if (problem.ParameterBlockSize(parameter_block) != 1) continue;
+    ++num_scales;
+    if (problem.IsParameterBlockConstant(parameter_block)) {
+      ++num_constant_scales;
+    }
+  }
+  return {num_constant_scales, num_scales};
+}
 
 std::pair<ObservationCovarianceMap, double> ObservationCovariancesAndCost(
     const GlobalPositionerOptions& options,
@@ -179,6 +247,87 @@ TEST(GlobalPositioning, ComposableProblem) {
   EXPECT_TRUE(positioner->Finalize(summary));
 }
 
+TEST(GlobalPositioning, ObservationScaleGaugeOptions) {
+  GlobalPositionerOptions options;
+  options.use_gpu = false;
+  EXPECT_TRUE(options.fix_observation_scale_gauge);
+
+  const auto [default_constants, default_scales] =
+      ObservationScaleConstantCounts(options);
+  ASSERT_GT(default_scales, 0);
+  EXPECT_EQ(default_constants, 1);
+
+  options.fix_observation_scale_gauge = false;
+  const auto [unfixed_constants, unfixed_scales] =
+      ObservationScaleConstantCounts(options);
+  EXPECT_EQ(unfixed_scales, default_scales);
+  EXPECT_EQ(unfixed_constants, 0);
+
+  options.optimize_scales = false;
+  const auto [disabled_constants, disabled_scales] =
+      ObservationScaleConstantCounts(options);
+  EXPECT_EQ(disabled_scales, default_scales);
+  EXPECT_EQ(disabled_constants, disabled_scales);
+}
+
+TEST(GlobalPositioning, UncalibratedObservationDownweightOption) {
+  const Reconstruction reconstruction =
+      CreateGlobalPositioningTestReconstruction();
+
+  auto evaluate_cost = [&reconstruction](
+                           const bool calibrated,
+                           const bool downweight_uncalibrated_observations) {
+    Reconstruction test_reconstruction = reconstruction;
+    for (const auto& [camera_id, _] : test_reconstruction.Cameras()) {
+      test_reconstruction.Camera(camera_id).has_prior_focal_length = calibrated;
+    }
+
+    GlobalPositionerOptions options;
+    options.use_gpu = false;
+    options.generate_random_positions = false;
+    options.generate_random_points = false;
+    options.downweight_uncalibrated_observations =
+        downweight_uncalibrated_observations;
+    auto positioner =
+        GlobalPositioner::CreateDefault(options,
+                                        PoseGraph(),
+                                        test_reconstruction,
+                                        {},
+                                        std::make_shared<ceres::TrivialLoss>());
+    double cost = 0.0;
+    EXPECT_TRUE(positioner->Problem().Evaluate(
+        ceres::Problem::EvaluateOptions(), &cost, nullptr, nullptr, nullptr));
+    return cost;
+  };
+
+  GlobalPositionerOptions default_options;
+  EXPECT_TRUE(default_options.downweight_uncalibrated_observations);
+  const double calibrated_cost = evaluate_cost(true, true);
+  const double stock_uncalibrated_cost = evaluate_cost(false, true);
+  const double equal_weight_uncalibrated_cost = evaluate_cost(false, false);
+  ASSERT_GT(calibrated_cost, 0.0);
+  EXPECT_NEAR(
+      stock_uncalibrated_cost, 0.5 * calibrated_cost, 1e-12 * calibrated_cost);
+  EXPECT_NEAR(
+      equal_weight_uncalibrated_cost, calibrated_cost, 1e-12 * calibrated_cost);
+}
+
+TEST(GlobalPositioning, InitializesWarmStartScalesFromCurrentScene) {
+  Reconstruction reconstruction = CreateGlobalPositioningTestReconstruction();
+  GlobalPositionerOptions options;
+  options.use_gpu = false;
+  options.generate_random_positions = false;
+  options.generate_random_points = false;
+  options.generate_scales = false;
+  std::vector<double> expected_scales =
+      ExpectedObservationScales(options, reconstruction);
+  std::sort(expected_scales.begin(), expected_scales.end());
+
+  auto positioner =
+      GlobalPositioner::CreateDefault(options, PoseGraph(), reconstruction);
+  EXPECT_EQ(ObservationScaleValues(positioner->Problem()), expected_scales);
+}
+
 TEST(GlobalPositioning, KeyedObservationCovariances) {
   Reconstruction reconstruction;
   SyntheticDatasetOptions dataset_options;
@@ -192,9 +341,7 @@ TEST(GlobalPositioning, KeyedObservationCovariances) {
   options.use_gpu = false;
   options.generate_random_positions = false;
   options.generate_random_points = false;
-  for (const auto& [camera_id, _] : reconstruction.Cameras()) {
-    reconstruction.Camera(camera_id).has_prior_focal_length = true;
-  }
+  options.downweight_uncalibrated_observations = false;
   auto [covariances, expected_cost] =
       ObservationCovariancesAndCost(options, reconstruction);
   ASSERT_FALSE(covariances.empty());

--- a/src/pycolmap/estimators/motion_averaging.cc
+++ b/src/pycolmap/estimators/motion_averaging.cc
@@ -38,6 +38,16 @@ void BindGlobalPositioner(py::module& m) {
                          &GlobalPositionerOptions::optimize_scales,
                          "Whether to optimize scales.")
           .def_readwrite(
+              "fix_observation_scale_gauge",
+              &GlobalPositionerOptions::fix_observation_scale_gauge,
+              "Whether to fix the first active observation scale to remove "
+              "the scale gauge.")
+          .def_readwrite(
+              "downweight_uncalibrated_observations",
+              &GlobalPositionerOptions::downweight_uncalibrated_observations,
+              "Whether to down-weight observations from cameras without a "
+              "focal-length prior.")
+          .def_readwrite(
               "refine_sensor_from_rig",
               &GlobalPositionerOptions::refine_sensor_from_rig,
               "When False, treat sensor_from_rig as a fixed pre-calibrated "

--- a/src/pycolmap/estimators/motion_averaging_test.py
+++ b/src/pycolmap/estimators/motion_averaging_test.py
@@ -73,6 +73,12 @@ def test_gravity_refiner_options_min_num_neighbors_readwrite() -> None:
 def test_global_positioner_options_default_init() -> None:
     options = pycolmap.GlobalPositionerOptions()
     assert options is not None
+    assert options.fix_observation_scale_gauge is True
+    assert options.downweight_uncalibrated_observations is True
+    options.fix_observation_scale_gauge = False
+    options.downweight_uncalibrated_observations = False
+    assert options.fix_observation_scale_gauge is False
+    assert options.downweight_uncalibrated_observations is False
 
 
 def test_global_positioner_retains_custom_loss():


### PR DESCRIPTION
This follow-up isolates three global-positioning behavior controls from [COLMAP #4670](https://github.com/colmap/colmap/pull/4670):

- optionally leave the observation-scale gauge unfixed;
- optionally disable the stock 0.5 weight for uncalibrated observations;
- initialize observation scales from the supplied geometry when random generation is disabled.

The base branch preserves the existing `RunGlobalPositioning(...)` behavior.
